### PR TITLE
Added merging for Timeseries and Events.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,10 +35,9 @@
     "no-dupe-keys": 2,
     "no-duplicate-case": 2,
     "no-empty": 2,
-    "no-empty-class": 2,
+    "no-empty-character-class": 2,
     "no-ex-assign": 2,
     "no-extra-boolean-cast": 2,
-    "no-extra-parens": 0,
     "no-extra-semi": 2,
     "no-func-assign": 2,
     "no-inner-declarations": [
@@ -143,7 +142,7 @@
     "no-process-exit": 0,
     "no-restricted-modules": 0,
     "no-sync": 2,
-    "indent": 2,
+    "indent": [2, 4, {"SwitchCase": 1}],
     "brace-style": [
       2,
       "1tbs",
@@ -188,7 +187,7 @@
     "no-ternary": 0,
     "no-trailing-spaces": 2,
     "no-underscore-dangle": 0,
-    "no-wrap-func": 2,
+    "no-extra-parens": 0,
     "one-var": [
       2,
       "never"
@@ -249,12 +248,16 @@
         "nonwords": false
       }
     ],
-    "spaced-line-comment": [
+    "spaced-comment": [
       2,
       "always"
     ],
     "wrap-regex": 0,
-    "no-var": 0,
-    "max-len": [2, 110, 4]
+    "max-len": [2, 80, 4],
+    "no-var": 2,
+    "no-const-assign": 2,
+    "prefer-const": 2,
+    "prefer-arrow-callback": 2,
+    "prefer-template": 1
   }
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -114,11 +114,11 @@ Returns the value for a specific key within the Event data. If no key is specifi
 
 Creates a new Event from an array of other events. This only works under the following conditions:
 
- * All Events are of the same time (i.e. all Events, all TimeRangeEvents or all IndexedEvents).
- * The fields within the data of each event need to be orthogonal from each other, in that event1 might have an "a" and "b" field, then event2 should not have a "a" field but might instead have a "c" field.
- * The time (or Index, or TimeRange) of each event must be the same.
+ * All Events are of the same type (i.e. all `Events`, all `TimeRangeEvents` or all `IndexedEvents`).
+ * The fields within the data of each event need to be orthogonal from each other, in that event1 might have an "a" and "b" field, then event2 should not have an "a" or "b" field but might instead have a "c" field.
+ * The time (or `Index`, or `TimeRange`) of each event must be the same.
 
- In this case the merge would create a new event with both a "name" and "description" field. Example:
+In this case the merge would create a new event with both a "a", "b" and "c" field. Example:
 
 ```javascript
 const event1 = new IndexedEvent("1h-396206", {a: 5, b: 6});
@@ -131,4 +131,4 @@ Result:
 "1h-396206" -> {a:5, b:6, c:2}
 ```
 
-Note: you can merge TimeSeries too, which internally uses this merge function to perform a merge across the whole series.
+Note: you can merge `TimeSeries` too, which internally uses this merge function to perform a merge across the whole series.

--- a/docs/events.md
+++ b/docs/events.md
@@ -10,17 +10,17 @@ There are three types of Events in Pond:
 
 The creation of an Event is done by combining two parts: the timestamp (or time range, or Index...) and the data.
 
-For a basic `Event`, you specify the timestamp as either a Javascript Date object, a Moment, or the number of ms since the UNIX epoch.
+ * For a basic `Event`, you specify the timestamp as either a Javascript Date object, a Moment, or the number of ms since the UNIX epoch.
 
-For a `TimeRangeEvent`, you specify a TimeRange, along with the data.
+ * For a `TimeRangeEvent`, you specify a TimeRange, along with the data.
 
-For a `IndexedEvent`, you specify an Index, along with the data, and if the event should be considered to be in UTC time or not.
+ * For a `IndexedEvent`, you specify an Index, along with the data, and if the event should be considered to be in UTC time or not.
 
 To specify the data you can supply either a Javascript object of key/values, a
 Immutable.Map, or a simple type such as an integer. In the case of the simple
 type this is a shorthand for supplying {"value": v}.
  
-Example:
+**Example:**
 
 Given some source of data that looks like this:
 
@@ -74,12 +74,61 @@ outageEvent.data()
 
 to fetch the whole data object, which will be an Immutable Map.
 
-### Query
+---
 
-* `toJSON()` - Returns a JSON representation of the Event
-* `toString()` - Returns a string representation of the Event, useful for serialization
-* `timestampAsUTCString()` - Returns the timestamp of the Event in UTC time.
-* `timestampAsLocalString()` - Returns the timestamp of the Event in Local time.
-* `timestamp()` - Returns the timestamp of the Event as a Date.
-* `data()` - Returns the internal data of the event, as an Immutable.Map.
-* `get(key)` - Returns the value for a specific key within the Event data. If no key is specified then 'value' is used for the key.
+### Query API
+
+#### toJSON()
+
+Returns a JSON representation of the Event
+
+#### toString()
+
+Returns a string representation of the Event, useful for serialization
+
+#### timestampAsUTCString()
+
+Returns the timestamp of the Event in UTC time.
+
+#### timestampAsLocalString()
+
+Returns the timestamp of the Event in Local time.
+
+#### timestamp()
+
+Returns the timestamp of the Event as a Date.
+
+#### data()
+
+Returns the internal data of the event, as an Immutable.Map.
+
+#### get(key)
+
+Returns the value for a specific key within the Event data. If no key is specified then 'value' is used for the key.
+
+---
+
+### Mutation API
+
+#### Event.merge([event1, event2, ...]) [Static]
+
+Creates a new Event from an array of other events. This only works under the following conditions:
+
+ * All Events are of the same time (i.e. all Events, all TimeRangeEvents or all IndexedEvents).
+ * The fields within the data of each event need to be orthogonal from each other, in that event1 might have an "a" and "b" field, then event2 should not have a "a" field but might instead have a "c" field.
+ * The time (or Index, or TimeRange) of each event must be the same.
+
+ In this case the merge would create a new event with both a "name" and "description" field. Example:
+
+```javascript
+const event1 = new IndexedEvent("1h-396206", {a: 5, b: 6});
+const event2 = new IndexedEvent("1h-396206", {c: 2});
+const merged = Event.merge([event1, event2]);
+```
+
+Result:
+```
+"1h-396206" -> {a:5, b:6, c:2}
+```
+
+Note: you can merge TimeSeries too, which internally uses this merge function to perform a merge across the whole series.

--- a/docs/start.md
+++ b/docs/start.md
@@ -8,13 +8,13 @@ npm install @esnet/pond --save
 
 ### Client
 
-While Pond is written in ES6 the npm dist is transpiled to ES5 so it should run anywhere. To use in a browser you will need to install it with npm and and build your source with Webpack or something similar.
+While Pond is written in ES6 the npm dist is transpiled to ES5 so it will run anywhere. To use it within a browser you will need to install it with npm and then build your source with Webpack, Browserify or something similar.
 
 ### Server
 
 On the server, it's best to use babel-node, though straight up node will generally work too.
 
-Here's a simple example:
+Here's a simple example, run with babel-node:
 
     import {Index, TimeSeries} from "@esnet/pond";
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -2,7 +2,7 @@
 
 Pond is a library for handling time related structures, so the most basic of elements is time itself. Pond doesn't wrap any specific representation. Instead constructors of other primitives will generally accept either:
 
- * ms since UNIX epoch
+ * milliseconds since the Unix epoch
  * a Javascript Date object
  * a Moment.
 

--- a/docs/time.md
+++ b/docs/time.md
@@ -1,4 +1,8 @@
 ## Time
 
-Pond is a library for handling time related stuctures, so the most basic of elements is time itself. Pond doesn't wrap any specific representation. Instead constructors of other primitives will generally accept either: ms since UNIX epoch, a Javascript Date object or a Moment.
+Pond is a library for handling time related structures, so the most basic of elements is time itself. Pond doesn't wrap any specific representation. Instead constructors of other primitives will generally accept either:
+
+ * ms since UNIX epoch
+ * a Javascript Date object
+ * a Moment.
 

--- a/docs/timerange.md
+++ b/docs/timerange.md
@@ -21,40 +21,105 @@ var range = new TimeRange([1326309060000, 1329941520000]);
 
 There is also a copy constructor.
 
-### Query
+---
 
-To get the bounding dates back from a TimeRange use `begin()` and `end()` on it.
+### Query API
 
-A TimeRange can also express its duration using `duration()`. The result will be in milliseconds. A human friendly string that represents the duration can be obtained with `humanizeDuration()`.
+#### begin()
 
-A TimeRange can serialize to a string with `toString()` or simple JSON with `toJSON()`. It can also print itself as local time with `toLocalSring()` and in UTC time with `toUTCString()`.
+Returns the begin time of the TimeRange as a Javascript Date object.
 
-There is also a humanized version of the TimeRange, obtained using `humanize()` (e.g. "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am") or as a range relative to now using `relativeString()` (e.g. "a few seconds ago to a month ago").
+#### end()
 
-### Comparison
+Returns the end time of the TimeRange as a Javascript Date object.
 
-TimeRange also supports a useful set of comparison operators:
+#### duration()
 
- * `equals(other)` - returns if one TimeRange is exactly the same range as another
- * `contains(other)` - returns true if other is completely inside this.
- * `within(other)` - Returns true if this TimeRange is completely within the supplied other TimeRange.
- * `overlaps(other)`- Returns true if the passed in other TimeRange overlaps this time Range.
- * `disjoint(other)` - Returns true if the passed in other Range in no way overlaps this time Range.
+Express the TimeRange as a duration. The result will be in milliseconds.
 
-### Mutation
+#### humanizeDuration()
+
+Returns a human friendly string that represents the duration.
+
+#### toString()
+
+Serialize to a string with `toString()`
+
+#### toJSON()
+
+Convert the TimeRange to simple Javascript objects.
+
+#### toLocalSring()
+
+Return a string version of the TimeRange in local time
+
+#### toUTCString()
+
+Return a string version of the TimeRange in UTC time
+
+#### humanize()
+
+Returns a humanized version of the TimeRange (e.g. "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am")
+
+#### relativeString()
+
+Returns a humanized version of the TimeRange as one time relative to another (e.g. "a few seconds ago to a month ago").
+
+---
+
+### Comparison API
+
+TimeRange also supports a useful set of comparison operators.
+
+#### equals(other)
+
+Returns if one TimeRange is exactly the same TimeRange as another.
+
+#### contains(other)
+
+Returns true if other is completely inside this TimeRange.
+
+#### within(other)
+
+Returns true if this TimeRange is completely within the supplied other TimeRange.
+
+#### overlaps(other)
+
+Returns true if the passed in other TimeRange overlaps this TimeRange.
+
+#### disjoint(other)
+
+Returns true if the passed in other Range in no way overlaps this TimeRange.
+
+
+---
+
+### Mutation API
 
 Any mutations to the TimeRange will return another TimeRange. Such operators include:
 
- * `setBegin(t)` and `setEnd(t)` - change the begin or end time of the TimeRange, resulting in a new TimeRange.
- * `extents(other)` - join a TimeRange with another, returning you a new TimeRange which spans them both.
- * `intersection(other)` - returns a new TimeRange which represents the intersection
-(overlapping) part of this and other.
+#### setBegin(t)` and `setEnd(t)
 
-### Static
+Change the begin or end time of the TimeRange, resulting in a new TimeRange.
 
-TimeRange also has several static methods to return common timeranges. So far these include:
+#### extents(other)
 
- * `lastDay()`
- * `lastSevenDays()`
- * `lastThirtyDays()`
- * `lastNinetyDays()`
+Join a TimeRange with another, returning you a new TimeRange which spans them both.
+
+#### intersection(other)
+
+Returns a new TimeRange which represents the overlapping part of this and the other TimeRange.
+
+---
+
+### Static helpers
+
+TimeRange also has several static methods to return common time ranges. So far these include:
+
+#### TimeRange.lastDay()
+
+#### TimeRange.lastSevenDays()
+
+#### TimeRange.lastThirtyDays()
+
+#### TimeRange.lastNinetyDays()

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -176,9 +176,9 @@ Returns the minimum value found in a given column. If a column is not supplied i
 
 Returns the mean of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value". This is the same as taking the avg().
 
-#### medium(column)
+#### median(column)
 
-Returns the medium of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
+Returns the median of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
 
 #### stddev(column)
 
@@ -213,7 +213,7 @@ The `info` passed into the `merge()` function is an Object which is used to crea
 
 There are some rules surrounding the use of `merge()`.
 
-If we consider each row of each `TimeSeries` with the same `Date` (or `Index`, or `TimeRange`), then we have a list of `Events` (or `IndexedEvents`, or `TimeRangeEvents`). This list needs to be reduced. To do this the events themselves are merged using `Event.merge()`. This operation will not attempt to reduce values which have the same column, for the same time, so for each of these lists of events there should be no shared columns. In other words, you can merge a `TimeSeries` with columns "a" and "b" with a `TimeSeries` with a column "c", but not with a `TimeSeries` with a column "a" (if the two `TimeSeries` overlap their times).
+If we consider each row of each `TimeSeries` with the same `Date` (or `Index`, or `TimeRange`), then we have a list of `Events` (or `IndexedEvents`, or `TimeRangeEvents`). This list needs to be reduced. To do this the events themselves are merged using `Event.merge()`. This operation will not attempt to reduce values which have the same column, for the same time, so for each of these lists of events there should be no shared columns. In other words, you can merge a `TimeSeries` with columns "a" and "b" with a `TimeSeries` with a column "c", but not a TimeSeries with a column "a" or "b" (if the two TimeSeries overlap their times).
 
 For example, first we create two `TimeSeries`, one with a "in" column and one with an "out" column:
 
@@ -268,8 +268,8 @@ One of the nice things about the `TimeSeries` representation in Pond is that it 
 
 #### TimeSeries.equals(series1, series2) [Static]
 
-Will check that the internal structures of the `TimeSeries` are the same reference. If you use the copy constructor, they will be the same.
+Will check that the internal structures of the `TimeSeries` are the same reference. If you use the copy constructor, they will be the same. Since the internals are built using immutable data structures this is an efficient comparison.
 
 #### TimeSeries.is(series1, series2) [Static]
 
-Perhaps more useful in that it will check to see if the structures, though perhaps being different references, have the same values.
+This will check to see if the structures, though perhaps being different references, have the same values.

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -6,17 +6,19 @@ A TimeSeries represents a series of events, with each event being a time (or Tim
 
 Currently you can initialize a TimeSeries with either a list of events, or with a data format that looks like this:
 
-    var data = {
-        "name": "traffic",
-        "columns": ["time", "value"],
-        "points": [
-            [1400425947000, 52],
-            [1400425948000, 18],
-            [1400425949000, 26],
-            [1400425950000, 93],
-            ...
-        ]
-    };
+```javascript
+var data = {
+    "name": "trafficc",
+    "columns": ["time", "value"],
+    "points": [
+        [1400425947000, 52],
+        [1400425948000, 18],
+        [1400425949000, 26],
+        [1400425950000, 93],
+        ...
+    ]
+};
+```
 
 To create a new TimeSeries object from the above format, simply use the constructor:
 
@@ -28,95 +30,220 @@ To create a new TimeSeries object from the above format, simply use the construc
   * **columns** - are necessary and give labels to the data in the points.
   * **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels. As just hinted at, the time column may actually be either a time or a timerange, represented by an Index. By using an Index it's possible to refer to a specific month, for example:
 
-    var availabilityData = {
-        "name": "Last 3 months availability",
-        "columns": ["time", "uptime"],
-        "points": [
-            ["2015-06", "100%"],   // <-- 2015-06 specified here represents June 2015
-            ["2015-05", "92%"],
-            ["2015-04", "87%"],
-        ]
-    };
+```javascript
+var availabilityData = {
+    "name": "Last 3 months availability",
+    "columns": ["time", "uptime"],
+    "points": [
+        ["2015-06", "100%"],   // <-- 2015-06 specified here represents June 2015
+        ["2015-05", "92%"],
+        ["2015-04", "87%"],
+    ]
+};
+```
 
-### Query
+---
 
- * `toJSON()` - return a JSON representation, essentially the above format
- * `toString()` - return a string representation, useful for serialization
- * `size()` - get how many rows the TimeSeries has
- * `at(i)` - get a particular row back out of the TimeSeries.It will return the row and an `Event`. like this:
+### Query API
 
-    for (var i=0; i < series.size(); i++) {
-        var event = series.at(1);
-        console.log(event.toString());
-    }
+#### toJSON()
 
- * generator - it is also possible to use the ES6 for..of style iteration in combination with the `events()` method:
+Returns a JSON representation, essentially the above format.
 
-    for (let event of series.events()) {
-        console.log(event.toString());
-    }
+#### toString()
 
-In either case, an Event is the result. An Event is a timestamp or timerange and some data, so to deconstruct the event you can use `timestamp()` and `data()` methods:
+Return a string representation, useful for serialization.
 
-    var data = event.data(); // {"value":18}
-    var timestamp = event.timestamp().getTime(); //1400425948000
+#### size()
+
+Get how many rows the TimeSeries has.
+
+#### at(row)
+
+Returns a particular row back out of the TimeSeries, referenced by the supplied row number. Since each row is conceptional an Event (i.e. a time, TimeRange or Index) mapped to an object containing key/value pairs), it will return an Event, TimeRangeEvent or IndexedEvent:
+
+```javascript
+for (let row=0; row < series.size(); row++) {
+    const event = series.at(row);
+    console.log(event.toString());
+}
+```
+
+#### generator (for..of)
+
+it is also possible to use the ES6 for..of style iteration in combination with the `events()` method to iterate over the Events in the TimeSeries:
+
+```javascript
+for (let event of series.events()) {
+    console.log(event.toString());
+}
+```
+
+In either style of iterating over the Events in a TimeSeries, an Event is the result. An Event is a timestamp, TimeRange or Index mapped to some data, so to deconstruct the event you can use `timestamp()` (or `Index()`, or `timerange()`depending on event type) and `data()` methods. For example, for a normal Event:
+
+```javascript
+var data = event.data(); // {"value":18}
+var timestamp = event.timestamp().getTime(); //1400425948000
+```
 
 See the `Event` docs for more information.
 
-* `bisect(t)` - as the series of points is conceptually an array, it is possible to look up the array index `i` by supplying a time `t` to the  method.
+#### bisect(t)
 
-* `range()` or `timerange()` - returns the range that the TimeSeries extends over as a TimeRange.
+As the series of points is conceptually an array of rows, it is possible to look up the row index by supplying a time `t` to the  method. It will return the row number that is the greatest, but still below t.
 
-* `begin()` and `end()` - returns the begin or end of the `range()` of the TimeSeries.
+#### timerange()
 
-* `index()`, `indexAsString()` and `indexAsRange()` - you can also optionally associate the whole TimeSeries with an Index. This is very helpful when caching different TimeSeries.
+Returns the range that the TimeSeries extends over as a TimeRange.
+
+#### begin()
+
+Returns the begin of the timerange of the TimeSeries.
+
+#### end()
+
+Returns the end of the timerange of the TimeSeries.
+
+#### index(), indexAsString(), indexAsRange()
+
+You can also optionally associate the whole TimeSeries with an Index. This is very helpful when caching different TimeSeries.
 
 To specify that, add it when constructing the TimeSeries:
 
-    var indexedData = {
-        "index": "1d-625",        // <-- Index specified here
-        "name": "traffic",
-        "columns": ["time", "temp"],
-        "points": [
-            [1400425947000, 26.2],
-            [1400425948000, 27.6],
-            [1400425949000, 28.9],
-            [1400425950000, 29.1],
-        ]
-    };
+```javascript
+var indexedData = {
+    "index": "1d-625",        // <-- Index specified here
+    "name": "traffic",
+    "columns": ["time", "temp"],
+    "points": [
+        [1400425947000, 26.2],
+        [1400425948000, 27.6],
+        [1400425949000, 28.9],
+        [1400425950000, 29.1],
+    ]
+};
+```
 
-You can then query that back in the future by using the index functions above.
+You can then query that back in the future by using the index functions:
+ * indexAsString()
+ * indexAsRange()
 
-* `isUTC()` - Returns if the data is UTC or not. This is specified in the constructor as well. UTC (or not) is important when adding data associated with an Index, such as "2015-06-01", i.e. is that June 1st in UTC or local. This only matters when querying the Index back and asking for its actual time range.
+#### isUTC()
 
-### Statistics
+Returns if the data is UTC or not. This is specified in the constructor as well. UTC (or not) is important when adding data associated with an Index, such as "2015-06-01", i.e. is that June 1st in UTC or local. This only matters when querying the Index back and asking for its actual time range.
 
-It is possible to get some basic statistics from a TimeSeries. Currently supported operators are:
+---
 
-* `sum()`
-* `avg()`
-* `max()`
-* `min()`
-* `mean()`
-* `medium()`
-* `stddev()`
+### Statistics functions
 
-All take an optional column name, otherwise a column `value` is assumed.
+It is possible to get some basic statistics from a TimeSeries. We will add additional operators as needed. Currently supported operators are:
 
-### Mutation
+#### sum(column)
 
-Although the TimeSeries is immutable itself, these operations will return a new modified TimeSeries:
+Returns the sum of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
 
- * `slice(begin, end)` - will return a new TimeSeries with reference just to the Events that were left after the slice. The result represents a portion of this TimeSeries from begin up to but not including end.
+#### avg(column)
+
+Returns an average of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
+
+#### max(column)
+
+Returns the maximum value found in a given column. If a column is not supplied it assumes the column to be "value" We often use this to generate axis scales when charting the TimeSeries.
+
+#### min(column)
+
+Returns the minimum value found in a given column. If a column is not supplied it assumes the column to be "value". We often use this to generate axis scales when charting the TimeSeries.
+
+#### mean(column)
+
+Returns the mean of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value". This is the same as taking the avg().
+
+#### medium(column)
+
+Returns the medium of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
+
+#### stddev(column)
+
+Returns the standard deviation of the Timeseries values for the given column. If a column is not supplied it assumes the column to be "value".
+
+---
+
+### Mutation API
+
+Although the TimeSeries is immutable itself, these operations will return a new modified TimeSeries. We expect to add several more functions here over time.
+
+#### slice(begin, end)
+
+Returns a new TimeSeries with reference just to the Events that were left after the slice. The result represents a portion of this TimeSeries from begin up to but not including end.
 
 For example:
 
-    const begin = series.bisect(t1);
-    const end = series.bisect(t2);
-    const cropped = series.slice(begin, end);  // Returns a cropped series
+```javascript
+const begin = series.bisect(t1);
+const end = series.bisect(t2);
+const cropped = series.slice(begin, end);  // Returns a cropped series
+```
 
-### Comparison
+#### TimeSeries.merge(name, [series1, series2, ...]) [Static]
 
-One of the nice things about the TimeSeries representation in Pond is that it is built on top of immutable data structures. As a result, determining if a series is different from before is trivial.
+Returns a new TimeSeries with a union of the columns in each of the TimeSeries past in. Columns cannot be shared between the inputs, i.e. values themselves can't be merged. In addition the constituent events must be the same type.
 
-A TimeSeries can be compared in two ways: with the `equals()` or `is()` static functions. `equals()` will check that the internal structures of the TimeSeries are the same reference. If you use the copy constructor, they will be the same. The `is()` function is perhaps more useful in that it will check to see if the structures, though perhaps being different references, have the same values.
+For example, if we create type TimeSeries:
+
+```javascript
+const inTraffic = new TimeSeries({
+    name: "in",
+    columns: ["time", "in"],
+    points: [
+        [1400425947000, 52],
+        [1400425948000, 18],
+        [1400425949000, 26],
+        [1400425950000, 93],
+    ]
+});
+
+const outTraffic = new TimeSeries({
+    name: "out",
+    columns: ["time", "out"],
+    points: [
+        [1400425947000, 34],
+        [1400425948000, 13],
+        [1400425949000, 67],
+        [1400425950000, 91],
+    ]
+});
+```
+
+
+We can them merge them:
+
+```javascript
+var trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
+```
+
+The result will look like this:
+
+```json
+{
+    "name":"traffic",
+    "columns":["time", "in", "out"],
+    "points":[
+        ["2014-05-18T15:12:27.000Z", 52, 34],
+        ["2014-05-18T15:12:28.000Z", 18, 13],
+        ["2014-05-18T15:12:29.000Z", 26, 67],
+        ["2014-05-18T15:12:30.000Z", 93, 91]
+    ]
+}
+```
+
+### Comparison static functions
+
+One of the nice things about the TimeSeries representation in Pond is that it is built on top of immutable data structures. For instance, if you have a TimeSeries and modify it, those TimeSeries will now have a different reference and noting that they have changed is trivial.
+
+#### TimeSeries.equals(series1, series2) [Static]
+
+Will check that the internal structures of the TimeSeries are the same reference. If you use the copy constructor, they will be the same.
+
+#### TimeSeries.is(series1, series2) [Static]
+
+Perhaps more useful in that it will check to see if the structures, though perhaps being different references, have the same values.

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -186,9 +186,16 @@ const cropped = series.slice(begin, end);  // Returns a cropped series
 
 #### TimeSeries.merge(name, [series1, series2, ...]) [Static]
 
-Returns a new TimeSeries with a union of the columns in each of the TimeSeries past in. Columns cannot be shared between the inputs, i.e. values themselves can't be merged. In addition the constituent events must be the same type.
+Returns a new TimeSeries that merges a list of TimeSeries together. The common uses for this are:
 
-For example, if we create type TimeSeries:
+ * Join a list of TimeSeries together that have different columns.
+ * Append together a list of TimeSeries with the same columns, but different times.
+
+There are some rules surrounding the use of `merge()`.
+
+If we consider each row of each TimeSeries with the same time (or `Index`, or `TimeRange`), then we have a list of Events (or `IndexedEvents`, or `TimeRangeEvents`). This list needs to be reduced. To do this the events themselves are merged using `Event.merge()`. This operation will not attempt to reduce values which have the same column, for the same time, so for each of these lists of events there should be no shared columns. In other words, you can merge a TimeSeries with columns "a" and "b" with a TimeSeries with a column "c", but not with a TimeSeries with a column "a" (if the two TimeSeries overlap their times).
+
+For example, first we create two TimeSeries, one with a "in" column and one with an "out" column:
 
 ```javascript
 const inTraffic = new TimeSeries({
@@ -213,7 +220,6 @@ const outTraffic = new TimeSeries({
     ]
 });
 ```
-
 
 We can them merge them:
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <style>
         html { overflow-y:scroll; }
         body { padding-top:50px; }
+        h1, h2, h3, h4 { color: steelblue; }
     </style>
 </head>
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-// Prims
+// Primitives
 exports.Index = require("./lib/index.js");
 exports.TimeRange = require("./lib/range.js");
 

--- a/index.js
+++ b/index.js
@@ -1,24 +1,33 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-//Prims
+// Prims
 exports.Index = require("./lib/index.js");
 exports.TimeRange = require("./lib/range.js");
 
-//Events
+// Events
 exports.Event = require("./lib/event.js").Event;
 exports.TimeRangeEvent = require("./lib/event.js").TimeRangeEvent;
 exports.IndexedEvent = require("./lib/event.js").IndexedEvent;
 
-//Series
+// Series
 exports.Series = require("./lib/series.js").Series;
 exports.TimeSeries = require("./lib/series.js").TimeSeries;
 exports.IndexedSeries = require("./lib/series.js").IndexedSeries;
 
-//Builder
+// Builder
 exports.Bucket = require("./lib/bucket.js");
 exports.Generator = require("./lib/generator.js");
 exports.Aggregator = require("./lib/aggregator.js");
 exports.Collector = require("./lib/collector.js");
 exports.Binner = require("./lib/binner.js");
 
-//Util
+// Util
 exports.Functions = require("./lib/functions.js");

--- a/lib/aggregator.js
+++ b/lib/aggregator.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/binner.js
+++ b/lib/binner.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -85,29 +85,79 @@ function uniqueKeys(events) {
     return new _immutable2["default"].Set(arrayOfKeys);
 }
 
-/**
- * A bucket is a mutable collection of values that is used to
- * accumulate aggregations over the index. The index may be an
- * Index instance or a string.
- *
- * The left side of the index is the range indicator, which is
- * itself a combination of a letter and a number:
- *     - the letter is the unit, either s (seconds), d (days),
- *       h (hours), or d (days).
- *     - the size is the quantity of that unit.
- * So 6h is six hours, 7d is seven days.
- *
- * The right side of the index is a number, which is n number of
- * that range since Jan 1, 1970 UTC.
- *
- * And example of an index might be 1d-1673. This uniquely
- * refers to a block of time 1 day long, starting 1673 days after
- * the beginning of 1970.
- */
+var MemoryCacheStrategy = (function () {
+    function MemoryCacheStrategy() {
+        _classCallCheck(this, MemoryCacheStrategy);
+
+        this._cache = {};
+    }
+
+    /**
+     * A bucket is a mutable collection of values that is used to
+     * accumulate aggregations over the index. The index may be an
+     * Index instance or a string.
+     *
+     * The left side of the index is the range indicator, which is
+     * itself a combination of a letter and a number:
+     *     - the letter is the unit, either s (seconds), d (days),
+     *       h (hours), or d (days).
+     *     - the size is the quantity of that unit.
+     * So 6h is six hours, 7d is seven days.
+     *
+     * The right side of the index is a number, which is n number of
+     * that range since Jan 1, 1970 UTC.
+     *
+     * And example of an index might be 1d-1673. This uniquely
+     * refers to a block of time 1 day long, starting 1673 days after
+     * the beginning of 1970.
+     */
+
+    _createClass(MemoryCacheStrategy, [{
+        key: "init",
+        value: function init() {
+            // nothing for memory cache
+        }
+    }, {
+        key: "addEvent",
+        value: function addEvent(key, event, cb) {
+            if (!_underscore2["default"].has(this._cache, key)) {
+                this._cache[key] = [];
+            }
+            this._cache[key].push(event);
+
+            // memory cache never fails (we assume)
+            cb(null);
+        }
+    }, {
+        key: "getEvents",
+        value: function getEvents(key, cb) {
+            if (_underscore2["default"].has(this._cache, key)) {
+                cb(null, this._cache[key]);
+            } else {
+                cb("Unknown cache key", null);
+            }
+        }
+    }, {
+        key: "shutdown",
+        value: function shutdown() {
+            // nothing for memory cache
+        }
+    }]);
+
+    return MemoryCacheStrategy;
+})();
 
 var Bucket = (function () {
-    function Bucket(index) {
+    function Bucket(index, strategy) {
         _classCallCheck(this, Bucket);
+
+        // Caching strategy
+        if (!strategy) {
+            this._cacheStrategy = new MemoryCacheStrategy();
+            this._cacheStrategy.init();
+        } else {
+            this._cacheStrategy = strategy;
+        }
 
         // Index
         if (_underscore2["default"].isString(index)) {
@@ -115,9 +165,6 @@ var Bucket = (function () {
         } else if (index instanceof _index2["default"]) {
             this._index = index;
         }
-
-        // Mutable internal list
-        this._cache = [];
     }
 
     _createClass(Bucket, [{
@@ -177,17 +224,20 @@ var Bucket = (function () {
     }, {
         key: "_pushToCache",
         value: function _pushToCache(event, cb) {
-            this._cache.push(event);
-            if (cb) {
-                cb(null);
-            }
+            this._cacheStrategy.addEvent(this.name(), event, function (err) {
+                if (cb) {
+                    cb(err);
+                }
+            });
         }
     }, {
         key: "_readFromCache",
         value: function _readFromCache(cb) {
-            if (cb) {
-                cb(this._cache);
-            }
+            this._cacheStrategy.getEvents(this.name(), function (err, events) {
+                if (cb) {
+                    cb(err, events);
+                }
+            });
         }
 
         //
@@ -214,22 +264,26 @@ var Bucket = (function () {
         value: function aggregate(operator, cb) {
             var _this = this;
 
-            this._readFromCache(function (events) {
-                if (events.length) {
-                    (function () {
-                        var keys = uniqueKeys(events);
-                        var result = {};
-                        _underscore2["default"].each(keys.toJS(), function (k) {
-                            var vals = _underscore2["default"].map(events, function (v) {
-                                return v.get(k);
+            this._readFromCache(function (err, events) {
+                if (!err) {
+                    if (events.length) {
+                        (function () {
+                            var keys = uniqueKeys(events);
+                            var result = {};
+                            _underscore2["default"].each(keys.toJS(), function (k) {
+                                var vals = _underscore2["default"].map(events, function (v) {
+                                    return v.get(k);
+                                });
+                                result[k] = operator.call(_this, _this._index, vals, k);
                             });
-                            result[k] = operator.call(_this, _this._index, vals, k);
-                        });
-                        var event = new _event.IndexedEvent(_this._index, result);
-                        if (cb) {
-                            cb(event);
-                        }
-                    })();
+                            var event = new _event.IndexedEvent(_this._index, result);
+                            if (cb) {
+                                cb(event);
+                            }
+                        })();
+                    } else if (cb) {
+                        cb();
+                    }
                 } else if (cb) {
                     cb();
                 }
@@ -246,15 +300,19 @@ var Bucket = (function () {
         value: function collect(cb) {
             var _this2 = this;
 
-            this._readFromCache(function (events) {
-                var series = new _series.TimeSeries({
-                    name: _this2._index.toString(),
-                    meta: {},
-                    index: _this2._index,
-                    events: events
-                });
-                if (cb) {
-                    cb(series);
+            this._readFromCache(function (err, events) {
+                if (!err) {
+                    var series = new _series.TimeSeries({
+                        name: _this2._index.toString(),
+                        meta: {},
+                        index: _this2._index,
+                        events: events
+                    });
+                    if (cb) {
+                        cb(series);
+                    }
+                } else if (cb) {
+                    cb();
                 }
             });
         }

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];
@@ -47,7 +57,7 @@ function timestampFromArgs(arg1) {
 }
 
 function dataFromArgs(arg1) {
-    var data = {};
+    var data = undefined;
     if (_underscore2["default"].isObject(arg1)) {
         data = new _immutable2["default"].Map(arg1);
     } else if (data instanceof _immutable2["default"].Map) {
@@ -218,17 +228,20 @@ var Event = (function () {
             var data = {};
             _underscore2["default"].each(events, function (event) {
                 if (!event instanceof Event) {
-                    throw new Error("Events being merged must have the same type");
+                    var msg = "Events being merged must have the same type";
+                    throw new Error(msg);
                 }
 
                 if (t.getTime() !== event.timestamp().getTime()) {
-                    throw new Error("Events being merged must have the same timestamp");
+                    var msg = "Events being merged must have the same timestamp";
+                    throw new Error(msg);
                 }
 
                 var d = event.toJSON().data;
                 _underscore2["default"].each(d, function (val, key) {
                     if (_underscore2["default"].has(data, key)) {
-                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                        var msg = "Events being merged may not have the same key '" + key + "'";
+                        throw new Error(msg);
                     }
                     data[key] = val;
                 });
@@ -243,17 +256,20 @@ var Event = (function () {
             var data = {};
             _underscore2["default"].each(events, function (event) {
                 if (!event instanceof TimeRangeEvent) {
-                    throw new Error("Events being merged must have the same type");
+                    var msg = "Events being merged must have the same type";
+                    throw new Error(msg);
                 }
 
                 if (timerange.toUTCString() !== event.timerange().toUTCString()) {
-                    throw new Error("Events being merged must have the same timerange");
+                    var msg = "Events being merged must have the same timerange";
+                    throw new Error(msg);
                 }
 
                 var d = event.toJSON().data;
                 _underscore2["default"].each(d, function (val, key) {
                     if (_underscore2["default"].has(data, key)) {
-                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                        var msg = "Events being merged may not have the same key '" + key + "'";
+                        throw new Error(msg);
                     }
                     data[key] = val;
                 });
@@ -278,7 +294,8 @@ var Event = (function () {
                 var d = event.toJSON().data;
                 _underscore2["default"].each(d, function (val, key) {
                     if (_underscore2["default"].has(data, key)) {
-                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                        var msg = "Events being merged may not have the same key '" + key + "'";
+                        throw new Error(msg);
                     }
                     data[key] = val;
                 });

--- a/lib/event.js
+++ b/lib/event.js
@@ -211,6 +211,98 @@ var Event = (function () {
         value: function stringify() {
             return JSON.stringify(this._data);
         }
+    }], [{
+        key: "mergeEvents",
+        value: function mergeEvents(events) {
+            var t = events[0].timestamp();
+            var data = {};
+            _underscore2["default"].each(events, function (event) {
+                if (!event instanceof Event) {
+                    throw new Error("Events being merged must have the same type");
+                }
+
+                if (t.getTime() !== event.timestamp().getTime()) {
+                    throw new Error("Events being merged must have the same timestamp");
+                }
+
+                var d = event.toJSON().data;
+                _underscore2["default"].each(d, function (val, key) {
+                    if (_underscore2["default"].has(data, key)) {
+                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                    }
+                    data[key] = val;
+                });
+            });
+
+            return new Event(t, data);
+        }
+    }, {
+        key: "mergeTimeRangeEvents",
+        value: function mergeTimeRangeEvents(events) {
+            var timerange = events[0].timerange();
+            var data = {};
+            _underscore2["default"].each(events, function (event) {
+                if (!event instanceof TimeRangeEvent) {
+                    throw new Error("Events being merged must have the same type");
+                }
+
+                if (timerange.toUTCString() !== event.timerange().toUTCString()) {
+                    throw new Error("Events being merged must have the same timerange");
+                }
+
+                var d = event.toJSON().data;
+                _underscore2["default"].each(d, function (val, key) {
+                    if (_underscore2["default"].has(data, key)) {
+                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                    }
+                    data[key] = val;
+                });
+            });
+
+            return new TimeRangeEvent(timerange, data);
+        }
+    }, {
+        key: "mergeIndexedEvents",
+        value: function mergeIndexedEvents(events) {
+            var index = events[0].indexAsString();
+            var data = {};
+            _underscore2["default"].each(events, function (event) {
+                if (!event instanceof IndexedEvent) {
+                    throw new Error("Events being merged must have the same type");
+                }
+
+                if (index !== event.indexAsString()) {
+                    throw new Error("Events being merged must have the same index");
+                }
+
+                var d = event.toJSON().data;
+                _underscore2["default"].each(d, function (val, key) {
+                    if (_underscore2["default"].has(data, key)) {
+                        throw new Error("Events being merged may not have the same key '" + key + "'");
+                    }
+                    data[key] = val;
+                });
+            });
+
+            return new IndexedEvent(index, data);
+        }
+    }, {
+        key: "merge",
+        value: function merge(events) {
+            if (events.length < 1) {
+                return;
+            } else if (events.length === 1) {
+                return events[0];
+            }
+
+            if (events[0] instanceof Event) {
+                return Event.mergeEvents(events);
+            } else if (events[0] instanceof TimeRangeEvent) {
+                return Event.mergeTimeRangeEvents(events);
+            } else if (events[0] instanceof IndexedEvent) {
+                return Event.mergeIndexedEvents(events);
+            }
+        }
     }]);
 
     return Event;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];
@@ -7,7 +17,7 @@ var _classCallCheck = require("babel-runtime/helpers/class-call-check")["default
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _underscore = require("underscore");
@@ -31,90 +41,90 @@ var _util2 = _interopRequireDefault(_util);
  */
 
 var Index = (function () {
-    function Index(s, utc) {
-        _classCallCheck(this, Index);
+  function Index(s, utc) {
+    _classCallCheck(this, Index);
 
-        this._utc = _underscore2["default"].isBoolean(utc) ? utc : true;
-        this._string = s;
-        this._timerange = _util2["default"].rangeFromIndexString(s, this._utc);
+    this._utc = _underscore2["default"].isBoolean(utc) ? utc : true;
+    this._string = s;
+    this._timerange = _util2["default"].rangeFromIndexString(s, this._utc);
+  }
+
+  /**
+   * Returns the Index as JSON, which will just be its string
+   * representation
+   * @return {Object} JSON representation of the Index
+   */
+
+  _createClass(Index, [{
+    key: "toJSON",
+    value: function toJSON() {
+      return this._string;
     }
 
     /**
-     * Returns the Index as JSON, which will just be its string
-     * representation
-     * @return {Object} JSON representation of the Index
+     * Simply returns the Index as its string
+     * @return {string} String representation of the Index
      */
+  }, {
+    key: "toString",
+    value: function toString() {
+      return this._string;
+    }
 
-    _createClass(Index, [{
-        key: "toJSON",
-        value: function toJSON() {
-            return this._string;
-        }
+    /**
+     * for the calendar range style Indexes, this lets you return
+     * that calendar range as a human readable format, e.g. "June, 2014".
+     * The format specified is a Moment.format.
+     * @return {string} String representation of the Index
+     */
+  }, {
+    key: "toNiceString",
+    value: function toNiceString(format) {
+      return _util2["default"].niceIndexString(this._string, format);
+    }
 
-        /**
-         * Simply returns the Index as its string
-         * @return {string} String representation of the Index
-         */
-    }, {
-        key: "toString",
-        value: function toString() {
-            return this._string;
-        }
+    /**
+     * Alias for toString()
+     * @return {string} String representation of the Index
+     */
+  }, {
+    key: "asString",
+    value: function asString() {
+      return this.toString();
+    }
 
-        /**
-         * for the calendar range style Indexes, this lets you return
-         * that calendar range as a human readable format, e.g. "June, 2014".
-         * The format specified is a Moment.format.
-         * @return {string} String representation of the Index
-         */
-    }, {
-        key: "toNiceString",
-        value: function toNiceString(format) {
-            return _util2["default"].niceIndexString(this._string, format);
-        }
+    /**
+     * Returns the Index as a TimeRange
+     * @return {TimeRange} TimeRange representation of the Index
+     */
+  }, {
+    key: "asTimerange",
+    value: function asTimerange() {
+      return this._timerange;
+    }
 
-        /**
-         * Alias for toString()
-         * @return {string} String representation of the Index
-         */
-    }, {
-        key: "asString",
-        value: function asString() {
-            return this.toString();
-        }
+    /**
+     * Returns the start date of the Index
+     * @return {Date} Begin date
+     */
+  }, {
+    key: "begin",
+    value: function begin() {
+      return this._timerange.begin();
+    }
 
-        /**
-         * Returns the Index as a TimeRange
-         * @return {TimeRange} TimeRange representation of the Index
-         */
-    }, {
-        key: "asTimerange",
-        value: function asTimerange() {
-            return this._timerange;
-        }
+    /**
+     * Returns the end date of the Index
+     * @return {Date} End date
+     */
+  }, {
+    key: "end",
+    value: function end() {
+      return this._timerange.end();
+    }
+  }]);
 
-        /**
-         * Returns the start date of the Index
-         * @return {Date} Begin date
-         */
-    }, {
-        key: "begin",
-        value: function begin() {
-            return this._timerange.begin();
-        }
-
-        /**
-         * Returns the end date of the Index
-         * @return {Date} End date
-         */
-    }, {
-        key: "end",
-        value: function end() {
-            return this._timerange.end();
-        }
-    }]);
-
-    return Index;
+  return Index;
 })();
 
 exports["default"] = Index;

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/series.js
+++ b/lib/series.js
@@ -38,7 +38,7 @@ var _range = require("./range");
 
 var _range2 = _interopRequireDefault(_range);
 
-var _event = require("./event");
+var _event2 = require("./event");
 
 var _util = require("./util");
 
@@ -498,7 +498,7 @@ var TimeSeries = (function (_Series) {
 
                         var columns = uniqueKeys(events).toJSON();
                         _underscore2["default"].each(events, function (event) {
-                            if (event instanceof _event.IndexedEvent) {
+                            if (event instanceof _event2.IndexedEvent) {
                                 times.push(event.indexAsString());
                             } else {
                                 times.push(event.timestamp());
@@ -744,9 +744,9 @@ var TimeSeries = (function (_Series) {
             var time = this._times.get(i);
             if (_underscore2["default"].isString(time)) {
                 var index = time;
-                return new _event.IndexedEvent(index, this._series.get(i), this._utc);
+                return new _event2.IndexedEvent(index, this._series.get(i), this._utc);
             } else {
-                return new _event.Event(time, this._series.get(i));
+                return new _event2.Event(time, this._series.get(i));
             }
         }
 
@@ -849,6 +849,60 @@ var TimeSeries = (function (_Series) {
         key: "is",
         value: function is(series1, series2) {
             return series1._name === series2._name && series1._utc === series2._utc && _immutable2["default"].is(series1._meta, series2._meta) && _immutable2["default"].is(series1._columns, series2._columns) && _immutable2["default"].is(series1._series, series2._series) && _immutable2["default"].is(series1._times, series2._times);
+        }
+    }, {
+        key: "merge",
+        value: function merge(name, seriesList) {
+            // for each series, map events to the same timestamp/index
+            var eventMap = {};
+            _underscore2["default"].each(seriesList, function (series) {
+                var _iteratorNormalCompletion3 = true;
+                var _didIteratorError3 = false;
+                var _iteratorError3 = undefined;
+
+                try {
+                    for (var _iterator3 = _getIterator(series.events()), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                        var _event = _step3.value;
+
+                        var key = undefined;
+                        if (_event instanceof _event2.Event) {
+                            key = _event.timestamp();
+                        } else if (_event instanceof _event2.IndexedEvent) {
+                            key = _event.index();
+                        } else if (_event instanceof _event2.TimeRangeEvent) {
+                            key = _event.timerange().toUTCString();
+                        }
+
+                        if (!_underscore2["default"].has(eventMap, key)) {
+                            eventMap[key] = [];
+                        }
+
+                        eventMap[key].push(_event);
+                    }
+                } catch (err) {
+                    _didIteratorError3 = true;
+                    _iteratorError3 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion3 && _iterator3["return"]) {
+                            _iterator3["return"]();
+                        }
+                    } finally {
+                        if (_didIteratorError3) {
+                            throw _iteratorError3;
+                        }
+                    }
+                }
+            });
+
+            // for each key, merge the events associated with that key
+            var eventList = [];
+            _underscore2["default"].each(eventMap, function (events) {
+                var event = _event2.Event.merge(events);
+                eventList.push(event);
+            });
+
+            return new TimeSeries({ name: name, events: eventList });
         }
     }]);
 

--- a/lib/series.js
+++ b/lib/series.js
@@ -203,7 +203,11 @@ var Series = (function () {
     }, {
         key: "meta",
         value: function meta(key) {
-            return this._meta.get(key);
+            if (!key) {
+                return this._meta.toJSON();
+            } else {
+                return this._meta.get(key);
+            }
         }
 
         //
@@ -862,7 +866,7 @@ var TimeSeries = (function (_Series) {
         }
     }, {
         key: "merge",
-        value: function merge(name, seriesList) {
+        value: function merge(options, seriesList) {
             // for each series, map events to the same timestamp/index
             var eventMap = {};
             _underscore2["default"].each(seriesList, function (series) {
@@ -906,13 +910,24 @@ var TimeSeries = (function (_Series) {
             });
 
             // for each key, merge the events associated with that key
-            var eventList = [];
-            _underscore2["default"].each(eventMap, function (events) {
-                var event = _event2.Event.merge(events);
-                eventList.push(event);
+            var events = [];
+            _underscore2["default"].each(eventMap, function (eventsList) {
+                var event = _event2.Event.merge(eventsList);
+                events.push(event);
             });
 
-            return new TimeSeries({ name: name, events: eventList });
+            var name = options.name;
+            var index = options.index;
+
+            var meta = _objectWithoutProperties(options, ["name", "index"]);
+
+            console.log(name, index, meta);
+
+            return new TimeSeries({ name: name,
+                index: index,
+                utc: this._utc,
+                meta: meta,
+                events: events });
         }
     }]);
 

--- a/lib/series.js
+++ b/lib/series.js
@@ -921,8 +921,6 @@ var TimeSeries = (function (_Series) {
 
             var meta = _objectWithoutProperties(options, ["name", "index"]);
 
-            console.log(name, index, meta);
-
             return new TimeSeries({ name: name,
                 index: index,
                 utc: this._utc,

--- a/lib/series.js
+++ b/lib/series.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _createClass = require("babel-runtime/helpers/create-class")["default"];

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 "use strict";
 
 var _interopRequireDefault = require("babel-runtime/helpers/interop-require-default")["default"];

--- a/package.json
+++ b/package.json
@@ -11,14 +11,20 @@
     "test": "npm run lint && mocha $npm_package_options_mocha",
     "test-only": "mocha $npm_package_options_mocha",
     "build": "rm -rf lib/* && babel src --optional runtime --stage 0 --out-dir lib",
-    "build-website": "webpack --config webpack.website.config.js",
-    "start-website": "webpack-dev-server  --config webpack.website.config.js",
+    "deploy-website": "gh-pages-deploy",
+    "start": "webpack-dev-server --content-base website/ --config webpack.website.config.js",
     "start-tester": "webpack-dev-server --config webpack.test.config.js --content-base ./devserver --port 9500 --colors"
   },
   "babel": {
     "optional": [
       "runtime",
       "es7.objectRestSpread"
+    ]
+  },
+  "gh-pages-deploy": {
+    "staticpath": "website",
+    "prep": [
+      "build-website"
     ]
   },
   "license": "BSD-3-Clause-LBNL",
@@ -40,6 +46,7 @@
     "eslint": "^1.5.0",
     "eslint-plugin-react": "^3.3.1",
     "file-loader": "^0.7.2",
+    "gh-pages-deploy": "^0.3.0",
     "json-loader": "^0.5.1",
     "jsx-loader": "^0.13.x",
     "mocha": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prepublish": "npm test && npm run build",
-    "lint": "eslint src",
+    "lint": "eslint src test/tests website/modules/*.jsx",
     "test": "npm run lint && mocha $npm_package_options_mocha",
     "test-only": "mocha $npm_package_options_mocha",
     "build": "rm -rf lib/* && babel src --optional runtime --stage 0 --out-dir lib",
@@ -37,7 +37,7 @@
     "bundle-loader": "^0.5.0",
     "chai": "^3.0.0",
     "css-loader": "^0.9.0",
-    "eslint": "^0.24.0",
+    "eslint": "^1.5.0",
     "eslint-plugin-react": "^3.3.1",
     "file-loader": "^0.7.2",
     "json-loader": "^0.5.1",

--- a/src/aggregator.js
+++ b/src/aggregator.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import Generator from "./generator";
 
 export default class Aggregator {
@@ -50,8 +60,8 @@ export default class Aggregator {
      * Add an event, which will be assigned to a bucket
      */
     addEvent(event, cb) {
-        let t = event.timestamp();
-        let bucket = this.bucket(t);
+        const t = event.timestamp();
+        const bucket = this.bucket(t);
 
         //
         // Adding the value to the bucket. This could be an async operation

--- a/src/binner.js
+++ b/src/binner.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import _ from "underscore";
 import Generator from "./generator";
 import TimeRange from "./range";
@@ -71,7 +81,7 @@ export default class Binner {
         _.each(this._activeBucketList, (bucket) => {
             const bucketTimeRange = bucket.index().asTimerange();
             const pointsTimeRange = new TimeRange(this._lastTime, time);
-            let intersection = pointsTimeRange.intersection(bucketTimeRange);
+            const intersection = pointsTimeRange.intersection(bucketTimeRange);
             if (intersection && intersection.begin().getTime() ===
                 bucketTimeRange.begin().getTime()) {
                 const {va, vb} = this.getEdgeValues(pointsTimeRange,
@@ -84,7 +94,7 @@ export default class Binner {
         });
 
         // Flush buckets
-        let deleteList = [];
+        const deleteList = [];
         _.each(this._activeBucketList, (bucket, key) => {
             if (bucket.end() < time) {
                 bucket.aggregate(this._processor, e => {

--- a/src/bucket.js
+++ b/src/bucket.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import Immutable from "immutable";
 import _ from "underscore";
 import {IndexedEvent} from "./event";
@@ -10,9 +20,9 @@ import Index from "./index";
  * to do this.
  */
 function uniqueKeys(events) {
-    var arrayOfKeys = [];
-    for (let e of events) {
-        for (let k of e.data().keySeq()) {
+    const arrayOfKeys = [];
+    for (const e of events) {
+        for (const k of e.data().keySeq()) {
             arrayOfKeys.push(k);
         }
     }
@@ -170,10 +180,10 @@ export default class Bucket {
         this._readFromCache((err, events) => {
             if (!err) {
                 if (events.length) {
-                    let keys = uniqueKeys(events);
-                    let result = {};
+                    const keys = uniqueKeys(events);
+                    const result = {};
                     _.each(keys.toJS(), k => {
-                        let vals = _.map(events, v => v.get(k));
+                        const vals = _.map(events, v => v.get(k));
                         result[k] = operator.call(this, this._index, vals, k);
                     });
                     const event = new IndexedEvent(this._index, result);
@@ -197,7 +207,7 @@ export default class Bucket {
     collect(cb) {
         this._readFromCache((err, events) => {
             if (!err) {
-                var series = new TimeSeries({
+                const series = new TimeSeries({
                     name: this._index.toString(),
                     meta: {},
                     index: this._index,

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import Generator from "./generator";
 
 export default class Collector {
@@ -52,7 +62,7 @@ export default class Collector {
     addEvent(event, cb) {
         const t = event.timestamp();
         const bucket = this.bucket(t);
-        bucket.addEvent(event, function (err) {
+        bucket.addEvent(event, err => {
             if (err) {
                 console.error("Could not add value to bucket:", err);
             }

--- a/src/event.js
+++ b/src/event.js
@@ -142,6 +142,95 @@ export class Event {
     stringify() {
         return JSON.stringify(this._data);
     }
+
+    static mergeEvents(events) {
+        let t = events[0].timestamp();
+        let data = {};
+        _.each(events, event => {
+            if (!event instanceof Event) {
+                throw new Error("Events being merged must have the same type");
+            }
+
+            if (t.getTime() !== event.timestamp().getTime()) {
+                throw new Error("Events being merged must have the same timestamp");
+            }
+
+            const d = event.toJSON().data;
+            _.each(d, (val, key) => {
+                if (_.has(data, key)) {
+                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    return;
+                }
+                data[key] = val;
+            })
+        });
+
+        return new Event(t, data);
+    }
+
+    static mergeTimeRangeEvents(events) {
+        let timerange = events[0].timerange();
+        let data = {};
+        _.each(events, event => {
+            if (!event instanceof TimeRangeEvent) {
+                throw new Error("Events being merged must have the same type");
+            }
+
+            if (timerange.toUTCString() !== event.timerange().toUTCString()) {
+                throw new Error("Events being merged must have the same timerange");
+            }
+
+            const d = event.toJSON().data;
+            _.each(d, (val, key) => {
+                if (_.has(data, key)) {
+                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    return;
+                }
+                data[key] = val;
+            })
+        });
+
+        return new TimeRangeEvent(timerange, data);
+    }
+
+    static mergeIndexedEvents(events) {
+        let index = events[0].indexAsString();
+        let data = {};
+        _.each(events, event => {
+            if (!event instanceof IndexedEvent) {
+                throw new Error("Events being merged must have the same type");
+            }
+
+            if (index !== event.indexAsString()) {
+                throw new Error("Events being merged must have the same index");
+            }
+
+            const d = event.toJSON().data;
+            _.each(d, (val, key) => {
+                if (_.has(data, key)) {
+                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    return;
+                }
+                data[key] = val;
+            })
+        });
+
+        return new IndexedEvent(index, data);
+    }
+
+    static merge(events) {
+        if (events.length < 1) {
+            return;
+        }
+
+        if (events[0] instanceof Event) {
+            return Event.mergeEvents(events);
+        } else if (events[0] instanceof TimeRangeEvent) {
+            return Event.mergeTimeRangeEvents(events);
+        } else if (events[0] instanceof IndexedEvent) {
+            return Event.mergeIndexedEvents(events);
+        }
+    }
 }
 
 /**

--- a/src/event.js
+++ b/src/event.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import moment from "moment";
 import _ from "underscore";
 import Immutable from "immutable";
@@ -21,7 +31,7 @@ function timestampFromArgs(arg1) {
 }
 
 function dataFromArgs(arg1) {
-    let data = {};
+    let data;
     if (_.isObject(arg1)) {
         data = new Immutable.Map(arg1);
     } else if (data instanceof Immutable.Map) {
@@ -67,7 +77,7 @@ export class Event {
     constructor(arg1, arg2) {
         // Copy constructor
         if (arg1 instanceof Event) {
-            let other = arg1;
+            const other = arg1;
             this._time = other._time;
             this._data = other._data;
             return;
@@ -144,21 +154,25 @@ export class Event {
     }
 
     static mergeEvents(events) {
-        let t = events[0].timestamp();
-        let data = {};
+        const t = events[0].timestamp();
+        const data = {};
         _.each(events, event => {
             if (!event instanceof Event) {
-                throw new Error("Events being merged must have the same type");
+                const msg = "Events being merged must have the same type";
+                throw new Error(msg);
             }
 
             if (t.getTime() !== event.timestamp().getTime()) {
-                throw new Error("Events being merged must have the same timestamp");
+                const msg = "Events being merged must have the same timestamp";
+                throw new Error(msg);
             }
 
             const d = event.toJSON().data;
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
-                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    const msg =
+                    `Events being merged may not have the same key '${key}'`;
+                    throw new Error(msg);
                 }
                 data[key] = val;
             });
@@ -168,21 +182,25 @@ export class Event {
     }
 
     static mergeTimeRangeEvents(events) {
-        let timerange = events[0].timerange();
-        let data = {};
+        const timerange = events[0].timerange();
+        const data = {};
         _.each(events, event => {
             if (!event instanceof TimeRangeEvent) {
-                throw new Error("Events being merged must have the same type");
+                const msg = "Events being merged must have the same type";
+                throw new Error(msg);
             }
 
             if (timerange.toUTCString() !== event.timerange().toUTCString()) {
-                throw new Error("Events being merged must have the same timerange");
+                const msg = "Events being merged must have the same timerange";
+                throw new Error(msg);
             }
 
             const d = event.toJSON().data;
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
-                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    const msg =
+                    `Events being merged may not have the same key '${key}'`;
+                    throw new Error(msg);
                 }
                 data[key] = val;
             });
@@ -192,8 +210,8 @@ export class Event {
     }
 
     static mergeIndexedEvents(events) {
-        let index = events[0].indexAsString();
-        let data = {};
+        const index = events[0].indexAsString();
+        const data = {};
         _.each(events, event => {
             if (!event instanceof IndexedEvent) {
                 throw new Error("Events being merged must have the same type");
@@ -206,7 +224,9 @@ export class Event {
             const d = event.toJSON().data;
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
-                    throw new Error(`Events being merged may not have the same key '${key}'`);
+                    const msg =
+                    `Events being merged may not have the same key '${key}'`;
+                    throw new Error(msg);
                 }
                 data[key] = val;
             });
@@ -271,7 +291,7 @@ export class TimeRangeEvent {
     constructor(arg1, arg2) {
         // Timerange
         if (arg1 instanceof TimeRange) {
-            let timerange = arg1;
+            const timerange = arg1;
             this._range = timerange;
         }
 

--- a/src/event.js
+++ b/src/event.js
@@ -218,6 +218,8 @@ export class Event {
     static merge(events) {
         if (events.length < 1) {
             return;
+        } else if (events.length === 1) {
+            return events[0];
         }
 
         if (events[0] instanceof Event) {

--- a/src/event.js
+++ b/src/event.js
@@ -159,10 +159,9 @@ export class Event {
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
                     throw new Error(`Events being merged may not have the same key '${key}'`);
-                    return;
                 }
                 data[key] = val;
-            })
+            });
         });
 
         return new Event(t, data);
@@ -184,10 +183,9 @@ export class Event {
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
                     throw new Error(`Events being merged may not have the same key '${key}'`);
-                    return;
                 }
                 data[key] = val;
-            })
+            });
         });
 
         return new TimeRangeEvent(timerange, data);
@@ -209,10 +207,9 @@ export class Event {
             _.each(d, (val, key) => {
                 if (_.has(data, key)) {
                     throw new Error(`Events being merged may not have the same key '${key}'`);
-                    return;
                 }
                 data[key] = val;
-            })
+            });
         });
 
         return new IndexedEvent(index, data);

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import _ from "underscore";
 
 export default {
@@ -5,7 +15,7 @@ export default {
         return _.reduce(values, (a, b) => { return a + b; }, 0);
     },
     avg: function (index, values) {
-        var sum = _.reduce(values, (a, b) => { return a + b; }, 0);
+        const sum = _.reduce(values, (a, b) => { return a + b; }, 0);
         return sum / values.length;
     },
     max: function (index, values) {

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,8 +1,18 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import moment from "moment";
 import _ from "underscore";
 import Bucket from "./bucket";
 
-var units = {
+const units = {
     s: {label: "seconds", length: 1},
     m: {label: "minutes", length: 60},
     h: {label: "hours", length: 60 * 60},
@@ -61,7 +71,7 @@ export default class Generator {
     bucketIndexList(date1, date2) {
         const pos1 = Generator.getBucketPosFromDate(date1, this._length);
         const pos2 = Generator.getBucketPosFromDate(date2, this._length);
-        let indexList = [];
+        const indexList = [];
         if (pos1 <= pos2) {
             for (let pos = pos1; pos <= pos2; pos++) {
                 indexList.push(`${this._size}-${pos}`);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import _ from "underscore";
 import util from "./util";
 

--- a/src/range.js
+++ b/src/range.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import _ from "underscore";
 import Immutable from "immutable";
 import moment from "moment";

--- a/src/series.js
+++ b/src/series.js
@@ -147,7 +147,11 @@ export class Series {
      * the key and the get back the value matching that key.
      */
     meta(key) {
-        return this._meta.get(key);
+        if (!key) {
+            return this._meta.toJSON();
+        } else {
+            return this._meta.get(key);
+        }
     }
 
     //
@@ -691,7 +695,7 @@ export class TimeSeries extends Series {
                 Immutable.is(series1._times, series2._times));
     }
 
-    static merge(name, seriesList) {
+    static merge(options, seriesList) {
         // for each series, map events to the same timestamp/index
         const eventMap = {};
         _.each(seriesList, (series) => {
@@ -714,12 +718,20 @@ export class TimeSeries extends Series {
         });
 
         // for each key, merge the events associated with that key
-        const eventList = [];
-        _.each(eventMap, (events) => {
-            const event = Event.merge(events);
-            eventList.push(event);
+        const events = [];
+        _.each(eventMap, (eventsList) => {
+            const event = Event.merge(eventsList);
+            events.push(event);
         });
 
-        return new TimeSeries({name: name, events: eventList});
+        const {name, index, ...meta} = options;
+
+        console.log(name, index, meta);
+
+        return new TimeSeries({name: name,
+                               index: index,
+                               utc: this._utc,
+                               meta: meta,
+                               events: events});
     }
 }

--- a/src/series.js
+++ b/src/series.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import _ from "underscore";
 import Immutable from "immutable";
 import Index from "./index";
@@ -68,9 +78,9 @@ export class Series {
                 this._series = data;
             } else {
                 this._series = Immutable.fromJS(
-                    _.map(data, function (d) {
-                        let pointMap = {};
-                        _.each(d, function (p, i) {
+                    _.map(data, d => {
+                        const pointMap = {};
+                        _.each(d, (p, i) => {
                             pointMap[columns[i]] = p;
                         });
                         return pointMap;
@@ -258,9 +268,9 @@ export class Series {
   * to do this.
   */
 function uniqueKeys(events) {
-    let arrayOfKeys = [];
-    for (let e of events) {
-        for (let k of e.data().keySeq()) {
+    const arrayOfKeys = [];
+    for (const e of events) {
+        for (const k of e.data().keySeq()) {
             arrayOfKeys.push(k);
         }
     }
@@ -341,7 +351,7 @@ export class TimeSeries extends Series {
             //
 
             // Construct the base series
-            let other = arg1;
+            const other = arg1;
 
             this._name = other._name;
             this._meta = other._meta;
@@ -368,8 +378,8 @@ export class TimeSeries extends Series {
 
             const obj = arg1;
 
-            let times = [];
-            let data = [];
+            const times = [];
+            const data = [];
 
             if (_.has(obj, "events")) {
 
@@ -618,7 +628,7 @@ export class TimeSeries extends Series {
         }
 
         for (; i < size; i++) {
-            let ts = this.at(i).timestamp().getTime();
+            const ts = this.at(i).timestamp().getTime();
             if (ts > tms) {
                 return i - 1 >= 0 ? i - 1 : 0;
             } else if (ts === tms) {
@@ -642,7 +652,7 @@ export class TimeSeries extends Series {
             return this;
         }
 
-        let events = [];
+        const events = [];
         for (let i = b; i < e; i++) {
             events.push(this.at(i));
         }
@@ -685,7 +695,7 @@ export class TimeSeries extends Series {
         // for each series, map events to the same timestamp/index
         const eventMap = {};
         _.each(seriesList, (series) => {
-            for (let event of series.events()) {
+            for (const event of series.events()) {
                 let key;
                 if (event instanceof Event) {
                     key = event.timestamp();

--- a/src/series.js
+++ b/src/series.js
@@ -682,9 +682,6 @@ export class TimeSeries extends Series {
     }
 
     static merge(name, seriesList) {
-
-        console.log("Merge series", name, seriesList);
-
         // for each series, map events to the same timestamp/index
         const eventMap = {};
         _.each(seriesList, (series) => {
@@ -708,7 +705,7 @@ export class TimeSeries extends Series {
 
         // for each key, merge the events associated with that key
         const eventList = [];
-        _.each(eventMap, (events, key) => {
+        _.each(eventMap, (events) => {
             const event = Event.merge(events);
             eventList.push(event);
         });

--- a/src/series.js
+++ b/src/series.js
@@ -229,7 +229,7 @@ export class Series {
         return this.avg(column);
     }
 
-    medium(column) {
+    median(column) {
         const c = column || "value";
         if (!this._columns.contains(c)) {
             return undefined;
@@ -725,9 +725,6 @@ export class TimeSeries extends Series {
         });
 
         const {name, index, ...meta} = options;
-
-        console.log(name, index, meta);
-
         return new TimeSeries({name: name,
                                index: index,
                                utc: this._utc,

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import moment from "moment";
 import _ from "underscore";
 import TimeRange from "./range";
@@ -43,7 +53,7 @@ export default {
                     endTime = isUTC ? moment.utc(beginTime).endOf("day") :
                                       moment(beginTime).endOf("day");
                 }
-            break;
+                break;
 
             case 2:
                 // Size should be two parts, a number and a letter if it's a
@@ -72,7 +82,7 @@ export default {
                     endTime = isUTC ? moment.utc(beginTime).endOf("month") :
                                       moment(beginTime).endOf("month");
                 }
-            break;
+                break;
 
             // A year e.g. 2015
             case 1:
@@ -81,7 +91,7 @@ export default {
                                     moment.utc([year]);
                 endTime = isUTC ? moment.utc(beginTime).endOf("year") :
                                   moment(beginTime).endOf("year");
-            break;
+                break;
         }
 
         if (beginTime && beginTime.isValid() && endTime && endTime.isValid()) {
@@ -120,7 +130,7 @@ export default {
                     }
 
                 }
-            break;
+                break;
 
             case 2:
                 const rangeRegex = /([0-9]+)([smhd])/;
@@ -139,7 +149,7 @@ export default {
                         return t.format("MMMM");
                     }
                 }
-            break;
+                break;
 
             case 1:
                 const year = parts[0];
@@ -149,7 +159,7 @@ export default {
                 } else {
                     return t.format("YYYY");
                 }
-            break;
+                break;
         }
         return index;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,13 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 require("babel/polyfill");
 require("./tests/index.test.js");
 require("./tests/range.test.js");

--- a/test/tests/bucket.test.js
+++ b/test/tests/bucket.test.js
@@ -1,10 +1,30 @@
-var expect = require("chai").expect;
-var _ = require("underscore");
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-var sept_2014_data = {
-    "name": "traffic",
-    "columns": ["time", "value"],
-    "points": [
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
+
+import {expect} from "chai";
+import _ from "underscore";
+import {Event} from "../../src/event";
+import Generator from "../../src/generator.js";
+import Aggregator from "../../src/aggregator";
+import Collector from "../../src/collector";
+import Binner from "../../src/binner";
+import {max, avg, sum, count, difference, derivative} from "../../src/functions";
+
+const sept2014Data = {
+    name: "traffic",
+    columns: ["time", "value"],
+    points: [
         [1409529600000, 80],
         [1409533200000, 88],
         [1409536800000, 52],
@@ -127,134 +147,123 @@ var sept_2014_data = {
 describe("Buckets", () => {
 
     describe("Generator tests", () => {
-
-        var Generator = require("../../src/generator.js");
-
-        //Test date: Sat Mar 14 2015 07:32:22 GMT-0700 (PDT)
-        var d = Date.UTC(2015, 2, 14,  7,32,22);
-        var generator = new Generator("5m");
-        it('should have the correct index', (done) => {
-            var b = generator.bucket(d);
-            var expected = "5m-4754394";
+        // Test date: Sat Mar 14 2015 07:32:22 GMT-0700 (PDT)
+        const d = Date.UTC(2015, 2, 14, 7, 32, 22);
+        const generator = new Generator("5m");
+        it("should have the correct index", done => {
+            const b = generator.bucket(d);
+            const expected = "5m-4754394";
             expect(b.index().asString()).to.equal(expected);
             done();
         });
 
-        var d1 = Date.UTC(2015, 2, 14,  7,30,0);
-        var d2 = Date.UTC(2015, 2, 14,  8,29,59);
+        const d1 = Date.UTC(2015, 2, 14, 7, 30, 0);
+        const d2 = Date.UTC(2015, 2, 14, 8, 29, 59);
 
-        it('should have the correct index list for a date range', (done) => {
-            var bucketList = generator.bucketList(d1, d2);
-            var expectedBegin = "5m-4754394";
-            var expectedEnd = "5m-4754405";
-            //_.each(bucketList, (b) => {
-            //    console.log("   -", b.index().asString(), b.index().asTimerange().humanize())
-            //})
+        it("should have the correct index list for a date range", done => {
+            const bucketList = generator.bucketList(d1, d2);
+            const expectedBegin = "5m-4754394";
+            const expectedEnd = "5m-4754405";
+            // _.each(bucketList, (b) => {
+            //     console.log("   -", b.index().asString(), b.index().asTimerange().humanize())
+            // })
             expect(bucketList.length).to.equal(12);
             expect(bucketList[0].index().asString()).to.equal(expectedBegin);
-            expect(bucketList[bucketList.length-1].index().asString()).to.equal(expectedEnd);
+            expect(bucketList[bucketList.length - 1].index().asString()).to.equal(expectedEnd);
             done();
         });
     });
 
     describe("5min bucket tests", () => {
 
-        var BucketGenerator = require("../../src/generator.js");
+        const BucketGenerator = require("../../src/generator.js");
 
-        //Test date: Sat Mar 14 2015 07:32:22 UTC
-        var d = Date.UTC(2015, 2, 14, 7, 32, 22);
-        var Buckets = new BucketGenerator("5m");
-        it('should have the correct index', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "5m-4754394";
+        // Test date: Sat Mar 14 2015 07:32:22 UTC
+        const d = Date.UTC(2015, 2, 14, 7, 32, 22);
+        const Buckets = new BucketGenerator("5m");
+        it("should have the correct index", done => {
+            const b = Buckets.bucket(d);
+            const expected = "5m-4754394";
             expect(b.index().asString()).to.equal(expected);
             done();
         });
 
-        it('should have the correct UTC string', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "5m-4754394: [Sat, 14 Mar 2015 07:30:00 GMT, Sat, 14 Mar 2015 07:35:00 GMT]";
+        it("should have the correct UTC string", done => {
+            const b = Buckets.bucket(d);
+            const expected = "5m-4754394: [Sat, 14 Mar 2015 07:30:00 GMT, Sat, 14 Mar 2015 07:35:00 GMT]";
             expect(b.toUTCString()).to.equal(expected);
             done();
         });
     });
 
-    describe("Hourly bucket tests", function () {
+    describe("Hourly bucket tests", () => {
 
-        var BucketGenerator = require("../../src/generator.js");
+        const BucketGenerator = require("../../src/generator.js");
 
-        //Test date: Sat Mar 14 2015 07:32:22 UTC
-        var d = Date.UTC(2015, 2, 14, 7, 32, 22);
-        var Buckets = new BucketGenerator("1h");
-        
-        it('should have the correct index', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "1h-396199";
+        // Test date: Sat Mar 14 2015 07:32:22 UTC
+        const d = Date.UTC(2015, 2, 14, 7, 32, 22);
+        const Buckets = new BucketGenerator("1h");
+
+        it("should have the correct index", done => {
+            const b = Buckets.bucket(d);
+            const expected = "1h-396199";
             expect(b.index().asString()).to.equal(expected);
             done();
         });
-        
-        it('should have the correct UTC string', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "1h-396199: [Sat, 14 Mar 2015 07:00:00 GMT, Sat, 14 Mar 2015 08:00:00 GMT]";
+
+        it("should have the correct UTC string", done => {
+            const b = Buckets.bucket(d);
+            const expected = "1h-396199: [Sat, 14 Mar 2015 07:00:00 GMT, Sat, 14 Mar 2015 08:00:00 GMT]";
             expect(b.toUTCString()).to.equal(expected);
             done();
         });
     });
 
-    describe("Daily bucket tests", function () {
+    describe("Daily bucket tests", () => {
+        const BucketGenerator = require("../../src/generator.js");
 
-        var BucketGenerator = require("../../src/generator.js");
+        // Test date: Sat Mar 14 2015 07:32:22 UTC
+        const d = new Date(2015, 2, 14, 7, 32, 22);
+        const Buckets = new BucketGenerator("1d");
 
-        //Test date: Sat Mar 14 2015 07:32:22 UTC
-        var d = new Date(2015, 2, 14, 7, 32, 22);
-        var Buckets = new BucketGenerator("1d");
-        
-        it('should have the correct index', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "1d-16508";
+        it("should have the correct index", done => {
+            const b = Buckets.bucket(d);
+            const expected = "1d-16508";
             expect(b.index().asString()).to.equal(expected);
             done();
         });
 
-        it('should have the correct UTC string', (done) => {
-            var b = Buckets.bucket(d);
-            var expected = "1d-16508: [Sat, 14 Mar 2015 00:00:00 GMT, Sun, 15 Mar 2015 00:00:00 GMT]";
+        it("should have the correct UTC string", done => {
+            const b = Buckets.bucket(d);
+            const expected = "1d-16508: [Sat, 14 Mar 2015 00:00:00 GMT, Sun, 15 Mar 2015 00:00:00 GMT]";
             expect(b.toUTCString()).to.equal(expected);
             done();
         });
-
     });
 
-    describe("Aggregator", function () {
-
-        var {Event, IndexedEvent} = require("../../src/event");
-        var TimeRange = require("../../src/range");
-        var Aggregator = require("../../src/aggregator");
-        var {max, avg, sum, count} = require("../../src/functions");
-
-        var incomingEvents = [];
+    describe("Aggregator", () => {
+        const incomingEvents = [];
         incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 57, 0), 3));
         incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 58, 0), 9));
         incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 59, 0), 6));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  0, 0), 4));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  1, 0), 5));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 0, 0), 4));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 1, 0), 5));
 
-        it('should calculate the correct max for the two 1hr buckets', (done) => {
-            var maxEvents = {};
+        it("should calculate the correct max for the two 1hr buckets", done => {
+            const maxEvents = {};
 
-            var MaxAggregator = new Aggregator("1h", max);
-            
+            const MaxAggregator = new Aggregator("1h", max);
+
             MaxAggregator.onEmit((index, event) => {
                 maxEvents[index.asString()] = event;
             });
 
-            //Add events
+            // Add events
             _.each(incomingEvents, (event) => {
                 MaxAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             MaxAggregator.done();
 
             expect(maxEvents["1h-396199"].get()).to.equal(9);
@@ -262,21 +271,21 @@ describe("Buckets", () => {
             done();
         });
 
-        it('should calculate the correct avg for the two 1hr buckets', (done) => {
-            var avgEvents = {};
+        it("should calculate the correct avg for the two 1hr buckets", done => {
+            const avgEvents = {};
 
-            var AvgAggregator = new Aggregator("1h", avg);
+            const AvgAggregator = new Aggregator("1h", avg);
 
             AvgAggregator.onEmit((index, event) => {
                 avgEvents[index.asString()] = event;
             });
 
-            //Add events
+            // Add events
             _.each(incomingEvents, (event) => {
                 AvgAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             AvgAggregator.done();
 
             expect(avgEvents["1h-396199"].get()).to.equal(6);
@@ -284,19 +293,19 @@ describe("Buckets", () => {
             done();
         });
 
-        it('should calculate the correct sum for the two 1hr buckets', (done) => {
-            var sumEvents = {};
-            var SumAggregator = new Aggregator("1h", sum);
+        it("should calculate the correct sum for the two 1hr buckets", done => {
+            const sumEvents = {};
+            const SumAggregator = new Aggregator("1h", sum);
             SumAggregator.onEmit((index, event) => {
                 sumEvents[index.asString()] = event;
             });
 
-            //Add events
+            // Add events
             _.each(incomingEvents, (event) => {
                 SumAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             SumAggregator.done();
 
             expect(sumEvents["1h-396199"].get("value")).to.equal(18);
@@ -304,9 +313,9 @@ describe("Buckets", () => {
             done();
         });
 
-        it('should calculate the correct count for the two 1hr buckets', (done) => {
-            var countEvents = {};
-            var CountAggregator = new Aggregator("1h", count);
+        it("should calculate the correct count for the two 1hr buckets", done => {
+            const countEvents = {};
+            const CountAggregator = new Aggregator("1h", count);
             CountAggregator.onEmit((index, event) => {
                 countEvents[index.asString()] = event;
             });
@@ -314,7 +323,7 @@ describe("Buckets", () => {
                 CountAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             CountAggregator.done();
 
             expect(countEvents["1h-396199"].get()).to.equal(3);
@@ -322,24 +331,23 @@ describe("Buckets", () => {
             done();
         });
 
-        it('should calculate the correct count for a series of points', (done) => {
-            var incomingEvents = [];
-            var countEvents = {};
+        it("should calculate the correct count for a series of points", done => {
+            const events = [];
+            const countEvents = {};
 
-            //Convert the series to events
-            _.each(sept_2014_data.points, (point) => {
-                incomingEvents.push(new Event(point[0], point[1]));
+            // Convert the series to events
+            _.each(sept2014Data.points, (point) => {
+                events.push(new Event(point[0], point[1]));
             });
 
-            var CountAggregator = new Aggregator("1d", count);
+            const CountAggregator = new Aggregator("1d", count);
             CountAggregator.onEmit((index, event) => {
                 countEvents[index.asString()] = event;
             });
-            _.each(incomingEvents, (event) => {
+            _.each(events, (event) => {
                 CountAggregator.addEvent(event);
             });
 
-            //Done
             CountAggregator.done();
 
             expect(countEvents["1d-16314"].get()).to.equal(24);
@@ -347,61 +355,53 @@ describe("Buckets", () => {
             done();
         });
 
-        it('should calculate the correct count with inline emit', (done) => {
-            var incomingEvents = [];
-            var countEvents = {};
+        it("should calculate the correct count with inline emit", done => {
+            const events = [];
+            const countEvents = {};
 
-            //Convert the series to events
-            _.each(sept_2014_data.points, (point) => {
-                incomingEvents.push(new Event(point[0], point[1]));
+            // Convert the series to events
+            _.each(sept2014Data.points, (point) => {
+                events.push(new Event(point[0], point[1]));
             });
 
-            var CountAggregator = new Aggregator("1d", count, (index, event) => {
+            const CountAggregator = new Aggregator("1d", count, (index, event) => {
                 countEvents[index.asString()] = event;
             });
-            
-            _.each(incomingEvents, (event) => {
+
+            _.each(events, (event) => {
                 CountAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             CountAggregator.done();
 
             expect(countEvents["1d-16314"].get()).to.equal(24);
             expect(countEvents["1d-16318"].get()).to.equal(20);
             done();
         });
-
     });
 
+    describe("Aggregator tests for object events", () => {
+        const incomingEvents = [];
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 57, 0), {cpu1: 23.4, cpu2: 55.1}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 58, 0), {cpu1: 36.2, cpu2: 45.6}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 59, 0), {cpu1: 38.6, cpu2: 65.2}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 0, 0), {cpu1: 24.5, cpu2: 85.2}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 1, 0), {cpu1: 45.2, cpu2: 91.6}));
 
-    describe("Aggregator tests for object events", function () {
-
-        var {Event, IndexedEvent} = require("../../src/event");
-        var TimeRange = require("../../src/range");
-        var Aggregator = require("../../src/aggregator");
-        var {max, avg, sum, count} = require("../../src/functions");
-
-        var incomingEvents = [];
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 57, 0), {"cpu1": 23.4, "cpu2": 55.1}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 58, 0), {"cpu1": 36.2, "cpu2": 45.6}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 59, 0), {"cpu1": 38.6, "cpu2": 65.2}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  0, 0), {"cpu1": 24.5, "cpu2": 85.2}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  1, 0), {"cpu1": 45.2, "cpu2": 91.6}));
-
-        it('should calculate the correct sum for the two 1hr buckets', (done) => {
-            var sumEvents = {};
-            var SumAggregator = new Aggregator("1h", sum);
+        it("should calculate the correct sum for the two 1hr buckets", done => {
+            const sumEvents = {};
+            const SumAggregator = new Aggregator("1h", sum);
             SumAggregator.onEmit((index, event) => {
                 sumEvents[index.asString()] = event;
             });
 
-            //Add events
+            // Add events
             _.each(incomingEvents, (event) => {
                 SumAggregator.addEvent(event);
             });
 
-            //Done
+            // Done
             SumAggregator.done();
 
             expect(sumEvents["1h-396199"].get("cpu1")).to.equal(98.2);
@@ -411,38 +411,29 @@ describe("Buckets", () => {
             done();
         });
     });
-   
-    describe("Collection tests", function () {
 
-        var {Event, IndexedEvent} = require("../../src/event");
-        var TimeRange = require("../../src/range");
-        var Collector = require("../../src/collector");
-        var {max, avg, sum, count} = require("../../src/functions");
+    describe("Collection tests", () => {
+        const incomingEvents = [];
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 57, 0), {cpu1: 23.4, cpu2: 55.1}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 58, 0), {cpu1: 36.2, cpu2: 45.6}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 59, 0), {cpu1: 38.6, cpu2: 65.2}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 0, 0), {cpu1: 24.5, cpu2: 85.2}));
+        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8, 1, 0), {cpu1: 45.2, cpu2: 91.6}));
 
-        var incomingEvents = [];
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 57, 0), {"cpu1": 23.4, "cpu2": 55.1}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 58, 0), {"cpu1": 36.2, "cpu2": 45.6}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 7, 59, 0), {"cpu1": 38.6, "cpu2": 65.2}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  0, 0), {"cpu1": 24.5, "cpu2": 85.2}));
-        incomingEvents.push(new Event(Date.UTC(2015, 2, 14, 8,  1, 0), {"cpu1": 45.2, "cpu2": 91.6}));
+        it("should calculate the correct sum for the two 1hr buckets", done => {
+            const collection = {};
 
-        it('should calculate the correct sum for the two 1hr buckets', (done) => {
-            var collection = {};
-
-            var hourlyCollection = new Collector("1h", (series) => {
+            const hourlyCollection = new Collector("1h", (series) => {
                 collection[series.index().asString()] = series;
             });
 
-            //Add events
+            // Add events
             _.each(incomingEvents, (event) => {
                 hourlyCollection.addEvent(event);
             });
 
-            //Done
+            // Done
             hourlyCollection.done();
-
-            var expected1 = '{"name":"1h-396206","index":"1h-396206","columns":["time","cpu1","cpu2"],"points":[["2015-03-14T14:57:00.000Z",23.4,55.1],["2015-03-14T14:58:00.000Z",36.2,45.6],["2015-03-14T14:59:00.000Z",38.6,65.2]]}';
-            var expected2 = '{"name":"1h-396207","index":"1h-396207","columns":["time","cpu1","cpu2"],"points":[["2015-03-14T15:00:00.000Z",24.5,85.2],["2015-03-14T15:01:00.000Z",45.2,91.6]]}';
 
             expect(collection["1h-396199"].indexAsString()).to.equal("1h-396199");
             expect(collection["1h-396200"].indexAsString()).to.equal("1h-396200");
@@ -458,26 +449,22 @@ describe("Buckets", () => {
 
 describe("Resample bin fitting", () => {
 
-    describe("Differences", function () {
-        let {Event, IndexedEvent} = require("../../src/event");
-        var {difference} = require("../../src/functions");
-        let Binner = require("../../src/binner");
+    describe("Differences", () => {
 
         // 0               100            |   v
         // |               |              |
         // 0              30              |   t ->
         // |               |              |
         // |<- 100 ------->|<- 0 -------->|   result (with flush)
-        it("should calculate the correct fitted data for two boundry aligned values", (done) => {
+        it("should calculate the correct fitted data for two boundry aligned values", done => {
             const input = [new Event(0, 0), new Event(30000, 100)];
-
-            let result = {};
-            let binner = new Binner("30s", difference, (event) => {
+            const result = {};
+            const binner = new Binner("30s", difference, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });
 
-            //Feed events
+            // Feed events
             _.each(input, event => binner.addEvent(event));
             binner.flush();
 
@@ -486,7 +473,7 @@ describe("Resample bin fitting", () => {
             done();
         });
 
-        //In this case, there is no middle buckets at all
+        // In this case, there is no middle buckets at all
         //
         //     |   100         |   213        |   v
         //     |   |           |   |          |
@@ -495,16 +482,16 @@ describe("Resample bin fitting", () => {
         //     |<- 0           |<- 7.3 ------>|   result (with flush)
         //         30s-1           30s-2
         //
-        it("should calculate the correct fitted data for no middle buckets with flush", (done) => {
+        it("should calculate the correct fitted data for no middle buckets with flush", done => {
             const input = [new Event(31000, 100), new Event(62000, 213)];
 
-            let result = {};
-            let binner = new Binner("30s", difference, (event) => {
+            const result = {};
+            const binner = new Binner("30s", difference, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });
 
-            //Feed events
+            // Feed events
             _.each(input, event => binner.addEvent(event));
             binner.flush();
 
@@ -519,11 +506,11 @@ describe("Resample bin fitting", () => {
         //    90             120  121       150  t ->
         //     |               |              |
         //     |<- 96.7 ------>| ?            |   result
-        it("should calculate the correct fitted data for no middle buckets that isn't flushed", (done) => {
+        it("should calculate the correct fitted data for no middle buckets that isn't flushed", done => {
             const input = [new Event(90000, 100), new Event(121000, 200)];
 
-            let result = {};
-            let binner = new Binner("30s", difference, (event) => {
+            const result = {};
+            const binner = new Binner("30s", difference, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });
@@ -541,11 +528,11 @@ describe("Resample bin fitting", () => {
         //    60          89  90            120            150            180 181       210   t ->
         //     |               |              |              |              |             |
         //     |<- ? --------->|<- 32.6 ----->|<- 32.6 ----->|<- 32.6 ----->|<- ? ------->|   result
-        it("should calculate the correct values for a sequence of middle buckets", (done) => {
+        it("should calculate the correct values for a sequence of middle buckets", done => {
             const input = [new Event(89000, 100), new Event(181000, 200)];
 
-            let result = {};
-            let binner = new Binner("30s", difference, (event) => {
+            const result = {};
+            const binner = new Binner("30s", difference, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });
@@ -560,14 +547,14 @@ describe("Resample bin fitting", () => {
             done();
         });
 
-        it("should not return a result for two points in the same bucket", (done) => {
+        it("should not return a result for two points in the same bucket", done => {
             const input = [
                 new Event(1386369693000, 141368641534364),
                 new Event(1386369719000, 141368891281597),
             ];
 
-            let result = {};
-            let binner = new Binner("30s", difference, (event) => {
+            const result = {};
+            const binner = new Binner("30s", difference, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });
@@ -580,25 +567,21 @@ describe("Resample bin fitting", () => {
 
     });
 
-    describe("Derivatives", function () {
-        let {Event, IndexedEvent} = require("../../src/event");
-        var {derivative} = require("../../src/functions");
-        let Binner = require("../../src/binner");
-
+    describe("Derivatives", () => {
         //     |           100 |              |              |              |   200       |   v
         //     |           |   |              |              |              |   |         |
         //    60          89  90            120            150            180 181       210   t ->
         //     |               |              |              |              |             |
         //     |<- ? --------->|<- 1.08/s --->|<- 1.08/s --->|<- 1.08/s --->|<- ? ------->|   result
         //
-        it("should calculate the correct derivative", (done) => {
+        it("should calculate the correct derivative", done => {
             const input = [
                 new Event(89000, 100),
                 new Event(181000, 200),
             ];
 
-            let result = {};
-            let binner = new Binner("30s", derivative, (event) => {
+            const result = {};
+            const binner = new Binner("30s", derivative, (event) => {
                 const key = event.index().asString();
                 result[key] = event;
             });

--- a/test/tests/event.test.js
+++ b/test/tests/event.test.js
@@ -1,108 +1,110 @@
-var moment = require("moment");
-var expect = require("chai").expect;
-var _ = require("underscore");
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-var testEventString = '{"time":1409529600000,"data":{"value":42}}';
-var testEventData = JSON.parse(testEventString);
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
 
-var outageList = {
-    "status": "OK",
-    "outage_events": [
+import {expect} from "chai";
+import {Event, TimeRangeEvent, IndexedEvent} from "../../src/event.js";
+import TimeRange from "../../src/range.js";
+import Index from "../../src/index.js";
+
+const outageList = {
+    status: "OK",
+    outage_events: [
         {
-            "start_time": "2015-04-22T03:30:00Z",
-            "end_time": "2015-04-22T13:00:00Z",
-            "description": "At 13:33 pacific circuit 06519 went down.",
-            "title": "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-            "completed": true,
-            "external_ticket": "",
-            "esnet_ticket": "ESNET-20150421-013",
-            "organization": "Internet2 / Level 3",
-            "type": "U"
+            start_time: "2015-04-22T03:30:00Z",
+            end_time: "2015-04-22T13:00:00Z",
+            description: "At 13:33 pacific circuit 06519 went down.",
+            title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+            completed: true,
+            external_ticket: "",
+            esnet_ticket: "ESNET-20150421-013",
+            organization: "Internet2 / Level 3",
+            type: "U"
         }, {
-            "start_time": "2015-04-22T03:30:00Z",
-            "end_time": "2015-04-22T16:50:00Z",
-            "title": "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-            "description": "The listed circuit was unavailable due to bent pins in two clots of the optical node chassis.",
-            "completed": true,
-            "external_ticket": "3576:144",
-            "esnet_ticket": "ESNET-20150421-013",
-            "organization": "Internet2 / Level 3",
-            "type": "U"
+            start_time: "2015-04-22T03:30:00Z",
+            end_time: "2015-04-22T16:50:00Z",
+            title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+            description: `The listed circuit was unavailable due to
+bent pins in two clots of the optical node chassis.`,
+            completed: true,
+            external_ticket: "3576:144",
+            esnet_ticket: "ESNET-20150421-013",
+            organization: "Internet2 / Level 3",
+            type: "U"
         }, {
-            "start_time": "2015-03-04T09:00:00Z",
-            "end_time": "2015-03-04T14:00:00Z",
-            "title": "ANL Scheduled Maintenance",
-            "description": "ANL will be switching border routers...",
-            "completed": true,
-            "external_ticket": "",
-            "esnet_ticket": "ESNET-20150302-002",
-            "organization": "ANL",
-            "type": "P"
+            start_time: "2015-03-04T09:00:00Z",
+            end_time: "2015-03-04T14:00:00Z",
+            title: "ANL Scheduled Maintenance",
+            description: "ANL will be switching border routers...",
+            completed: true,
+            external_ticket: "",
+            esnet_ticket: "ESNET-20150302-002",
+            organization: "ANL",
+            type: "P"
         }
     ]
-}
+};
 
-describe("Events", function () {
+describe("Events", () => {
 
-    var {Event, TimeRangeEvent, IndexedEvent}  = require("../../src/event.js");
-    var TimeRange = require("../../src/range.js");
-    var Index = require("../../src/index.js");
+    describe("Event", () => {
 
-    describe("Event", function () {
-
-        it("can create an indexed event using a string index and data", function(done) {
-            let event = new IndexedEvent("1d-12355", {"value": 42});
-            let expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
+        it("can create an indexed event using a string index and data", done => {
+            const event = new IndexedEvent("1d-12355", {value: 42});
+            const expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
             expect(event.timerangeAsUTCString()).to.equal(expected);
             expect(event.get("value")).to.equal(42);
             done();
         });
 
-        it("can create an indexed event using an existing Index and data", function(done) {
-            let index = new Index("1d-12355");
-            let event = new IndexedEvent(index, {"value": 42});
-            let expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
+        it("can create an indexed event using an existing Index and data", done => {
+            const index = new Index("1d-12355");
+            const event = new IndexedEvent(index, {value: 42});
+            const expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
             expect(event.timerangeAsUTCString()).to.equal(expected);
             expect(event.get("value")).to.equal(42);
             done();
         });
 
-        it("can merge multiple events together", (done) => {
-            var t = new Date("2015-04-22T03:30:00Z");
-
-            var event1 = new Event(t, {a: 5, b: 6});
-            var event2 = new Event(t, {c: 2});
-            var merged = Event.merge([event1, event2]);
-
+        it("can merge multiple events together", done => {
+            const t = new Date("2015-04-22T03:30:00Z");
+            const event1 = new Event(t, {a: 5, b: 6});
+            const event2 = new Event(t, {c: 2});
+            const merged = Event.merge([event1, event2]);
             expect(merged.get("a")).to.equal(5);
             expect(merged.get("b")).to.equal(6);
             expect(merged.get("c")).to.equal(2);
             done();
         });
 
-        it("can merge multiple indexed events together", (done) => {
-            var index = "1h-396206";
-
-            var event1 = new IndexedEvent(index, {a: 5, b: 6});
-            var event2 = new IndexedEvent(index, {c: 2});
-            var merged = Event.merge([event1, event2]);
-
+        it("can merge multiple indexed events together", done => {
+            const index = "1h-396206";
+            const event1 = new IndexedEvent(index, {a: 5, b: 6});
+            const event2 = new IndexedEvent(index, {c: 2});
+            const merged = Event.merge([event1, event2]);
             expect(merged.get("a")).to.equal(5);
             expect(merged.get("b")).to.equal(6);
             expect(merged.get("c")).to.equal(2);
             done();
         });
 
-        it("can merge multiple timerange events together", (done) => {
-            var index = "1h-396206";
-            let beginTime = new Date("2015-04-22T03:30:00Z");
-            let endTime = new Date("2015-04-22T13:00:00Z");
-            var timerange = new TimeRange(beginTime, endTime);
-
-            var event1 = new TimeRangeEvent(timerange, {a: 5, b: 6});
-            var event2 = new TimeRangeEvent(timerange, {c: 2});
-            var merged = Event.merge([event1, event2]);
-
+        it("can merge multiple timerange events together", done => {
+            const beginTime = new Date("2015-04-22T03:30:00Z");
+            const endTime = new Date("2015-04-22T13:00:00Z");
+            const timerange = new TimeRange(beginTime, endTime);
+            const event1 = new TimeRangeEvent(timerange, {a: 5, b: 6});
+            const event2 = new TimeRangeEvent(timerange, {c: 2});
+            const merged = Event.merge([event1, event2]);
             expect(merged.get("a")).to.equal(5);
             expect(merged.get("b")).to.equal(6);
             expect(merged.get("c")).to.equal(2);
@@ -110,11 +112,11 @@ describe("Events", function () {
         });
 
         /*
-        it("can merge multiple events together", (done) => {
-            var t = new Date("2015-04-22T03:30:00Z");
-            var event1 = new Event(t, {a: 5, b: 6});
-            var event2 = new Event(t, {a: 2});
-            var merged = Event.merge([event1, event2]);
+        it("can merge multiple events together", done => {
+            const t = new Date("2015-04-22T03:30:00Z");
+            const event1 = new Event(t, {a: 5, b: 6});
+            const event2 = new Event(t, {a: 2});
+            const merged = Event.merge([event1, event2]);
             console.log("merged", merged);
             expect(merged).to.be.undefined;
             done();
@@ -122,29 +124,23 @@ describe("Events", function () {
         */
     });
 
-    describe("TimeRangeEvent", function() {
-        it("can create a TimeRangeEvent using a object", function(done) {
-            //Pick one event
-            let sampleEvent = outageList["outage_events"][0];
+    describe("TimeRangeEvent", () => {
+        it("can create a TimeRangeEvent using a object", done => {
+            // Pick one event
+            const sampleEvent = outageList["outage_events"][0];
 
-            //extract the begin and end times
-            let beginTime = new Date(sampleEvent.start_time);
-            let endTime = new Date(sampleEvent.end_time);
-            var timerange = new TimeRange(beginTime, endTime);
-
-            var event = new TimeRangeEvent(timerange, sampleEvent);
-
-            var expected = '{"timerange":[1429673400000,1429707600000],"data":{"external_ticket":"","start_time":"2015-04-22T03:30:00Z","completed":true,"end_time":"2015-04-22T13:00:00Z","organization":"Internet2 / Level 3","title":"STAR-CR5 < 100 ge 06519 > ANL  - Outage","type":"U","esnet_ticket":"ESNET-20150421-013","description":"At 13:33 pacific circuit 06519 went down."}}';
+            // Extract the begin and end times
+            const beginTime = new Date(sampleEvent.start_time);
+            const endTime = new Date(sampleEvent.end_time);
+            const timerange = new TimeRange(beginTime, endTime);
+            const event = new TimeRangeEvent(timerange, sampleEvent);
+            const expected = `{"timerange":[1429673400000,1429707600000],"data":{"external_ticket":"","start_time":"2015-04-22T03:30:00Z","completed":true,"end_time":"2015-04-22T13:00:00Z","organization":"Internet2 / Level 3","title":"STAR-CR5 < 100 ge 06519 > ANL  - Outage","type":"U","esnet_ticket":"ESNET-20150421-013","description":"At 13:33 pacific circuit 06519 went down."}}`;
             expect(`${event}`).to.equal(expected);
             expect(event.begin().getTime()).to.equal(1429673400000);
             expect(event.end().getTime()).to.equal(1429707600000);
-            expect(event.humanizeDuration()).to.equal("10 hours")
+            expect(event.humanizeDuration()).to.equal("10 hours");
             expect(event.get("title")).to.equal("STAR-CR5 < 100 ge 06519 > ANL  - Outage");
             done();
         });
-    });
-
-    describe("IndexedEvent", function() {
-
     });
 });

--- a/test/tests/event.test.js
+++ b/test/tests/event.test.js
@@ -66,6 +66,60 @@ describe("Events", function () {
             expect(event.get("value")).to.equal(42);
             done();
         });
+
+        it("can merge multiple events together", (done) => {
+            var t = new Date("2015-04-22T03:30:00Z");
+
+            var event1 = new Event(t, {a: 5, b: 6});
+            var event2 = new Event(t, {c: 2});
+            var merged = Event.merge([event1, event2]);
+
+            expect(merged.get("a")).to.equal(5);
+            expect(merged.get("b")).to.equal(6);
+            expect(merged.get("c")).to.equal(2);
+            done();
+        });
+
+        it("can merge multiple indexed events together", (done) => {
+            var index = "1h-396206";
+
+            var event1 = new IndexedEvent(index, {a: 5, b: 6});
+            var event2 = new IndexedEvent(index, {c: 2});
+            var merged = Event.merge([event1, event2]);
+
+            expect(merged.get("a")).to.equal(5);
+            expect(merged.get("b")).to.equal(6);
+            expect(merged.get("c")).to.equal(2);
+            done();
+        });
+
+        it("can merge multiple timerange events together", (done) => {
+            var index = "1h-396206";
+            let beginTime = new Date("2015-04-22T03:30:00Z");
+            let endTime = new Date("2015-04-22T13:00:00Z");
+            var timerange = new TimeRange(beginTime, endTime);
+
+            var event1 = new TimeRangeEvent(timerange, {a: 5, b: 6});
+            var event2 = new TimeRangeEvent(timerange, {c: 2});
+            var merged = Event.merge([event1, event2]);
+
+            expect(merged.get("a")).to.equal(5);
+            expect(merged.get("b")).to.equal(6);
+            expect(merged.get("c")).to.equal(2);
+            done();
+        });
+
+        /*
+        it("can merge multiple events together", (done) => {
+            var t = new Date("2015-04-22T03:30:00Z");
+            var event1 = new Event(t, {a: 5, b: 6});
+            var event2 = new Event(t, {a: 2});
+            var merged = Event.merge([event1, event2]);
+            console.log("merged", merged);
+            expect(merged).to.be.undefined;
+            done();
+        });
+        */
     });
 
     describe("TimeRangeEvent", function() {

--- a/test/tests/index.test.js
+++ b/test/tests/index.test.js
@@ -1,91 +1,108 @@
-var moment = require('moment');
-var expect = require('chai').expect;
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-describe("Indexes", function () {
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
 
-    var Index = require("../../src/index.js");
+import {expect} from "chai";
+import Index from "../../src/index.js";
 
-    describe("Index creation", function () {
-        it('can create a daily index', function(done) {
-            var index = new Index("1d-12355");
-            var expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
+describe("Indexes", () => {
+
+    describe("Index creation", () => {
+
+        it("can create a daily index", done => {
+            const index = new Index("1d-12355");
+            const expected = "[Thu, 30 Oct 2003 00:00:00 GMT, Fri, 31 Oct 2003 00:00:00 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("a day");
             done();
         });
-        it('can create a hourly index', function(done) {
-            var index = new Index("1h-123554");
-            var expected = "[Sun, 05 Feb 1984 02:00:00 GMT, Sun, 05 Feb 1984 03:00:00 GMT]";
+
+        it("can create a hourly index", done => {
+            const index = new Index("1h-123554");
+            const expected = "[Sun, 05 Feb 1984 02:00:00 GMT, Sun, 05 Feb 1984 03:00:00 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("an hour");
             done();
         });
 
-        it('can create a 5 minute index', function(done) {
-            var index = new Index("5m-4135541");
-            var expected = "[Sat, 25 Apr 2009 12:25:00 GMT, Sat, 25 Apr 2009 12:30:00 GMT]";
+        it("can create a 5 minute index", done => {
+            const index = new Index("5m-4135541");
+            const expected = "[Sat, 25 Apr 2009 12:25:00 GMT, Sat, 25 Apr 2009 12:30:00 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("5 minutes");
             done();
         });
 
-        it('can create a 30 second index', function(done) {
-            var index = new Index("30s-41135541");
-            var expected = "[Sun, 08 Feb 2009 04:10:30 GMT, Sun, 08 Feb 2009 04:11:00 GMT]";
+        it("can create a 30 second index", done => {
+            const index = new Index("30s-41135541");
+            const expected = "[Sun, 08 Feb 2009 04:10:30 GMT, Sun, 08 Feb 2009 04:11:00 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("a few seconds");
             done();
         });
 
-        it('can create a year index', function(done) {
-            var index = new Index("2014");
-            var expected = "[Wed, 01 Jan 2014 00:00:00 GMT, Wed, 31 Dec 2014 23:59:59 GMT]";
+        it("can create a year index", done => {
+            const index = new Index("2014");
+            const expected = "[Wed, 01 Jan 2014 00:00:00 GMT, Wed, 31 Dec 2014 23:59:59 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("a year");
             done();
         });
-    
-        it('can create a month index', function(done) {
-            var index = new Index("2014-09");
-            var expected = "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]";
+
+        it("can create a month index", done => {
+            const index = new Index("2014-09");
+            const expected = "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("a month");
             done();
         });
 
-        it('can create a day index', function(done) {
-            var index = new Index("2014-09-17");
-            var expected = "[Wed, 17 Sep 2014 00:00:00 GMT, Wed, 17 Sep 2014 23:59:59 GMT]";
+        it("can create a day index", done => {
+            const index = new Index("2014-09-17");
+            const expected = "[Wed, 17 Sep 2014 00:00:00 GMT, Wed, 17 Sep 2014 23:59:59 GMT]";
             expect(index.asTimerange().toUTCString()).to.equal(expected);
             expect(index.asTimerange().humanizeDuration()).to.equal("a day");
             done();
         });
 
     });
-    describe("Index nice names", function () {
-        it('can create a year index', function(done) {
-            var index = new Index("2014");
-            var expected = "2014";
-            expect(index.toNiceString()).to.equal(expected);
-            done();
-        });
-    
-        it('can create a month index..', function(done) {
-            var index = new Index("2014-09");
-            var expected = "September";
+
+    describe("Index nice names", () => {
+
+        it("can create a year index", done => {
+            const index = new Index("2014");
+            const expected = "2014";
             expect(index.toNiceString()).to.equal(expected);
             done();
         });
 
-        it('can create a day index', function(done) {
-            var index = new Index("2014-09-17");
-            var expected = "September 17th 2014";
+        it("can create a month index..", done => {
+            const index = new Index("2014-09");
+            const expected = "September";
             expect(index.toNiceString()).to.equal(expected);
             done();
         });
-        it('can create a day index', function(done) {
-            var index = new Index("2014-09-17");
-            var expected = "17 Sep 2014";
+
+        it("can create a day index", done => {
+            const index = new Index("2014-09-17");
+            const expected = "September 17th 2014";
+            expect(index.toNiceString()).to.equal(expected);
+            done();
+        });
+
+        it("can create a day index", done => {
+            const index = new Index("2014-09-17");
+            const expected = "17 Sep 2014";
             expect(index.toNiceString("DD MMM YYYY")).to.equal(expected);
             done();
         });

--- a/test/tests/range.test.js
+++ b/test/tests/range.test.js
@@ -1,40 +1,50 @@
-var moment = require('moment');
-var expect = require('chai').expect;
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-var fmt = "YYYY-MM-DD HH:mm";
-var fmt2 = "YYYY-MM-DD HH:mm:ss";
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
 
-describe("Time ranges", function () {
+import {expect} from "chai";
+import moment from "moment";
+import TimeRange from "../../src/range.js";
 
-    var TimeRange = require("../../src/range.js");
+const fmt = "YYYY-MM-DD HH:mm";
+const fmt2 = "YYYY-MM-DD HH:mm:ss";
 
-    describe("TimeRange creation", function () {
-        it('can create a new range with a begin and end time', function(done) {
-            var beginTime = moment("2012-01-11 11:11", fmt).toDate();
-            var endTime =   moment("2012-02-22 12:12", fmt).toDate();
-            var range = new TimeRange(beginTime, endTime);
+describe("Time ranges", () => {
 
+    describe("TimeRange creation", () => {
+        it("can create a new range with a begin and end time", done => {
+            const beginTime = moment("2012-01-11 11:11", fmt).toDate();
+            const endTime = moment("2012-02-22 12:12", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
             expect(range.begin().getTime()).to.equal(beginTime.getTime());
             expect(range.end().getTime()).to.equal(endTime.getTime());
             done();
         });
-        it('can create a new range with two UNIX epoch times in an array', function(done) {
-            var range = new TimeRange([1326309060000, 1329941520000]);
+        it("can create a new range with two UNIX epoch times in an array", done => {
+            const range = new TimeRange([1326309060000, 1329941520000]);
             expect(range.toJSON()).to.deep.equal([1326309060000, 1329941520000]);
             done();
         });
     });
 
-    describe("TimeRange copying", function () {
-        it('can be copied to give a new range', function(done) {
-            var beginTime = moment("2012-01-11 1:11", fmt).toDate();
-            var endTime =   moment("2012-02-12 2:12", fmt).toDate();
-            var newTime =   moment("2012-03-13 3:13", fmt).toDate();
-            var rangeOrig = new TimeRange(beginTime, endTime);
-            var rangeCopy = new TimeRange(rangeOrig);
-
-            //We expect the copy to not equal the original, but for the dates
-            //within the copy to be the same
+    describe("TimeRange copying", () => {
+        it("can be copied to give a new range", done => {
+            const beginTime = moment("2012-01-11 1:11", fmt).toDate();
+            const endTime = moment("2012-02-12 2:12", fmt).toDate();
+            const rangeOrig = new TimeRange(beginTime, endTime);
+            const rangeCopy = new TimeRange(rangeOrig);
+            // We expect the copy to not equal the original, but for the dates
+            // within the copy to be the same
             expect(rangeCopy).to.not.equal(rangeOrig);
             expect(rangeCopy.begin().getTime()).to.equal(beginTime.getTime());
             expect(rangeCopy.end().getTime()).to.equal(endTime.getTime());
@@ -42,127 +52,125 @@ describe("Time ranges", function () {
         });
     });
 
-    describe("TimeRange serialization", function () {
-        it('can output JSON in the correct format', function(done) {
-            var beginTime = moment("2012-01-11 11:11", fmt).utc().toDate();
-            var endTime =   moment("2012-02-22 12:12", fmt).utc().toDate();
-            var range = new TimeRange(beginTime, endTime);
-            expect(range.toJSON()).to.deep.equal([1326298260000, 1329930720000]);
+    describe("TimeRange serialization", () => {
+
+        it("can output JSON in the correct format", done => {
+            const beginTime = moment.utc("2012-01-11 11:11", fmt).toDate();
+            const endTime = moment.utc("2012-02-22 12:12", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            expect(range.toJSON()).to.deep.equal([1326280260000, 1329912720000]);
             done();
         });
-        it('can output a string representation', function(done) {
-            var beginTime = moment("2012-01-11 11:11", fmt).utc().toDate();
-            var endTime =   moment("2012-02-22 12:12", fmt).utc().toDate();
-            var range = new TimeRange(beginTime, endTime);
-            expect(range.toString()).to.equal('[1326298260000,1329930720000]');
+
+        it("can output a string representation", done => {
+            const beginTime = moment.utc("2012-01-11 11:11", fmt).toDate();
+            const endTime = moment.utc("2012-02-22 12:12", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            expect(range.toString()).to.equal("[1326280260000,1329912720000]");
             done();
         });
 
     });
 
-    describe("TimeRange human friendly display", function () {
-        it('can display range as a human friendly string', function(done) {
-            var beginTime = moment("2014-08-01 05:19:59", fmt2).toDate();
-            var endTime =   moment("2014-08-01 07:41:06", fmt2).toDate();
-            var range = new TimeRange(beginTime, endTime);
-            var expected = "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am"
+    describe("TimeRange human friendly display", () => {
+
+        it("can display range as a human friendly string", done => {
+            const beginTime = moment("2014-08-01 05:19:59", fmt2).toDate();
+            const endTime = moment("2014-08-01 07:41:06", fmt2).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            const expected = "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am";
             expect(range.humanize()).to.equal(expected);
             done();
         });
-        it('can display relative ranges as a human friendly string', function(done) {
-            var range = TimeRange.lastThirtyDays();
-            var expected = "a few seconds ago to a month ago"
+
+        it("can display relative ranges as a human friendly string", done => {
+            const range = TimeRange.lastThirtyDays();
+            const expected = "a few seconds ago to a month ago";
             expect(range.relativeString()).to.equal(expected);
             done();
         });
     });
 
-    describe("TimeRange mutation", function () {
-        it('can be mutatated to form a new range', function(done) {
-            var beginTime = moment("2012-01-11 1:11", fmt).toDate();
-            var endTime =   moment("2012-02-12 2:12", fmt).toDate();
-            var newTime =   moment("2012-03-13 3:13", fmt).toDate();
+    describe("TimeRange mutation", () => {
 
-            var range = new TimeRange(beginTime, endTime);
-            var mutatedTimeRange = range.setEnd(newTime);
+        it("can be mutatated to form a new range", done => {
+            const beginTime = moment("2012-01-11 1:11", fmt).toDate();
+            const endTime = moment("2012-02-12 2:12", fmt).toDate();
+            const newTime = moment("2012-03-13 3:13", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            const mutatedTimeRange = range.setEnd(newTime);
 
-            //Expect the range to be difference and the end time to be different
+            // Expect the range to be difference and the end time to be different
             expect(mutatedTimeRange).to.not.equal(range);
             expect(mutatedTimeRange.end().getTime()).to.equal(newTime.getTime());
             done();
         });
     });
 
-    describe("TimeRange compare to another range", function () {
+    describe("TimeRange compare to another range", () => {
 
-        it('can be compared to see if they are equal', function(done) {
-            var ta = moment("2010-01-01 12:00", fmt).toDate();
-            var tb = moment("2010-02-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
-
-            var tc = moment("2010-01-01 12:00", fmt).toDate();
-            var td = moment("2010-02-01 12:00", fmt).toDate();
-            var range2 = new TimeRange(tc, td);
-
-            var te = moment("2012-03-01 12:00", fmt).toDate();
-            var tf = moment("2012-04-02 12:00", fmt).toDate();
-            var range3 = new TimeRange(te, tf);
-
+        it("can be compared to see if they are equal", done => {
+            const ta = moment("2010-01-01 12:00", fmt).toDate();
+            const tb = moment("2010-02-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
+            const tc = moment("2010-01-01 12:00", fmt).toDate();
+            const td = moment("2010-02-01 12:00", fmt).toDate();
+            const range2 = new TimeRange(tc, td);
+            const te = moment("2012-03-01 12:00", fmt).toDate();
+            const tf = moment("2012-04-02 12:00", fmt).toDate();
+            const range3 = new TimeRange(te, tf);
             expect(range1.equals(range2)).to.be.true;
             expect(range1.equals(range3)).to.be.false;
-
             done();
         });
 
-        it('can be compared for overlap to a non-overlapping range', function(done) {
-            var ta = moment("2010-01-01 12:00", fmt).toDate();
-            var tb = moment("2010-02-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
-
-            var tc = moment("2010-03-15 12:00", fmt).toDate();
-            var td = moment("2010-04-15 12:00", fmt).toDate();
-            var range2 = new TimeRange(tc, td);
-
+        it("can be compared for overlap to a non-overlapping range", done => {
+            const ta = moment("2010-01-01 12:00", fmt).toDate();
+            const tb = moment("2010-02-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
+            const tc = moment("2010-03-15 12:00", fmt).toDate();
+            const td = moment("2010-04-15 12:00", fmt).toDate();
+            const range2 = new TimeRange(tc, td);
             expect(range1.overlaps(range2)).to.be.false;
             expect(range2.overlaps(range1)).to.be.false;
             done();
         });
 
-        it('can be compared for overlap to an overlapping range', function(done) {
-            var ta = moment("2010-01-01 12:00", fmt).toDate();
-            var tb = moment("2010-09-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
+        it("can be compared for overlap to an overlapping range", done => {
+            const ta = moment("2010-01-01 12:00", fmt).toDate();
+            const tb = moment("2010-09-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
 
-            var td = moment("2010-08-15 12:00", fmt).toDate();
-            var te = moment("2010-11-15 12:00", fmt).toDate();
-            var range2 = new TimeRange(td, te);
+            const td = moment("2010-08-15 12:00", fmt).toDate();
+            const te = moment("2010-11-15 12:00", fmt).toDate();
+            const range2 = new TimeRange(td, te);
 
             expect(range1.overlaps(range2)).to.be.true;
             expect(range2.overlaps(range1)).to.be.true;
             done();
         });
 
-        it('can be compared for containment to an range contained within it completely', function(done) {
-            var ta = moment("2010-01-01 12:00", fmt).toDate();
-            var tb = moment("2010-09-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
+        it("can be compared for containment to an range contained within it completely", done => {
+            const ta = moment("2010-01-01 12:00", fmt).toDate();
+            const tb = moment("2010-09-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
 
-            var td = moment("2010-03-15 12:00", fmt).toDate();
-            var te = moment("2010-06-15 12:00", fmt).toDate();
-            var range2 = new TimeRange(td, te);
+            const td = moment("2010-03-15 12:00", fmt).toDate();
+            const te = moment("2010-06-15 12:00", fmt).toDate();
+            const range2 = new TimeRange(td, te);
 
             expect(range1.contains(range2)).to.be.true;
             done();
         });
 
-        it('can be compared for containment to an overlapping range', function(done) {
-            var ta = moment("2010-01-01 12:00", fmt).toDate();
-            var tb = moment("2010-09-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
+        it("can be compared for containment to an overlapping range", done => {
+            const ta = moment("2010-01-01 12:00", fmt).toDate();
+            const tb = moment("2010-09-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
 
-            var td = moment("2010-06-15 12:00", fmt).toDate();
-            var te = moment("2010-12-15 12:00", fmt).toDate();
-            var range2 = new TimeRange(td, te);
+            const td = moment("2010-06-15 12:00", fmt).toDate();
+            const te = moment("2010-12-15 12:00", fmt).toDate();
+            const range2 = new TimeRange(td, te);
 
             expect(range1.contains(range2)).to.be.false;
             done();
@@ -170,94 +178,80 @@ describe("Time ranges", function () {
     });
 
 
-    describe("TimeRange compare with time", function () {
+    describe("TimeRange compare with time", () => {
 
-        it('can be compared to a time before the range', function(done) {
-            var ta = moment("2010-06-01 12:00", fmt).toDate();
-            var tb =   moment("2010-08-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
-
-            var before = moment("2010-01-15 12:00", fmt).toDate();
-
+        it("can be compared to a time before the range", done => {
+            const ta = moment("2010-06-01 12:00", fmt).toDate();
+            const tb = moment("2010-08-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
+            const before = moment("2010-01-15 12:00", fmt).toDate();
             expect(range1.contains(before)).to.be.false;
             done();
         });
 
-        it('can be compared to a time during the range', function(done) {
-            var ta = moment("2010-06-01 12:00", fmt).toDate();
-            var tb =   moment("2010-08-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
-
-            var during = moment("2010-07-15 12:00", fmt).toDate();
-
+        it("can be compared to a time during the range", done => {
+            const ta = moment("2010-06-01 12:00", fmt).toDate();
+            const tb = moment("2010-08-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
+            const during = moment("2010-07-15 12:00", fmt).toDate();
             expect(range1.contains(during)).to.be.true;
             done();
         });
 
-        it('can be compared to a time after the range', function(done) {
-            var ta = moment("2010-06-01 12:00", fmt).toDate();
-            var tb =   moment("2010-08-01 12:00", fmt).toDate();
-            var range1 = new TimeRange(ta, tb);
-
-            var after  = moment("2010-12-15 12:00", fmt).toDate();
-
+        it("can be compared to a time after the range", done => {
+            const ta = moment("2010-06-01 12:00", fmt).toDate();
+            const tb = moment("2010-08-01 12:00", fmt).toDate();
+            const range1 = new TimeRange(ta, tb);
+            const after = moment("2010-12-15 12:00", fmt).toDate();
             expect(range1.contains(after)).to.be.false;
             done();
         });
     });
 
-    describe("Intersections of ranges", function () {
+    describe("Intersections of ranges", () => {
 
-        it("can be undefined if the ranges don't intersect", function(done) {
+        it("can be undefined if the ranges don't intersect", done => {
             // Two non-overlapping ranges: intersect() returns undefined
-            var beginTime = moment("2010-01-01 12:00", fmt).toDate();
-            var endTime =   moment("2010-06-01 12:00", fmt).toDate();
-            var range = new TimeRange(beginTime, endTime);
-
-            var beginTimeOutside = moment("2010-07-15 12:00", fmt).toDate();
-            var endTimeOutside =   moment("2010-08-15 12:00", fmt).toDate();
-            var rangeOutside = new TimeRange(beginTimeOutside, endTimeOutside);
-
+            const beginTime = moment("2010-01-01 12:00", fmt).toDate();
+            const endTime = moment("2010-06-01 12:00", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            const beginTimeOutside = moment("2010-07-15 12:00", fmt).toDate();
+            const endTimeOutside = moment("2010-08-15 12:00", fmt).toDate();
+            const rangeOutside = new TimeRange(beginTimeOutside, endTimeOutside);
             expect(range.intersection(rangeOutside)).to.be.undefined;
             done();
         });
 
-        it("can be a new range if the ranges intersect", function(done) {
-            // Two overlapping ranges: intersect() returns 
+        it("can be a new range if the ranges intersect", done => {
+            // Two overlapping ranges: intersect() returns
             //    01 -------06       range
             //           05-----07   rangeOverlap
             //           05-06       intersection
-            var beginTime = moment("2010-01-01 12:00", fmt).toDate();
-            var endTime =   moment("2010-06-01 12:00", fmt).toDate();
-            var range = new TimeRange(beginTime, endTime);
-
-            var beginTimeOverlap = moment("2010-05-01 12:00", fmt).toDate();
-            var endTimeOverlap =   moment("2010-07-01 12:00", fmt).toDate();
-            var rangeOverlap = new TimeRange(beginTimeOverlap, endTimeOverlap);
-
-            var expected = new TimeRange(beginTimeOverlap, endTime);
-
+            const beginTime = moment("2010-01-01 12:00", fmt).toDate();
+            const endTime = moment("2010-06-01 12:00", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            const beginTimeOverlap = moment("2010-05-01 12:00", fmt).toDate();
+            const endTimeOverlap = moment("2010-07-01 12:00", fmt).toDate();
+            const rangeOverlap = new TimeRange(beginTimeOverlap, endTimeOverlap);
+            const expected = new TimeRange(beginTimeOverlap, endTime);
             expect(range.intersection(rangeOverlap).toString()).to.equal(expected.toString());
             done();
         });
 
-        it("can be a new range (the smaller range) if one range surrounds another", function(done) {
+        it("can be a new range (the smaller range) if one range surrounds another", done => {
             // One range fully inside the other intersect() returns the smaller range
             //    01 -------06    range
             //       02--04       rangeInside
             //       02--04       intersection
-            var beginTime = moment("2010-01-01 12:00", fmt).toDate();
-            var endTime =   moment("2010-06-01 12:00", fmt).toDate();
-            var range = new TimeRange(beginTime, endTime);
-
-            var beginTimeInside = moment("2010-02-01 12:00", fmt).toDate();
-            var endTimeInside =   moment("2010-04-01 12:00", fmt).toDate();
-            var rangeInside = new TimeRange(beginTimeInside, endTimeInside);
-
+            const beginTime = moment("2010-01-01 12:00", fmt).toDate();
+            const endTime = moment("2010-06-01 12:00", fmt).toDate();
+            const range = new TimeRange(beginTime, endTime);
+            const beginTimeInside = moment("2010-02-01 12:00", fmt).toDate();
+            const endTimeInside = moment("2010-04-01 12:00", fmt).toDate();
+            const rangeInside = new TimeRange(beginTimeInside, endTimeInside);
             expect(range.intersection(rangeInside).toString()).to.equal(rangeInside.toString());
             expect(rangeInside.intersection(range).toString()).to.equal(rangeInside.toString());
             done();
         });
     });
-
 });

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -611,7 +611,6 @@ describe("Mutation of timeseries", function () {
             var inTraffic = new TimeSeries(trafficDataIn);
             var outTraffic = new TimeSeries(trafficDataOut);
             var trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
-            console.log("Merged series:", trafficSeries.toString());
             expect(trafficSeries.at(2).get("in")).to.equal(26);
             expect(trafficSeries.at(2).get("out")).to.equal(67);
             done();

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -640,7 +640,7 @@ describe("Mutation of timeseries", () => {
         it("can merge two timeseries columns together using merge", (done) => {
             const inTraffic = new TimeSeries(trafficDataIn);
             const outTraffic = new TimeSeries(trafficDataOut);
-            const trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
+            const trafficSeries = TimeSeries.merge({name: "traffic"}, [inTraffic, outTraffic]);
             expect(trafficSeries.at(2).get("in")).to.equal(26);
             expect(trafficSeries.at(2).get("out")).to.equal(67);
             done();
@@ -649,7 +649,7 @@ describe("Mutation of timeseries", () => {
         it("can append two timeseries together using merge", (done) => {
             const tile1 = new TimeSeries(partialTraffic1);
             const tile2 = new TimeSeries(partialTraffic2);
-            const trafficSeries = TimeSeries.merge("traffic", [tile1, tile2]);
+            const trafficSeries = TimeSeries.merge({name: "traffic", source: "router"}, [tile1, tile2]);
             expect(trafficSeries.size()).to.equal(8);
             expect(trafficSeries.at(0).get()).to.equal(34);
             expect(trafficSeries.at(1).get()).to.equal(13);
@@ -659,6 +659,8 @@ describe("Mutation of timeseries", () => {
             expect(trafficSeries.at(5).get()).to.equal(86);
             expect(trafficSeries.at(6).get()).to.equal(27);
             expect(trafficSeries.at(7).get()).to.equal(72);
+            expect(trafficSeries.name()).to.equal("traffic");
+            expect(trafficSeries.meta("source")).to.equal("router");
             done();
         });
     });

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -506,9 +506,9 @@ describe("TimeSeries", () => {
             done();
         });
 
-        it("can find the medium of the series", done => {
+        it("can find the median of the series", done => {
             const series = new TimeSeries(statsData);
-            expect(series.medium()).to.equal(14);
+            expect(series.median()).to.equal(14);
             done();
         });
 

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -314,6 +314,28 @@ const trafficDataOut = {
     ]
 };
 
+const partialTraffic1 = {
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "value"],
+    points: [
+        [1400425947000, 34],
+        [1400425948000, 13],
+        [1400425949000, 67],
+        [1400425950000, 91],
+    ]
+};
+
+const partialTraffic2 = {
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "value"],
+    points: [
+        [1400425951000, 65],
+        [1400425952000, 86],
+        [1400425953000, 27],
+        [1400425954000, 72],
+    ]
+};
+
 describe("TimeSeries", () => {
 
     describe("TimeSeries created with a javascript objects", () => {
@@ -603,28 +625,40 @@ describe("Mutation of timeseries", () => {
     describe("Series created with a javascript object", () => {
         it("can create an slice a series", done => {
             const series = new TimeSeries(availabilityData);
-
             const expectedLastTwo = `{"name":"availability","columns":["time","uptime"],"points":[["2014-08","88%"],["2014-07","100%"]]}`;
             const lastTwo = series.slice(-2);
             expect(lastTwo.toString()).to.equal(expectedLastTwo);
-
             const expectedFirstThree = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"]]}`;
             const firstThree = series.slice(0, 3);
             expect(firstThree.toString()).to.equal(expectedFirstThree);
-
             const expectedAll = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"],["2015-03","99%"],["2015-02","92%"],["2015-01","100%"],["2014-12","99%"],["2014-11","91%"],["2014-10","99%"],["2014-09","95%"],["2014-08","88%"],["2014-07","100%"]]}`;
             const sliceAll = series.slice();
             expect(sliceAll.toString()).to.equal(expectedAll);
-
             done();
         });
 
-        it("can merge two timeseries together", (done) => {
+        it("can merge two timeseries columns together using merge", (done) => {
             const inTraffic = new TimeSeries(trafficDataIn);
             const outTraffic = new TimeSeries(trafficDataOut);
             const trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
             expect(trafficSeries.at(2).get("in")).to.equal(26);
             expect(trafficSeries.at(2).get("out")).to.equal(67);
+            done();
+        });
+
+        it("can append two timeseries together using merge", (done) => {
+            const tile1 = new TimeSeries(partialTraffic1);
+            const tile2 = new TimeSeries(partialTraffic2);
+            const trafficSeries = TimeSeries.merge("traffic", [tile1, tile2]);
+            expect(trafficSeries.size()).to.equal(8);
+            expect(trafficSeries.at(0).get()).to.equal(34);
+            expect(trafficSeries.at(1).get()).to.equal(13);
+            expect(trafficSeries.at(2).get()).to.equal(67);
+            expect(trafficSeries.at(3).get()).to.equal(91);
+            expect(trafficSeries.at(4).get()).to.equal(65);
+            expect(trafficSeries.at(5).get()).to.equal(86);
+            expect(trafficSeries.at(6).get()).to.equal(27);
+            expect(trafficSeries.at(7).get()).to.equal(72);
             done();
         });
     });

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -280,6 +280,28 @@ const bisectTestData = {
     ]
 };
 
+const trafficDataIn = {
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "in"],
+    points: [
+        [1400425947000, 52],
+        [1400425948000, 18],
+        [1400425949000, 26],
+        [1400425950000, 93],
+    ]
+};
+
+const trafficDataOut = {
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "out"],
+    points: [
+        [1400425947000, 34],
+        [1400425948000, 13],
+        [1400425949000, 67],
+        [1400425950000, 91],
+    ]
+};
+
 describe("TimeSeries", function () {
 
     describe("TimeSeries created with a javascript objects", function () {
@@ -542,6 +564,8 @@ describe("Timeseries containing indexed timeranges", function () {
     });
 
     /**
+     * DISABLED TEST
+     *
      * The problem is this test creates times in local time, but running the test in
      * different timezones will produce a different timeseries.
 
@@ -580,6 +604,16 @@ describe("Mutation of timeseries", function () {
             var sliceAll = series.slice();
             expect(sliceAll.toString()).to.equal(expectedAll);
 
+            done();
+        });
+
+        it("can merge two timeseries together", (done) => {
+            var inTraffic = new TimeSeries(trafficDataIn);
+            var outTraffic = new TimeSeries(trafficDataOut);
+            var trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
+            console.log("Merged series:", trafficSeries.toString());
+            expect(trafficSeries.at(2).get("in")).to.equal(26);
+            expect(trafficSeries.at(2).get("out")).to.equal(67);
             done();
         });
     });

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -1,6 +1,16 @@
-/*eslint-env node, mocha */
-/*eslint no-unused-expressions: 0 */
-/*eslint max-len: 0 */
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
 
 import moment from "moment";
 import {expect} from "chai";
@@ -92,6 +102,7 @@ const availabilityData = {
     ]
 };
 
+/*
 const availabilityDataLocalTime = {
     name: "availability",
     utc: false,
@@ -111,6 +122,7 @@ const availabilityDataLocalTime = {
         ["2014-07", "100%"]
     ]
 };
+*/
 
 const interfaceData = {
     name: "star-cr5:to_anl_ip-a_v4",
@@ -302,9 +314,9 @@ const trafficDataOut = {
     ]
 };
 
-describe("TimeSeries", function () {
+describe("TimeSeries", () => {
 
-    describe("TimeSeries created with a javascript objects", function () {
+    describe("TimeSeries created with a javascript objects", () => {
         it("can create an series", done => {
             const series = new TimeSeries(data);
             expect(series).to.be.ok;
@@ -312,12 +324,12 @@ describe("TimeSeries", function () {
         });
     });
 
-    describe("TimeSeries created with a list of events", function () {
+    describe("TimeSeries created with a list of events", () => {
         it("can create an series", done => {
             const events = [];
             events.push(new Event(new Date(2015, 7, 1), {value: 27}));
             events.push(new Event(new Date(2015, 8, 1), {value: 14}));
-            var series = new TimeSeries({
+            const series = new TimeSeries({
                 name: "events",
                 events: events
             });
@@ -326,7 +338,7 @@ describe("TimeSeries", function () {
         });
         it("can create an series with no events", done => {
             const events = [];
-            var series = new TimeSeries({
+            const series = new TimeSeries({
                 name: "events",
                 events: events
             });
@@ -335,164 +347,164 @@ describe("TimeSeries", function () {
         });
     });
 
-    describe("Timeseries basic query", function () {
+    describe("Timeseries basic query", () => {
         it("can create an series", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series).to.be.ok;
             done();
         });
 
         it("can return the size of the series", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.size()).to.equal(4);
             done();
         });
 
         it("can return an item in the series as an event", done => {
-            var series = new TimeSeries(data);
-            var event = series.at(1);
+            const series = new TimeSeries(data);
+            const event = series.at(1);
             expect(event).to.be.an.instanceof(Event);
             done();
         });
 
         it("can return an item in the series with the correct data", done => {
-            var series = new TimeSeries(data);
-            var event = series.at(1);
+            const series = new TimeSeries(data);
+            const event = series.at(1);
             expect(JSON.stringify(event.data())).to.equal(`{"value":18,"status":"ok"}`);
             expect(event.timestamp().getTime()).to.equal(1400425948000);
             done();
         });
 
         it("can serialize to a string", done => {
-            var series = new TimeSeries(data);
-            var expectedString = `{"name":"traffic","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+            const series = new TimeSeries(data);
+            const expectedString = `{"name":"traffic","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
             expect(series.toString()).to.equal(expectedString);
             done();
         });
 
         it("can return the time range of the series", done => {
-            var series = new TimeSeries(data);
-            var expectedString = "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
+            const series = new TimeSeries(data);
+            const expectedString = "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
             expect(series.range().toUTCString()).to.equal(expectedString);
             done();
         });
     });
 
-    describe("Timeseries with meta data can be created with a javascript object", function () {
+    describe("Timeseries with meta data can be created with a javascript object", () => {
         it("can create an series with meta data and get that data back", done => {
-            var series = new TimeSeries(interfaceData);
-            var expected = `{"name":"star-cr5:to_anl_ip-a_v4","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]],"site_interface":"et-1/0/0","site":"anl","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud"}`;
+            const series = new TimeSeries(interfaceData);
+            const expected = `{"name":"star-cr5:to_anl_ip-a_v4","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]],"site_interface":"et-1/0/0","site":"anl","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud"}`;
             expect(series.toString()).to.equal(expected);
             expect(series.meta("interface")).to.equal("to_anl_ip-a_v4");
             done();
         });
     });
 
-    describe("Compare series", function () {
+    describe("Compare series", () => {
         it("can compare a series and a reference to a series as being equal", done => {
-            var series = new TimeSeries(data);
-            var refSeries = series;
+            const series = new TimeSeries(data);
+            const refSeries = series;
             expect(series).to.equal(refSeries);
             done();
         });
 
         it("can use the equals() comparator to compare a series and a copy of the series as true", done => {
-            var series = new TimeSeries(data);
-            var copyOfSeries = new TimeSeries(series);
+            const series = new TimeSeries(data);
+            const copyOfSeries = new TimeSeries(series);
             expect(TimeSeries.equal(series, copyOfSeries)).to.be.true;
             done();
         });
 
         it("can use the equals() comparator to compare a series and a value equivalent series as false", done => {
-            var series = new TimeSeries(data);
-            var otherSeries = new TimeSeries(data);
+            const series = new TimeSeries(data);
+            const otherSeries = new TimeSeries(data);
             expect(TimeSeries.equal(series, otherSeries)).to.be.false;
             done();
         });
 
         it("can use the is() comparator to compare a series and a value equivalent series as true", done => {
-            var series = new TimeSeries(data);
-            var otherSeries = new TimeSeries(data);
+            const series = new TimeSeries(data);
+            const otherSeries = new TimeSeries(data);
             expect(TimeSeries.is(series, otherSeries)).to.be.true;
             done();
         });
     });
 
-    describe("Series can be reduced", function () {
+    describe("Series can be reduced", () => {
 
         it("can sum the series", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.sum("value")).to.equal(189);
             done();
         });
 
         it("can sum the series with no column name specified", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.sum()).to.equal(189);
             done();
         });
 
         it("can sum the series with a bogus column name and get undefined", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.sum("invalid")).to.be.undefined;
             done();
         });
 
         it("can find the max of the series", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.max()).to.equal(93);
             done();
         });
 
         it("can find the min of the series", done => {
-            var series = new TimeSeries(data);
+            const series = new TimeSeries(data);
             expect(series.min()).to.equal(18);
             done();
         });
 
     });
 
-    describe("Series can be reduced to stats", function () {
+    describe("Series can be reduced to stats", () => {
 
         it("can avg the series", done => {
-            var series = new TimeSeries(statsData);
+            const series = new TimeSeries(statsData);
             expect(series.avg()).to.equal(15);
             done();
         });
 
         it("can mean of the series (the avg)", done => {
-            var series = new TimeSeries(statsData);
+            const series = new TimeSeries(statsData);
             expect(series.mean()).to.equal(15);
             done();
         });
 
         it("can find the mean of the series", done => {
-            var series = new TimeSeries(statsData);
+            const series = new TimeSeries(statsData);
             expect(series.mean()).to.equal(15);
             done();
         });
 
         it("can find the medium of the series", done => {
-            var series = new TimeSeries(statsData);
+            const series = new TimeSeries(statsData);
             expect(series.medium()).to.equal(14);
             done();
         });
 
         it("can find the standard deviation of the series", done => {
-            var series = new TimeSeries(statsData);
+            const series = new TimeSeries(statsData);
             expect(series.stdev()).to.equal(2.6666666666666665);
             done();
         });
 
         it("can find the standard deviation and mean of another series", done => {
-            var series = new TimeSeries(statsData2);
+            const series = new TimeSeries(statsData2);
             expect(Math.round(series.mean() * 10) / 10).to.equal(38.8);
             expect(Math.round(series.stdev() * 10) / 10).to.equal(11.4);
             done();
         });
     });
 
-    describe("Series index can be found with bisect", function () {
+    describe("Series index can be found with bisect", () => {
 
         it("can find the bisect starting from 0", done => {
             const series = new TimeSeries(bisectTestData);
@@ -525,20 +537,20 @@ describe("TimeSeries", function () {
  * if the series represents june 2014 then the Index might be "2014-06", or the
  * 123rd day since the epoch would be "1d-123"
  */
-describe("Indexed TimeSeries", function () {
+describe("Indexed TimeSeries", () => {
 
-    describe("Series created with a javascript object", function () {
+    describe("Series created with a javascript object", () => {
 
         it("can serialize to a string", done => {
-            var series = new TimeSeries(indexedData);
-            var expectedString = `{"name":"traffic","index":"1d-625","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+            const series = new TimeSeries(indexedData);
+            const expectedString = `{"name":"traffic","index":"1d-625","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
             expect(series.toString()).to.equal(expectedString);
             done();
         });
 
         it("can return the time range of the series", done => {
-            var series = new TimeSeries(indexedData);
-            var expectedString = "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
+            const series = new TimeSeries(indexedData);
+            const expectedString = "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
             expect(series.indexAsRange().toUTCString()).to.equal(expectedString);
             done();
         });
@@ -550,12 +562,12 @@ describe("Indexed TimeSeries", function () {
  * if the series represents june 2014 then the Index might be "2014-06", or the
  * 123rd day since the epoch would be "1d-123"
  */
-describe("Timeseries containing indexed timeranges", function () {
+describe("Timeseries containing indexed timeranges", () => {
 
-    describe("Series created with indexed data in the default UTC time", function () {
+    describe("Series created with indexed data in the default UTC time", () => {
         it("can create an series with indexed data (in UTC time)", done => {
-            var series = new TimeSeries(availabilityData);
-            var event = series.at(2);
+            const series = new TimeSeries(availabilityData);
+            const event = series.at(2);
             expect(event.timerangeAsUTCString()).to.equal("[Wed, 01 Apr 2015 00:00:00 GMT, Thu, 30 Apr 2015 23:59:59 GMT]");
             expect(series.range().begin().getTime()).to.equal(1404172800000);
             expect(series.range().end().getTime()).to.equal(1435708799999);
@@ -569,10 +581,10 @@ describe("Timeseries containing indexed timeranges", function () {
      * The problem is this test creates times in local time, but running the test in
      * different timezones will produce a different timeseries.
 
-    describe("Series created with indexed data in local time", function () {
+    describe("Series created with indexed data in local time", () => {
         it("can create an series with indexed data in local time", done => {
-            var series = new TimeSeries(availabilityDataLocalTime);
-            var event = series.at(2);
+            const series = new TimeSeries(availabilityDataLocalTime);
+            const event = series.at(2);
             expect(event.timerangeAsUTCString()).to.equal("[Wed, 01 Apr 2015 07:00:00 GMT, Fri, 01 May 2015 06:59:59 GMT]");
             expect(series.range().begin().getTime()).to.equal(1404198000000);
             expect(series.range().end().getTime()).to.equal(1435733999999);
@@ -586,31 +598,31 @@ describe("Timeseries containing indexed timeranges", function () {
 /**
  * A series should be able to be mutated, producing another TimeSeries as a result
  */
-describe("Mutation of timeseries", function () {
+describe("Mutation of timeseries", () => {
 
-    describe("Series created with a javascript object", function () {
+    describe("Series created with a javascript object", () => {
         it("can create an slice a series", done => {
-            var series = new TimeSeries(availabilityData);
+            const series = new TimeSeries(availabilityData);
 
-            var expectedLastTwo = `{"name":"availability","columns":["time","uptime"],"points":[["2014-08","88%"],["2014-07","100%"]]}`;
-            var lastTwo = series.slice(-2);
+            const expectedLastTwo = `{"name":"availability","columns":["time","uptime"],"points":[["2014-08","88%"],["2014-07","100%"]]}`;
+            const lastTwo = series.slice(-2);
             expect(lastTwo.toString()).to.equal(expectedLastTwo);
 
-            var expectedFirstThree = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"]]}`;
-            var firstThree = series.slice(0, 3);
+            const expectedFirstThree = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"]]}`;
+            const firstThree = series.slice(0, 3);
             expect(firstThree.toString()).to.equal(expectedFirstThree);
 
-            var expectedAll = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"],["2015-03","99%"],["2015-02","92%"],["2015-01","100%"],["2014-12","99%"],["2014-11","91%"],["2014-10","99%"],["2014-09","95%"],["2014-08","88%"],["2014-07","100%"]]}`;
-            var sliceAll = series.slice();
+            const expectedAll = `{"name":"availability","columns":["time","uptime"],"points":[["2015-06","100%"],["2015-05","92%"],["2015-04","87%"],["2015-03","99%"],["2015-02","92%"],["2015-01","100%"],["2014-12","99%"],["2014-11","91%"],["2014-10","99%"],["2014-09","95%"],["2014-08","88%"],["2014-07","100%"]]}`;
+            const sliceAll = series.slice();
             expect(sliceAll.toString()).to.equal(expectedAll);
 
             done();
         });
 
         it("can merge two timeseries together", (done) => {
-            var inTraffic = new TimeSeries(trafficDataIn);
-            var outTraffic = new TimeSeries(trafficDataOut);
-            var trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
+            const inTraffic = new TimeSeries(trafficDataIn);
+            const outTraffic = new TimeSeries(trafficDataOut);
+            const trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
             expect(trafficSeries.at(2).get("in")).to.equal(26);
             expect(trafficSeries.at(2).get("out")).to.equal(67);
             done();

--- a/webpack.website.config.js
+++ b/webpack.website.config.js
@@ -4,25 +4,24 @@
 
 module.exports = {
 
-  entry: {
-    app: ['./website/modules/main.jsx']
-  },
+    entry: {
+        app: ["./website/modules/main.jsx"]
+    },
 
-  output: {
-    filename: 'website-bundle.js'
-  },
+    output: {
+        filename: "./website/website-bundle.js"
+    },
 
-  module: {
-    loaders: [
-      { test: /\.(js|jsx)$/, loader: 'babel?optional=es7.objectRestSpread' },
-      { test: /\.css$/, loader: 'style-loader!css-loader' },
-      { test: /\.(png|jpg|gif)$/, loader: 'url-loader?limit=20000'},
-      { test: /\.json$/, loader: 'json-loader' },
-      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&minetype=application/font-woff" },
-      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "file-loader?name=[name].[ext]" }
-    ]
-  },
-  resolve: {
-    extensions: ['', '.js', '.jsx', '.json']
-  }
+    module: {
+        loaders: [
+            { test: /\.(js|jsx)$/, loader: "babel?stage=0" },
+            { test: /\.css$/, loader: "style-loader!css-loader" },
+            { test: /\.(png|jpg|gif)$/, loader: "url-loader?limit=20000"},
+            { test: /\.json$/, loader: "json-loader" }
+        ]
+    },
+
+    resolve: {
+        extensions: ["", ".js", ".jsx", ".json"]
+    }
 };

--- a/website/index.html
+++ b/website/index.html
@@ -12,6 +12,16 @@
         html { overflow-y:scroll; }
         body { padding-top:50px; }
         h1, h2, h3, h4 { color: steelblue; }
+        .sidebar-heading {
+            text-transform: uppercase;
+            font-weight: 600;
+            font-size: 12px;
+        }
+        h2, h3 {
+            border-bottom: #DDD;
+            border-bottom-style: solid;
+            border-bottom-width: thin;
+        }
     </style>
 </head>
 

--- a/website/modules/aggregators.jsx
+++ b/website/modules/aggregators.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/aggregators.md");
+import text from "raw!../../docs/aggregators.md";
 
 export default React.createClass({
 

--- a/website/modules/app.jsx
+++ b/website/modules/app.jsx
@@ -38,57 +38,57 @@ export default React.createClass({
                             width={80}/>
                     </div>
                     <div className="col-md-10">
-                        <h2>Pond: Timeseries Library</h2>
+                        <h1>Pond - Timeseries library</h1>
                     </div>
                 </div>
 
-              <hr />
+                <hr />
 
-              <div className="row">
+                <div className="row">
 
-                <div className="col-md-2" style={sidebarStyle}>
-                    <div className="docs-sidebar">
-                        <ul className="docs-sidenav nav">
-                            <li><Link to="intro">Introduction</Link></li>
-                            <li><Link to="start">Getting started</Link></li>
+                    <div className="col-md-3" style={sidebarStyle}>
+                        <div className="docs-sidebar">
+                            <ul className="docs-sidenav nav">
+                                <li><Link to="intro">Introduction</Link></li>
+                                <li><Link to="start">Getting started</Link></li>
 
-                            <hr />
+                                <hr />
 
-                            Examples:
-                            <li><Link to="rollups">Rollups</Link></li>
+                                <span className="sidebar-heading">Examples:</span>
+                                <li><Link to="rollups">Rollups</Link></li>
 
-                            <hr />
+                                <hr />
 
-                            API:
-                            <li><Link to="time">Time</Link></li>
-                            <li><Link to="timerange">TimeRange</Link></li>
-                            <li><Link to="index">Index</Link></li>
-                            <li><Link to="events">Events</Link></li>
-                            <li><Link to="timeseries">TimeSeries</Link></li>
-                            <li><Link to="aggregators">Aggregators</Link></li>
-                            <li><Link to="collectors">Collectors</Link></li>
-                            <li><Link to="binners">Binners</Link></li>
+                                <span className="sidebar-heading">API:</span>
+                                <li><Link to="time">Time</Link></li>
+                                <li><Link to="timerange">TimeRange</Link></li>
+                                <li><Link to="index">Index</Link></li>
+                                <li><Link to="events">Events</Link></li>
+                                <li><Link to="timeseries">TimeSeries</Link></li>
+                                <li><Link to="aggregators">Aggregators</Link></li>
+                                <li><Link to="collectors">Collectors</Link></li>
+                                <li><Link to="binners">Binners</Link></li>
 
-                            <hr />
+                                <hr />
 
-                            Links:
-                            <li><a href="https://github.com/esnet/pond/">GitHub</a></li>
-                            <li><a href="https://www.es.net/">ESnet</a></li>
-                            <li><a href="http://software.es.net/">Open Source</a></li>
+                                <span className="sidebar-heading">Links:</span>
+                                <li><a href="https://github.com/esnet/pond/">GitHub</a></li>
+                                <li><a href="https://www.es.net/">ESnet</a></li>
+                                <li><a href="http://software.es.net/">Open Source</a></li>
 
-                            <hr />
+                                <hr />
 
-                            Related Projects:
-                            <li><a href="http://software.es.net/react-timeseries-charts/">Timeseries Charts</a></li>
-                            <li><a href="http://software.es.net/react-network-diagrams/">Network Diagrams</a></li>
+                                <span className="sidebar-heading">Related Projects:</span>
+                                <li><a href="http://software.es.net/react-timeseries-charts/">Timeseries Charts</a></li>
+                                <li><a href="http://software.es.net/react-network-diagrams/">Network Diagrams</a></li>
 
-                        </ul>
+                            </ul>
+                        </div>
                     </div>
-                </div>
 
-                <div className="col-md-10">
-                  <RouteHandler />
-                </div>
+                    <div className="col-md-9">
+                      <RouteHandler />
+                    </div>
 
               </div>
           </div>

--- a/website/modules/app.jsx
+++ b/website/modules/app.jsx
@@ -1,85 +1,97 @@
-"use strict";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-var React = require("react/addons");
-var Router = require("react-router");
-var {RouteHandler,
-     Link} = Router;
+/* eslint-disable max-len */
 
-require("../styles/app.css");
-var logo = document.createElement("img");
+import React from "react";
+import {Link, RouteHandler} from "react-router";
+
+import "../styles/app.css";
+const logo = document.createElement("img");
 logo.src = require("../img/logo.png");
 
 export default React.createClass({
 
-    render: function() {
+    render() {
 
-    var sidebarStyle = {
-        borderRightStyle: "solid",
-        borderRightColor: "#F2F1F1",
-        borderRightWidth: 1
-    };
+        const sidebarStyle = {
+            borderRightStyle: "solid",
+            borderRightColor: "#F2F1F1",
+            borderRightWidth: 1
+        };
 
-    return (
-        <div>
-            <div className="row">
-                <div className="col-md-2">
-                    <img style={{float: "right"}} className="main-image" src={logo.src} width={80}/>
+        return (
+            <div>
+                <div className="row">
+                    <div className="col-md-2">
+                        <img
+                            style={{float: "right"}}
+                            className="main-image"
+                            src={logo.src}
+                            width={80}/>
+                    </div>
+                    <div className="col-md-10">
+                        <h2>Pond: Timeseries Library</h2>
+                    </div>
                 </div>
+
+              <hr />
+
+              <div className="row">
+
+                <div className="col-md-2" style={sidebarStyle}>
+                    <div className="docs-sidebar">
+                        <ul className="docs-sidenav nav">
+                            <li><Link to="intro">Introduction</Link></li>
+                            <li><Link to="start">Getting started</Link></li>
+
+                            <hr />
+
+                            Examples:
+                            <li><Link to="rollups">Rollups</Link></li>
+
+                            <hr />
+
+                            API:
+                            <li><Link to="time">Time</Link></li>
+                            <li><Link to="timerange">TimeRange</Link></li>
+                            <li><Link to="index">Index</Link></li>
+                            <li><Link to="events">Events</Link></li>
+                            <li><Link to="timeseries">TimeSeries</Link></li>
+                            <li><Link to="aggregators">Aggregators</Link></li>
+                            <li><Link to="collectors">Collectors</Link></li>
+                            <li><Link to="binners">Binners</Link></li>
+
+                            <hr />
+
+                            Links:
+                            <li><a href="https://github.com/esnet/pond/">GitHub</a></li>
+                            <li><a href="https://www.es.net/">ESnet</a></li>
+                            <li><a href="http://software.es.net/">Open Source</a></li>
+
+                            <hr />
+
+                            Related Projects:
+                            <li><a href="http://software.es.net/react-timeseries-charts/">Timeseries Charts</a></li>
+                            <li><a href="http://software.es.net/react-network-diagrams/">Network Diagrams</a></li>
+
+                        </ul>
+                    </div>
+                </div>
+
                 <div className="col-md-10">
-                    <h2>Pond: Timeseries Library</h2>
+                  <RouteHandler />
                 </div>
-            </div>
 
-          <hr />
-
-          <div className="row">
-
-            <div className="col-md-2" style={sidebarStyle}>
-                <div className="docs-sidebar">
-                    <ul className="docs-sidenav nav">
-                        <li><Link to="intro">Introduction</Link></li>
-                        <li><Link to="start">Getting started</Link></li>
-
-                        <hr />
-
-                        Examples:
-                        <li><Link to="rollups">Rollups</Link></li>
-
-                        <hr />
-
-                        API:
-                        <li><Link to="time">Time</Link></li>
-                        <li><Link to="timerange">TimeRange</Link></li>
-                        <li><Link to="index">Index</Link></li>
-                        <li><Link to="events">Events</Link></li>
-                        <li><Link to="timeseries">TimeSeries</Link></li>
-                        <li><Link to="aggregators">Aggregators</Link></li>
-                        <li><Link to="collectors">Collectors</Link></li>
-                        <li><Link to="binners">Binners</Link></li>
-
-                        <hr />
-
-                        Links:
-                        <li><a href="https://github.com/esnet/pond/">GitHub</a></li>
-                        <li><a href="https://www.es.net/">ESnet</a></li>
-                        <li><a href="http://software.es.net/">Open Source</a></li>
-
-                        <hr />
-
-                        Related Projects:
-                        <li><a href="http://software.es.net/react-timeseries-charts/">Timeseries Charts</a></li>
-                        <li><a href="http://software.es.net/react-network-diagrams/">Network Diagrams</a></li>
-
-                    </ul>
-                </div>
-            </div>
-
-            <div className="col-md-10">
-              <RouteHandler />
-            </div>
-
+              </div>
           </div>
-      </div>
-    );
-  }
+        );
+    }
 });

--- a/website/modules/binners.jsx
+++ b/website/modules/binners.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/binners.md");
+import text from "raw!../../docs/binners.md";
 
 export default React.createClass({
 

--- a/website/modules/collectors.jsx
+++ b/website/modules/collectors.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/collectors.md");
+import text from "raw!../../docs/collectors.md";
 
 export default React.createClass({
 

--- a/website/modules/events.jsx
+++ b/website/modules/events.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/events.md");
+import text from "raw!../../docs/events.md";
 
 export default React.createClass({
 

--- a/website/modules/highlighter.jsx
+++ b/website/modules/highlighter.jsx
@@ -1,8 +1,18 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 export default {
 
     highlightCodeBlocks() {
         const els = document.querySelectorAll("pre code");
-        for (var i = 0; i < els.length; i++) {
+        for (let i = 0; i < els.length; i++) {
             if (!els[i].classList.contains("hljs")) {
                 window.hljs.highlightBlock(els[i]);
             }

--- a/website/modules/index.jsx
+++ b/website/modules/index.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/index.md");
+import text from "raw!../../docs/index.md";
 
 export default React.createClass({
 

--- a/website/modules/intro.jsx
+++ b/website/modules/intro.jsx
@@ -1,16 +1,26 @@
-import React from "react/addons";
-import Markdown from "react-markdown-el";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
 
-var text = require("raw!../../README.md");
+import React from "react";
+import Markdown from "react-markdown";
+
+import text from "raw!../../README.md";
 
 export default React.createClass({
 
-    render: function() {
+    render() {
         return (
             <div>
                 <div className="row">
                     <div className="col-md-12">
-                        <Markdown text={text}/>
+                        <Markdown source={text}/>
                     </div>
                 </div>
             </div>

--- a/website/modules/main.jsx
+++ b/website/modules/main.jsx
@@ -1,7 +1,17 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 // Import the require hook for babel runtime
 import "babel/register";
 
-import React from "react/addons";
+import React from "react";
 import Router from "react-router";
 
 import App from "./app.jsx";
@@ -42,6 +52,6 @@ const routes = (
     </Route>
 );
 
-Router.run(routes, function (Handler) {
+Router.run(routes, Handler => {
     React.render(<Handler/>, document.getElementById("content"));
 });

--- a/website/modules/rollup.jsx
+++ b/website/modules/rollup.jsx
@@ -1,4 +1,14 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Highlighter from "./highlighter";
 import Markdown from "react-markdown";
 import Ring from "ringjs";
@@ -51,14 +61,15 @@ export default React.createClass({
         // Setup our aggregators
         //
 
-        this.fiveMinuteAggregator = new Aggregator("5m", avg, (index, event) => {
-            let events = this.state.fiveMinuteAvg;
-            events.push(event);
-            this.setState({fiveMinuteAvg: events});
-        });
+        this.fiveMinuteAggregator =
+            new Aggregator("5m", avg, (index, event) => {
+                const events = this.state.fiveMinuteAvg;
+                events.push(event);
+                this.setState({fiveMinuteAvg: events});
+            });
 
         this.hourlyAggregator = new Aggregator("1h", avg, (index, event) => {
-            let events = this.state.hourlyAvg;
+            const events = this.state.hourlyAvg;
             events.push(event);
             this.setState({hourlyAvg: events});
         });
@@ -116,9 +127,15 @@ export default React.createClass({
         const eventSeries =
             new TimeSeries({name: "raw", events: this.state.events.toArray()});
         const fiveMinuteSeries =
-            new TimeSeries({name: "five minute avg", events: this.state.fiveMinuteAvg.toArray()});
+            new TimeSeries({
+                name: "five minute avg",
+                events: this.state.fiveMinuteAvg.toArray()
+            });
         const hourlySeries =
-            new TimeSeries({name: "hourly", events: this.state.hourlyAvg.toArray()});
+            new TimeSeries({
+                name: "hourly",
+                events: this.state.hourlyAvg.toArray()
+            });
 
         // Timerange for the chart axis
         const initialBeginTime = new Date(2015, 0, 1);
@@ -136,9 +153,20 @@ export default React.createClass({
         // Charts (after a certain amount of time, just show hourly rollup)
         const charts = (
             <Charts>
-                <BarChart axis="y" series={fiveMinuteSeries} style={fiveMinuteStyle} columns={["value"]} />
-                <BarChart axis="y" series={hourlySeries} style={hourlyStyle} columns={["value"]} />
-                <ScatterChart axis="y" series={eventSeries} style={scatterStyle} />
+                <BarChart
+                    axis="y"
+                    series={fiveMinuteSeries}
+                    style={fiveMinuteStyle}
+                    columns={["value"]} />
+                <BarChart
+                    axis="y"
+                    series={hourlySeries}
+                    style={hourlyStyle}
+                    columns={["value"]} />
+                <ScatterChart
+                    axis="y"
+                    series={eventSeries}
+                    style={scatterStyle} />
             </Charts>
         );
 
@@ -154,7 +182,11 @@ export default React.createClass({
                         <Resizable>
                             <ChartContainer timeRange={timeRange}>
                                 <ChartRow height="150">
-                                    <YAxis id="y" label="Value" min={0} max={1500} width="70" type="linear"/>
+                                    <YAxis
+                                        id="y"
+                                        label="Value"
+                                        min={0} max={1500}
+                                        width="70" type="linear"/>
                                     {charts}
                                 </ChartRow>
                             </ChartContainer>

--- a/website/modules/start.jsx
+++ b/website/modules/start.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/start.md");
+import text from "raw!../../docs/start.md";
 
 export default React.createClass({
 

--- a/website/modules/time.jsx
+++ b/website/modules/time.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/time.md");
+import text from "raw!../../docs/time.md";
 
 export default React.createClass({
 

--- a/website/modules/timerange.jsx
+++ b/website/modules/timerange.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/timerange.md");
+import text from "raw!../../docs/timerange.md";
 
 export default React.createClass({
 

--- a/website/modules/timeseries.jsx
+++ b/website/modules/timeseries.jsx
@@ -1,8 +1,18 @@
-import React from "react/addons";
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
-var text = require("raw!../../docs/timeseries.md");
+import text from "raw!../../docs/timeseries.md";
 
 export default React.createClass({
 


### PR DESCRIPTION
Merging for Timeseries and Events.
Added docs and tests.

There's linting fixes in here too, but the main files are events.js and series.js, along with event.test.js and series.test.js. Docs updated in timeseries.md and events.md.

You can either merge two series with different columns together, or same columns and different times.

Example of merging two columns together:

```javascript
const inTraffic = new TimeSeries({
    name: "in",
    columns: ["time", "in"],
    points: [
        [1400425947000, 52],
        [1400425948000, 18],
        [1400425949000, 26],
        [1400425950000, 93],
    ]
});

const outTraffic = new TimeSeries({
    name: "out",
    columns: ["time", "out"],
    points: [
        [1400425947000, 34],
        [1400425948000, 13],
        [1400425949000, 67],
        [1400425950000, 91],
    ]
});
```

We can them merge them:

```javascript
var trafficSeries = TimeSeries.merge("traffic", [inTraffic, outTraffic]);
```

The result will look like this:

```json
{
    "name":"traffic",
    "columns":["time", "in", "out"],
    "points":[
        ["2014-05-18T15:12:27.000Z", 52, 34],
        ["2014-05-18T15:12:28.000Z", 18, 13],
        ["2014-05-18T15:12:29.000Z", 26, 67],
        ["2014-05-18T15:12:30.000Z", 93, 91]
    ]
}
```
Fixes #2.