### PR TITLE
Fix series compare static functions

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -27,37 +27,41 @@ in Pipeline event processing.
 
 * [Collection](#Collection)
     * [new Collection(arg1, [copyEvents])](#new_Collection_new)
-    * [.toJSON()](#Collection+toJSON) ⇒ <code>Object</code>
-    * [.toString()](#Collection+toString) ⇒ <code>string</code>
-    * [.type()](#Collection+type) ⇒ <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code>
-    * [.size()](#Collection+size) ⇒ <code>number</code>
-    * [.sizeValid()](#Collection+sizeValid) ⇒ <code>number</code>
-    * [.at(pos)](#Collection+at) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atTime(time)](#Collection+atTime) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atFirst()](#Collection+atFirst) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atLast()](#Collection+atLast) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.bisect(t, b)](#Collection+bisect) ⇒ <code>number</code>
-    * [.events()](#Collection+events)
-    * [.eventList()](#Collection+eventList) ⇒ <code>Immutable.List</code>
-    * [.eventListAsArray()](#Collection+eventListAsArray) ⇒ <code>Array</code>
-    * [.range()](#Collection+range) ⇒ <code>TimeRange</code>
-    * [.addEvent(event)](#Collection+addEvent) ⇒ <code>[Collection](#Collection)</code>
-    * [.slice(begin, end)](#Collection+slice) ⇒ <code>[Collection](#Collection)</code>
-    * [.filter(func)](#Collection+filter) ⇒ <code>[Collection](#Collection)</code>
-    * [.map(func)](#Collection+map) ⇒ <code>[Collection](#Collection)</code>
-    * [.clean(fieldSpec)](#Collection+clean) ⇒ <code>[Collection](#Collection)</code>
-    * [.collapse(fieldSpecList, name, reducer, append)](#Collection+collapse) ⇒ <code>[Collection](#Collection)</code>
-    * [.count()](#Collection+count) ⇒ <code>number</code>
-    * [.first()](#Collection+first)
-    * [.last()](#Collection+last)
-    * [.sum()](#Collection+sum)
-    * [.avg(fieldSpec)](#Collection+avg) ⇒ <code>number</code>
-    * [.max(fieldSpec)](#Collection+max) ⇒ <code>number</code>
-    * [.min(fieldSpec)](#Collection+min) ⇒ <code>number</code>
-    * [.mean(fieldSpec)](#Collection+mean) ⇒ <code>number</code>
-    * [.median(fieldSpec)](#Collection+median) ⇒ <code>number</code>
-    * [.stdev(fieldSpec)](#Collection+stdev) ⇒ <code>number</code>
-    * [.aggregate(func, fieldSpec)](#Collection+aggregate) ⇒ <code>number</code>
+    * _instance_
+        * [.toJSON()](#Collection+toJSON) ⇒ <code>Object</code>
+        * [.toString()](#Collection+toString) ⇒ <code>string</code>
+        * [.type()](#Collection+type) ⇒ <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code>
+        * [.size()](#Collection+size) ⇒ <code>number</code>
+        * [.sizeValid()](#Collection+sizeValid) ⇒ <code>number</code>
+        * [.at(pos)](#Collection+at) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atTime(time)](#Collection+atTime) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atFirst()](#Collection+atFirst) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atLast()](#Collection+atLast) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.bisect(t, b)](#Collection+bisect) ⇒ <code>number</code>
+        * [.events()](#Collection+events)
+        * [.eventList()](#Collection+eventList) ⇒ <code>Immutable.List</code>
+        * [.eventListAsArray()](#Collection+eventListAsArray) ⇒ <code>Array</code>
+        * [.range()](#Collection+range) ⇒ <code>TimeRange</code>
+        * [.addEvent(event)](#Collection+addEvent) ⇒ <code>[Collection](#Collection)</code>
+        * [.slice(begin, end)](#Collection+slice) ⇒ <code>[Collection](#Collection)</code>
+        * [.filter(func)](#Collection+filter) ⇒ <code>[Collection](#Collection)</code>
+        * [.map(func)](#Collection+map) ⇒ <code>[Collection](#Collection)</code>
+        * [.clean(fieldSpec)](#Collection+clean) ⇒ <code>[Collection](#Collection)</code>
+        * [.collapse(fieldSpecList, name, reducer, append)](#Collection+collapse) ⇒ <code>[Collection](#Collection)</code>
+        * [.count()](#Collection+count) ⇒ <code>number</code>
+        * [.first()](#Collection+first)
+        * [.last()](#Collection+last)
+        * [.sum()](#Collection+sum)
+        * [.avg(fieldSpec)](#Collection+avg) ⇒ <code>number</code>
+        * [.max(fieldSpec)](#Collection+max) ⇒ <code>number</code>
+        * [.min(fieldSpec)](#Collection+min) ⇒ <code>number</code>
+        * [.mean(fieldSpec)](#Collection+mean) ⇒ <code>number</code>
+        * [.median(fieldSpec)](#Collection+median) ⇒ <code>number</code>
+        * [.stdev(fieldSpec)](#Collection+stdev) ⇒ <code>number</code>
+        * [.aggregate(func, fieldSpec)](#Collection+aggregate) ⇒ <code>number</code>
+    * _static_
+        * [.equal(collection1, collection2)](#Collection.equal) ⇒ <code>bool</code>
+        * [.is(collection1, collection2)](#Collection.is) ⇒ <code>bool</code>
 
 <a name="new_Collection_new"></a>
 
@@ -389,4 +393,30 @@ do the reduction.
 - func <code>function</code> - User defined reduction function. Will be
 passed a list of values. Should return a singe value.
 - fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+
+<a name="Collection.equal"></a>
+
+### Collection.equal(collection1, collection2) ⇒ <code>bool</code>
+Static function to compare two collections to each other. If the collections
+are of the same instance as each other then equals will return true.
+
+**Kind**: static method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- collection1 <code>[Collection](#Collection)</code>
+- collection2 <code>[Collection](#Collection)</code>
+
+<a name="Collection.is"></a>
+
+### Collection.is(collection1, collection2) ⇒ <code>bool</code>
+Static function to compare two collections to each other. If the collections
+are of the same value as each other then equals will return true.
+
+**Kind**: static method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- collection1 <code>[Collection](#Collection)</code>
+- collection2 <code>[Collection](#Collection)</code>
 

--- a/docs/series.md
+++ b/docs/series.md
@@ -118,7 +118,8 @@ series.avg("NASA_north", d => d.in);  // 250
         * [.sizeValid()](#TimeSeries+sizeValid)
         * [.count()](#TimeSeries+count) ⇒ <code>number</code>
     * _static_
-        * [.equal()](#TimeSeries.equal)
+        * [.equal(series1, series2)](#TimeSeries.equal) ⇒ <code>bool</code>
+        * [.is(series1, series2)](#TimeSeries.is) ⇒ <code>bool</code>
         * [.sum(data, seriesList, fieldSpec)](#TimeSeries.sum) ⇒ <code>[TimeSeries](#TimeSeries)</code>
 
 <a name="TimeSeries+toJSON"></a>
@@ -258,10 +259,30 @@ Returns the number of rows in the series. (Same as size())
 **Returns**: <code>number</code> - Size of the series  
 <a name="TimeSeries.equal"></a>
 
-### TimeSeries.equal()
-STATIC
+### TimeSeries.equal(series1, series2) ⇒ <code>bool</code>
+Static function to compare two TimeSeries to each other. If the TimeSeries
+are of the same instance as each other then equals will return true.
 
 **Kind**: static method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- series1 <code>[TimeSeries](#TimeSeries)</code>
+- series2 <code>[TimeSeries](#TimeSeries)</code>
+
+<a name="TimeSeries.is"></a>
+
+### TimeSeries.is(series1, series2) ⇒ <code>bool</code>
+Static function to compare two TimeSeries to each other. If the TimeSeries
+are of the same value as each other then equals will return true.
+
+**Kind**: static method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- series1 <code>[TimeSeries](#TimeSeries)</code>
+- series2 <code>[TimeSeries](#TimeSeries)</code>
+
 <a name="TimeSeries.sum"></a>
 
 ### TimeSeries.sum(data, seriesList, fieldSpec) ⇒ <code>[TimeSeries](#TimeSeries)</code>

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -828,6 +828,21 @@ var Collection = function (_BoundedIn) {
                 return fieldSpec.split(".");
             }
         }
+
+        /**
+         * STATIC
+         */
+
+    }], [{
+        key: "equal",
+        value: function equal(collection1, collection2) {
+            return collection1._type === collection2._type && collection1._eventList === collection2._eventList;
+        }
+    }, {
+        key: "is",
+        value: function is(collection1, collection2) {
+            return collection1._type === collection2._type && _immutable2.default.is(collection1._eventList, collection2._eventList);
+        }
     }]);
     return Collection;
 }(_pipelineInBounded2.default);

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -833,11 +833,28 @@ var Collection = function (_BoundedIn) {
          * STATIC
          */
 
+        /**
+         * Static function to compare two collections to each other. If the collections
+         * are of the same instance as each other then equals will return true.
+         * @param  {Collection} collection1
+         * @param  {Collection} collection2
+         * @return {bool} result
+         */
+
     }], [{
         key: "equal",
         value: function equal(collection1, collection2) {
             return collection1._type === collection2._type && collection1._eventList === collection2._eventList;
         }
+
+        /**
+         * Static function to compare two collections to each other. If the collections
+         * are of the same value as each other then equals will return true.
+         * @param  {Collection} collection1
+         * @param  {Collection} collection2
+         * @return {bool} result
+         */
+
     }, {
         key: "is",
         value: function is(collection1, collection2) {

--- a/lib/series.js
+++ b/lib/series.js
@@ -708,11 +708,28 @@ var TimeSeries = function () {
          * STATIC
          */
 
+        /**
+         * Static function to compare two TimeSeries to each other. If the TimeSeries
+         * are of the same instance as each other then equals will return true.
+         * @param  {TimeSeries} series1
+         * @param  {TimeSeries} series2
+         * @return {bool} result
+         */
+
     }], [{
         key: "equal",
         value: function equal(series1, series2) {
             return series1._data === series2._data && series1._collection === series2._collection;
         }
+
+        /**
+         * Static function to compare two TimeSeries to each other. If the TimeSeries
+         * are of the same value as each other then equals will return true.
+         * @param  {TimeSeries} series1
+         * @param  {TimeSeries} series2
+         * @return {bool} result
+         */
+
     }, {
         key: "is",
         value: function is(series1, series2) {

--- a/lib/series.js
+++ b/lib/series.js
@@ -711,12 +711,12 @@ var TimeSeries = function () {
     }], [{
         key: "equal",
         value: function equal(series1, series2) {
-            return series1._name === series2._name && series1._meta === series2._meta && series1._utc === series2._utc && series1._columns === series2._columns && series1._data === series2._data && series1._times === series2._times;
+            return series1._data === series2._data && series1._collection === series2._collection;
         }
     }, {
         key: "is",
         value: function is(series1, series2) {
-            return series1._name === series2._name && series1._utc === series2._utc && _immutable2.default.is(series1._meta, series2._meta) && _immutable2.default.is(series1._columns, series2._columns) && _immutable2.default.is(series1._data, series2._data) && _immutable2.default.is(series1._times, series2._times);
+            return _immutable2.default.is(series1._data, series2._data) && _collection2.default.is(series1._collection, series2._collection);
         }
     }, {
         key: "map",

--- a/src/collection.js
+++ b/src/collection.js
@@ -484,11 +484,25 @@ class Collection extends BoundedIn {
      * STATIC
      */
 
+     /**
+      * Static function to compare two collections to each other. If the collections
+      * are of the same instance as each other then equals will return true.
+      * @param  {Collection} collection1
+      * @param  {Collection} collection2
+      * @return {bool} result
+      */
     static equal(collection1, collection2) {
         return (collection1._type === collection2._type &&
                 collection1._eventList === collection2._eventList);
     }
 
+     /**
+      * Static function to compare two collections to each other. If the collections
+      * are of the same value as each other then equals will return true.
+      * @param  {Collection} collection1
+      * @param  {Collection} collection2
+      * @return {bool} result
+      */
     static is(collection1, collection2) {
         return (collection1._type === collection2._type &&
                 Immutable.is(collection1._eventList, collection2._eventList));
@@ -496,4 +510,3 @@ class Collection extends BoundedIn {
 }
 
 export default Collection;
-

--- a/src/collection.js
+++ b/src/collection.js
@@ -479,6 +479,20 @@ class Collection extends BoundedIn {
             return fieldSpec.split(".");
         }
     }
+
+    /**
+     * STATIC
+     */
+
+    static equal(collection1, collection2) {
+        return (collection1._type === collection2._type &&
+                collection1._eventList === collection2._eventList);
+    }
+
+    static is(collection1, collection2) {
+        return (collection1._type === collection2._type &&
+                Immutable.is(collection1._eventList, collection2._eventList));
+    }
 }
 
 export default Collection;

--- a/src/series.js
+++ b/src/series.js
@@ -482,11 +482,25 @@ class TimeSeries {
      * STATIC
      */
 
+     /**
+      * Static function to compare two TimeSeries to each other. If the TimeSeries
+      * are of the same instance as each other then equals will return true.
+      * @param  {TimeSeries} series1
+      * @param  {TimeSeries} series2
+      * @return {bool} result
+      */
     static equal(series1, series2) {
         return (series1._data === series2._data &&
                 series1._collection === series2._collection);
     }
 
+     /**
+      * Static function to compare two TimeSeries to each other. If the TimeSeries
+      * are of the same value as each other then equals will return true.
+      * @param  {TimeSeries} series1
+      * @param  {TimeSeries} series2
+      * @return {bool} result
+      */
     static is(series1, series2) {
         return (Immutable.is(series1._data, series2._data) &&
                 Collection.is(series1._collection, series2._collection));

--- a/src/series.js
+++ b/src/series.js
@@ -483,21 +483,13 @@ class TimeSeries {
      */
 
     static equal(series1, series2) {
-        return (series1._name === series2._name &&
-                series1._meta === series2._meta &&
-                series1._utc === series2._utc &&
-                series1._columns === series2._columns &&
-                series1._data === series2._data &&
-                series1._times === series2._times);
+        return (series1._data === series2._data &&
+                series1._collection === series2._collection);
     }
 
     static is(series1, series2) {
-        return (series1._name === series2._name &&
-                series1._utc === series2._utc &&
-                Immutable.is(series1._meta, series2._meta) &&
-                Immutable.is(series1._columns, series2._columns) &&
-                Immutable.is(series1._data, series2._data) &&
-                Immutable.is(series1._times, series2._times));
+        return (Immutable.is(series1._data, series2._data) &&
+                Collection.is(series1._collection, series2._collection));
     }
 
     static map(data, seriesList, mapper, fieldSpec) {

--- a/test/index.js
+++ b/test/index.js
@@ -20,5 +20,6 @@ if (typeof window !== "undefined") {
 require("./tests/index.test.js");
 require("./tests/range.test.js");
 require("./tests/event.test.js");
+require("./tests/collection.test.js");
 require("./tests/pipeline.test.js");
 require("./tests/series.test.js");

--- a/test/tests/collection.test.js
+++ b/test/tests/collection.test.js
@@ -1,0 +1,107 @@
+/**
+ *  Copyright (c) 2015, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+/* global it, describe */
+/* eslint no-unused-expressions: 0 */
+/* eslint-disable max-len */
+/* eslint no-unused-vars: 0 */
+
+import { expect } from "chai";
+
+import Collection from "../../src/collection.js";
+import Event from "../../src/event";
+
+const eventList1 = [
+    new Event(new Date("2015-04-22T03:30:00Z"), {in: 1, out: 2}),
+    new Event(new Date("2015-04-22T03:31:00Z"), {in: 3, out: 4}),
+    new Event(new Date("2015-04-22T03:32:00Z"), {in: 5, out: 6})
+];
+
+const inOutData = {
+    name: "traffic",
+    columns: ["time", "in", "out", "perpendicular"],
+    points: [
+        [1409529600000, 80, 37, 1000],
+        [1409533200000, 88, 22, 1001],
+        [1409536800000, 52, 56, 1002]
+    ]
+};
+
+/**
+ * Note the Collections are currently moslty tested through either
+ * the pipeline code or the TimeSeries code.
+ */
+describe("Collections", () => {
+
+    it("can create a Collection from an event list", done => {
+        const collection = new Collection(eventList1);
+        expect(collection).to.be.ok;
+        done();
+    });
+
+    it("can compare a collection and a reference to a collection as being equal", done => {
+        const collection = new Collection(eventList1);
+        const refCollection = collection;
+        expect(collection).to.equal(refCollection);
+        done();
+    });
+
+    it("can use the equals() comparator to compare a series and a copy of the series as true", done => {
+        const collection = new Collection(eventList1);
+        const copy = new Collection(collection);
+        expect(Collection.equal(collection, copy)).to.be.true;
+        done();
+    });
+
+    it("can use the equals() comparator to compare a collection and a value equivalent collection as false", done => {
+        const collection = new Collection(eventList1);
+        const otherSeries = new Collection(eventList1);
+        expect(Collection.equal(collection, otherSeries)).to.be.false;
+        done();
+    });
+
+    it("can use the is() comparator to compare a collection and a value equivalent collection as true", done => {
+        const collection = new Collection(eventList1);
+        const otherSeries = new Collection(eventList1);
+        expect(Collection.is(collection, otherSeries)).to.be.true;
+        done();
+    });
+
+    it("can use size() and at() to get to Collection items", done => {
+        const collection = new Collection(eventList1);
+        expect(collection.size()).to.equal(3);
+        expect(Event.is(collection.at(0), eventList1[0])).to.be.true;
+        expect(Event.is(collection.at(1), eventList1[1])).to.be.true;
+        expect(Event.is(collection.at(2), eventList1[2])).to.be.true;
+        done();
+    });
+
+    it("can loop (for .. of) over a Collection's events", done => {
+        const collection = new Collection(eventList1);
+        const events = [];
+        for (const e of collection.events()) {
+            events.push(e);
+        }
+        expect(events.length).to.equal(3);
+        expect(Event.is(events[0], eventList1[0])).to.be.true;
+        expect(Event.is(events[1], eventList1[1])).to.be.true;
+        expect(Event.is(events[2], eventList1[2])).to.be.true;
+        done();
+    });
+
+    it("can add an event and get a new Collection back", done => {
+        const collection = new Collection(eventList1);
+        const event = new Event(new Date("2015-04-22T03:32:00Z"), {in: 1, out: 2});
+        const newCollection = collection.addEvent(event);
+        expect(newCollection.size()).to.equal(4);
+        done();
+    });
+
+});

--- a/test/tests/pipeline.test.js
+++ b/test/tests/pipeline.test.js
@@ -178,47 +178,6 @@ const inOutData = {
 
 describe("Pipeline", () => {
 
-
-    describe("Collections", () => {
-
-        it("can create a Collection from an event list", done => {
-            const collection = new Collection(eventList1);
-            expect(collection).to.be.ok;
-            done();
-        });
-
-        it("can use size() and at() to get to Collection items", done => {
-            const collection = new Collection(eventList1);
-            expect(collection.size()).to.equal(3);
-            expect(Event.is(collection.at(0), eventList1[0])).to.be.true;
-            expect(Event.is(collection.at(1), eventList1[1])).to.be.true;
-            expect(Event.is(collection.at(2), eventList1[2])).to.be.true;
-            done();
-        });
-
-        it("can loop (for .. of) over a Collection's events", done => {
-            const collection = new Collection(eventList1);
-            const events = [];
-            for (const e of collection.events()) {
-                events.push(e);
-            }
-            expect(events.length).to.equal(3);
-            expect(Event.is(events[0], eventList1[0])).to.be.true;
-            expect(Event.is(events[1], eventList1[1])).to.be.true;
-            expect(Event.is(events[2], eventList1[2])).to.be.true;
-            done();
-        });
-
-        it("can add an event and get a new Collection back", done => {
-            const collection = new Collection(eventList1);
-            const event = new Event(new Date("2015-04-22T03:32:00Z"), {in: 1, out: 2});
-            const newCollection = collection.addEvent(event);
-            expect(newCollection.size()).to.equal(4);
-            done();
-        });
-
-    });
-
     describe("test processor using offsetBy", () => {
 
         it("can transform process events with an offsetBy chain", done => {

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -463,6 +463,7 @@ describe("TimeSeries", () => {
             expect(TimeSeries.is(series, otherSeries)).to.be.true;
             done();
         });
+
     });
 
     describe("TimeSeries reducing functions", () => {


### PR DESCRIPTION
Series:
 - fix TimeSeries.is() and TimeSeries.equals() to correctly compare updated API

Collection:
 - add Collection.is() and Collection.equals() to compare collections to each other