### PR TITLE
Use the pipelines for TimeSeries collapse()

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -46,7 +46,6 @@ in Pipeline event processing.
     * [.filter(func)](#Collection+filter) ⇒ <code>[Collection](#Collection)</code>
     * [.map(func)](#Collection+map) ⇒ <code>[Collection](#Collection)</code>
     * [.clean(fieldSpec)](#Collection+clean) ⇒ <code>[Collection](#Collection)</code>
-    * [.collapse(fieldSpecList, name, reducer, append)](#Collection+collapse) ⇒ <code>[Collection](#Collection)</code>
     * [.count()](#Collection+count) ⇒ <code>number</code>
     * [.first()](#Collection+first)
     * [.last()](#Collection+last)
@@ -268,22 +267,6 @@ The resulting Collection will be clean (for that fieldSpec).
 **Params**
 
 - fieldSpec <code>string</code> <code> = &quot;value&quot;</code> - The field to test
-
-<a name="Collection+collapse"></a>
-
-### collection.collapse(fieldSpecList, name, reducer, append) ⇒ <code>[Collection](#Collection)</code>
-Takes a fieldSpecList (list of column names) and collapses
-them to a new column which is the reduction of the matched columns
-in the fieldSpecList.
-
-**Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>[Collection](#Collection)</code> - A new, modified, Collection  
-**Params**
-
-- fieldSpecList <code>array</code> - The list of columns
-- name <code>string</code> - The resulting summed column name
-- reducer <code>function</code> - Reducer function e.g. sum
-- append <code>boolean</code> <code> = true</code> - Append the summed column, rather than replace
 
 <a name="Collection+count"></a>
 

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -16,10 +16,11 @@ can iterate over the collection with a for..of loop, get the size()
 of the collection and access a specific element with at().
 
 You can also perform aggregations of the events, map them, filter them
-and clean them.
+clean them, etc.
 
 Collections form the backing structure for a TimeSeries, as well as
-in Pipeline event processing.
+in Pipeline event processing. They are an instance of a BoundedIn, so
+they can be used as a pipeline source.
 
 **Kind**: global class  
 ## API Reference
@@ -27,36 +28,40 @@ in Pipeline event processing.
 
 * [Collection](#Collection)
     * [new Collection(arg1, [copyEvents])](#new_Collection_new)
-    * [.toJSON()](#Collection+toJSON) ⇒ <code>Object</code>
-    * [.toString()](#Collection+toString) ⇒ <code>string</code>
-    * [.type()](#Collection+type) ⇒ <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code>
-    * [.size()](#Collection+size) ⇒ <code>number</code>
-    * [.sizeValid()](#Collection+sizeValid) ⇒ <code>number</code>
-    * [.at(pos)](#Collection+at) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atTime(time)](#Collection+atTime) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atFirst()](#Collection+atFirst) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.atLast()](#Collection+atLast) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-    * [.bisect(t, b)](#Collection+bisect) ⇒ <code>number</code>
-    * [.events()](#Collection+events)
-    * [.eventList()](#Collection+eventList) ⇒ <code>Immutable.List</code>
-    * [.eventListAsArray()](#Collection+eventListAsArray) ⇒ <code>Array</code>
-    * [.range()](#Collection+range) ⇒ <code>TimeRange</code>
-    * [.addEvent(event)](#Collection+addEvent) ⇒ <code>[Collection](#Collection)</code>
-    * [.slice(begin, end)](#Collection+slice) ⇒ <code>[Collection](#Collection)</code>
-    * [.filter(func)](#Collection+filter) ⇒ <code>[Collection](#Collection)</code>
-    * [.map(func)](#Collection+map) ⇒ <code>[Collection](#Collection)</code>
-    * [.clean(fieldSpec)](#Collection+clean) ⇒ <code>[Collection](#Collection)</code>
-    * [.count()](#Collection+count) ⇒ <code>number</code>
-    * [.first()](#Collection+first)
-    * [.last()](#Collection+last)
-    * [.sum()](#Collection+sum)
-    * [.avg(fieldSpec)](#Collection+avg) ⇒ <code>number</code>
-    * [.max(fieldSpec)](#Collection+max) ⇒ <code>number</code>
-    * [.min(fieldSpec)](#Collection+min) ⇒ <code>number</code>
-    * [.mean(fieldSpec)](#Collection+mean) ⇒ <code>number</code>
-    * [.median(fieldSpec)](#Collection+median) ⇒ <code>number</code>
-    * [.stdev(fieldSpec)](#Collection+stdev) ⇒ <code>number</code>
-    * [.aggregate(func, fieldSpec)](#Collection+aggregate) ⇒ <code>number</code>
+    * _instance_
+        * [.toJSON()](#Collection+toJSON) ⇒ <code>Object</code>
+        * [.toString()](#Collection+toString) ⇒ <code>string</code>
+        * [.type()](#Collection+type) ⇒ <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code>
+        * [.size()](#Collection+size) ⇒ <code>number</code>
+        * [.sizeValid()](#Collection+sizeValid) ⇒ <code>number</code>
+        * [.at(pos)](#Collection+at) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atTime(time)](#Collection+atTime) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atFirst()](#Collection+atFirst) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.atLast()](#Collection+atLast) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
+        * [.bisect(t, b)](#Collection+bisect) ⇒ <code>number</code>
+        * [.events()](#Collection+events)
+        * [.eventList()](#Collection+eventList) ⇒ <code>Immutable.List</code>
+        * [.eventListAsArray()](#Collection+eventListAsArray) ⇒ <code>Array</code>
+        * [.range()](#Collection+range) ⇒ <code>TimeRange</code>
+        * [.addEvent(event)](#Collection+addEvent) ⇒ <code>[Collection](#Collection)</code>
+        * [.slice(begin, end)](#Collection+slice) ⇒ <code>[Collection](#Collection)</code>
+        * [.filter(func)](#Collection+filter) ⇒ <code>[Collection](#Collection)</code>
+        * [.map(func)](#Collection+map) ⇒ <code>[Collection](#Collection)</code>
+        * [.clean(fieldSpec)](#Collection+clean) ⇒ <code>[Collection](#Collection)</code>
+        * [.count()](#Collection+count) ⇒ <code>number</code>
+        * [.first(fieldSpec)](#Collection+first) ⇒ <code>number</code>
+        * [.last(fieldSpec)](#Collection+last) ⇒ <code>number</code>
+        * [.sum(fieldSpec)](#Collection+sum) ⇒ <code>number</code>
+        * [.avg(fieldSpec)](#Collection+avg) ⇒ <code>number</code>
+        * [.max(fieldSpec)](#Collection+max) ⇒ <code>number</code>
+        * [.min(fieldSpec)](#Collection+min) ⇒ <code>number</code>
+        * [.mean(fieldSpec)](#Collection+mean) ⇒ <code>number</code>
+        * [.median(fieldSpec)](#Collection+median) ⇒ <code>number</code>
+        * [.stdev(fieldSpec)](#Collection+stdev) ⇒ <code>number</code>
+        * [.aggregate(func, fieldSpec)](#Collection+aggregate) ⇒ <code>number</code>
+    * _static_
+        * [.equal(collection1, collection2)](#Collection.equal) ⇒ <code>bool</code>
+        * [.is(collection1, collection2)](#Collection.is) ⇒ <code>bool</code>
 
 <a name="new_Collection_new"></a>
 
@@ -90,14 +95,16 @@ string representation of `toJSON()`.
 <a name="Collection+type"></a>
 
 ### collection.type() ⇒ <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code>
-Returns the Event object type in this collection. Since
-Collections my only have one type of Event (Event, IndexedEvent
-or TimeRangeEvent) this will return that type. If no events
-have been added to the Collection it will return undefined.
+Returns the Event object type in this Collection.
+
+Since Collections may only have one type of event (`Event`, `IndexedEvent`
+or `TimeRangeEvent`) this will return that type. If no events
+have been added to the Collection it will return `undefined`.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Returns**: <code>Event</code> &#124; <code>IndexedEvent</code> &#124; <code>TimeRangeEvent</code> - - The class of the type
-of events contained in this Collection.  
+                                              of events contained in
+                                              this Collection.  
 <a name="Collection+size"></a>
 
 ### collection.size() ⇒ <code>number</code>
@@ -111,8 +118,8 @@ Returns the number of events in this collection
 Returns the number of valid items in this collection.
 
 Uses the fieldSpec to look up values in all events.
-It then counts the number that are considered valid,
-i.e. are not NaN, undefined or null.
+It then counts the number that are considered valid, which
+specifically are not NaN, undefined or null.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Returns**: <code>number</code> - Count of valid events  
@@ -138,7 +145,8 @@ for (let row=0; row < series.size(); row++) {
 <a name="Collection+atTime"></a>
 
 ### collection.atTime(time) ⇒ <code>Event</code> &#124; <code>TimeRangeEvent</code> &#124; <code>IndexedEvent</code>
-Returns an event in the Collection by its time.
+Returns an event in the Collection by its time. This is the same
+as calling `bisect` first and then using `at` with the index.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Params**
@@ -160,8 +168,7 @@ Returns the last event in the Collection.
 <a name="Collection+bisect"></a>
 
 ### collection.bisect(t, b) ⇒ <code>number</code>
-Returns the index that bisects the Collection at
-the time specified
+Returns the index that bisects the Collection at the time specified.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Returns**: <code>number</code> - The row number that is the greatest, but still below t.  
@@ -192,7 +199,7 @@ Returns the raw Immutable event list
 <a name="Collection+eventListAsArray"></a>
 
 ### collection.eventListAsArray() ⇒ <code>Array</code>
-Returns a Javascript array of events
+Returns a Javascript array representation of the event list
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Returns**: <code>Array</code> - All events as a Javascript Array.  
@@ -200,17 +207,20 @@ Returns a Javascript array of events
 
 ### collection.range() ⇒ <code>TimeRange</code>
 From the range of times, or Indexes within the TimeSeries, return
-the extents of the TimeSeries as a TimeRange.
+the extents of the TimeSeries as a TimeRange. This is currently implemented
+by walking the events.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
 **Returns**: <code>TimeRange</code> - The extents of the TimeSeries  
 <a name="Collection+addEvent"></a>
 
 ### collection.addEvent(event) ⇒ <code>[Collection](#Collection)</code>
-Adds an event to the collection, returns a new Collection
+Adds an event to the collection, returns a new Collection. The event added
+can be an Event, TimeRangeEvent or IndexedEvent, but it must be of the
+same type as other events within the Collection.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>[Collection](#Collection)</code> - A new, modified, Collection.  
+**Returns**: <code>[Collection](#Collection)</code> - A new, modified, Collection containing the new event.  
 **Params**
 
 - event <code>Event</code> | <code>TimeRangeEvent</code> | <code>IndexedEvent</code> - The event being added.
@@ -223,7 +233,7 @@ Collection representing a portion of this TimeSeries from begin up to
 but not including end.
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>[Collection](#Collection)</code> - A new, modified, Collection.  
+**Returns**: <code>[Collection](#Collection)</code> - The new, sliced, Collection.  
 **Params**
 
 - begin <code>Number</code> - The position to begin slicing
@@ -235,11 +245,11 @@ but not including end.
 Filter the collection's event list with the supplied function
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>[Collection](#Collection)</code> - A new, modified, Collection.  
+**Returns**: <code>[Collection](#Collection)</code> - A new, filtered, Collection.  
 **Params**
 
 - func <code>function</code> - The filter function, that should return
-true or false when passed in an event.
+                       true or false when passed in an event.
 
 <a name="Collection+map"></a>
 
@@ -277,32 +287,47 @@ Returns the number of events in this collection
 **Returns**: <code>number</code> - The number of events  
 <a name="Collection+first"></a>
 
-### collection.first()
+### collection.first(fieldSpec) ⇒ <code>number</code>
 Returns the first value in the Collection for the fieldspec
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>number</code> - The first value  
+**Params**
+
+- fieldSpec <code>string</code> <code> = &quot;value&quot;</code> - The field to fetch
+
 <a name="Collection+last"></a>
 
-### collection.last()
+### collection.last(fieldSpec) ⇒ <code>number</code>
 Returns the last value in the Collection for the fieldspec
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>number</code> - The last value  
+**Params**
+
+- fieldSpec <code>string</code> <code> = &quot;value&quot;</code> - The field to fetch
+
 <a name="Collection+sum"></a>
 
-### collection.sum()
+### collection.sum(fieldSpec) ⇒ <code>number</code>
 Returns the sum Collection for the fieldspec
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>number</code> - The sum  
+**Params**
+
+- fieldSpec <code>string</code> <code> = &quot;value&quot;</code> - The field to sum over the collection
+
 <a name="Collection+avg"></a>
 
 ### collection.avg(fieldSpec) ⇒ <code>number</code>
 Aggregates the events down to their average
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The average  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to average over the collection
 
 <a name="Collection+max"></a>
 
@@ -310,10 +335,10 @@ Aggregates the events down to their average
 Aggregates the events down to their maximum value
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The max value for the field  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to find the max within the collection
 
 <a name="Collection+min"></a>
 
@@ -321,21 +346,21 @@ Aggregates the events down to their maximum value
 Aggregates the events down to their minimum value
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The min value for the field  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to find the min within the collection
 
 <a name="Collection+mean"></a>
 
 ### collection.mean(fieldSpec) ⇒ <code>number</code>
-Aggregates the events down to their mean
+Aggregates the events down to their mean (same as avg)
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The mean  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to find the mean of within the collection
 
 <a name="Collection+median"></a>
 
@@ -343,10 +368,10 @@ Aggregates the events down to their mean
 Aggregates the events down to their medium value
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The resulting median value  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate over
 
 <a name="Collection+stdev"></a>
 
@@ -354,10 +379,10 @@ Aggregates the events down to their medium value
 Aggregates the events down to their stdev
 
 **Kind**: instance method of <code>[Collection](#Collection)</code>  
-**Returns**: <code>number</code> - The resulting value  
+**Returns**: <code>number</code> - The resulting stdev value  
 **Params**
 
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate over
 
 <a name="Collection+aggregate"></a>
 
@@ -370,6 +395,33 @@ do the reduction.
 **Params**
 
 - func <code>function</code> - User defined reduction function. Will be
-passed a list of values. Should return a singe value.
-- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate
+                           passed a list of values. Should return a
+                           singe value.
+- fieldSpec <code>String</code> <code> = value</code> - The field to aggregate over
+
+<a name="Collection.equal"></a>
+
+### Collection.equal(collection1, collection2) ⇒ <code>bool</code>
+Static function to compare two collections to each other. If the collections
+are of the same instance as each other then equals will return true.
+
+**Kind**: static method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- collection1 <code>[Collection](#Collection)</code>
+- collection2 <code>[Collection](#Collection)</code>
+
+<a name="Collection.is"></a>
+
+### Collection.is(collection1, collection2) ⇒ <code>bool</code>
+Static function to compare two collections to each other. If the collections
+are of the same value as each other then equals will return true.
+
+**Kind**: static method of <code>[Collection](#Collection)</code>  
+**Returns**: <code>bool</code> - result  
+**Params**
+
+- collection1 <code>[Collection](#Collection)</code>
+- collection2 <code>[Collection](#Collection)</code>
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -172,7 +172,7 @@ of collection data.
     * [.map(op)](#Pipeline+map) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.filter(op)](#Pipeline+filter) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.select(fieldSpec)](#Pipeline+select) ⇒ <code>[Pipeline](#Pipeline)</code>
-    * [.collapse(fieldSpec, name, append)](#Pipeline+collapse) ⇒ <code>[Pipeline](#Pipeline)</code>
+    * [.collapse(fieldSpec, name, reducer, append)](#Pipeline+collapse) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.take(limit)](#Pipeline+take) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.asTimeRangeEvents(options)](#Pipeline+asTimeRangeEvents) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.asIndexedEvents(options)](#Pipeline+asIndexedEvents) ⇒ <code>[Pipeline](#Pipeline)</code>
@@ -205,8 +205,10 @@ Set the window, returning a new Pipeline. The argument here
 is an object with {type, duration}.
 type may be:
  * "Fixed"
+ * other types coming
+
 duration is of the form:
- * "30s", "5m" or "1d" etc
+ * "30s" or "1d" etc
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  
@@ -231,11 +233,20 @@ or a array of fieldSpecs
 <a name="Pipeline+emitOn"></a>
 
 ### pipeline.emitOn(trigger) ⇒ <code>[Pipeline](#Pipeline)</code>
-Sets the condition under which accumulated collection will
+Sets the condition under which an accumulated collection will
 be emitted. If specified before an aggregation this will control
 when the resulting event will be emitted relative to the
-window accumulation. Current options are to emit on every event
-or just when the collection is complete.
+window accumulation. Current options are:
+ * to emit on every event, or
+ * just when the collection is complete, or
+ * when a flush signal is received, either manually calling done(),
+   or at the end of a bounded source
+
+The difference will depend on the output you want, how often
+you want to get updated, and if you need to get a partial state.
+There's currently no support for late data or watermarks. If an
+event passes comes in after a collection window, that collection
+is considered finished.
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  
@@ -247,16 +258,18 @@ Collection should be emitted. May be:
                     maintained collections will emit their result
     * "discard"   - when a collection is to be discarded,
                     first it will emit. But only then.
+    * "flush"     - when a flush signal is received
 
 <a name="Pipeline+from"></a>
 
 ### pipeline.from(src) ⇒ <code>[Pipeline](#Pipeline)</code>
-The "In" to get events from. The In needs to be able to
-iterate its events using for..of loop for bounded Ins, or
-be able to emit for unbounded Ins. The actual batch, or stream
-connection occurs when an output is defined with to().
+The source to get events from. The source needs to be able to
+iterate its events using `for..of` loop for bounded Ins, or
+be able to emit() for unbounded Ins. The actual batch, or stream
+connection occurs when an output is defined with `to()`.
 
-from() returns a new Pipeline.
+Pipelines can be chained together since a source may be another
+Pipeline.
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  
@@ -269,13 +282,12 @@ from() returns a new Pipeline.
 <a name="Pipeline+to"></a>
 
 ### pipeline.to() ⇒ <code>[Pipeline](#Pipeline)</code>
-Sets up the destination sink for the pipeline. The output should
-be a BatchOut subclass for a bounded input and a StreamOut subclass
-for an unbounded input.
+Sets up the destination sink for the pipeline.
 
-For a batch mode connection, the output is connected and then the
-source input is iterated over to process all events into the pipeline and
-down to the out.
+For a batch mode connection, i.e. one with a Bounded source,
+the output is connected to a clone of the parts of the Pipeline dependencies
+that lead to this output. This is done by a Runner. The source input is
+then iterated over to process all events into the pipeline and though to the Out.
 
 For stream mode connections, the output is connected and from then on
 any events added to the input will be processed down the pipeline to
@@ -311,7 +323,7 @@ Outputs the count of events
 
 ### pipeline.offsetBy(by, fieldSpec) ⇒ <code>[Pipeline](#Pipeline)</code>
 Processor to offset a set of fields by a value. Mostly used for
-testing processor operations.
+testing processor and pipeline operations with a simple operation.
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The modified Pipeline  
@@ -325,6 +337,7 @@ testing processor operations.
 ### pipeline.aggregate(fields) ⇒ <code>[Pipeline](#Pipeline)</code>
 Uses the current Pipeline windowing and grouping
 state to build collections of events and aggregate them.
+
 `IndexedEvent`s will be emitted out of the aggregator based
 on the `emitOn` state of the Pipeline.
 
@@ -339,18 +352,18 @@ object. This is a map from fieldName to operator.
 - fields <code>object</code> - Fields and operators to be aggregated
 
 **Example**  
-```js
+```
 import { Pipeline, EventOut, functions } from "pondjs";
 const { avg } = functions;
 
 const p = Pipeline()
   .from(input)
   .windowBy("1h")           // 1 day fixed windows
-  .emitOn("eachEvent")    // emit result on each event
+  .emitOn("eachEvent")      // emit result on each event
   .aggregate({in: avg, out: avg})
   .asEvents()
   .to(EventOut, {}, event => {
-     result[`${event.index()}`] = event;
+     result[`${event.index()}`] = event; // Result
   });
 ```
 <a name="Pipeline+asEvents"></a>
@@ -406,17 +419,30 @@ Select a subset of columns
 
 <a name="Pipeline+collapse"></a>
 
-### pipeline.collapse(fieldSpec, name, append) ⇒ <code>[Pipeline](#Pipeline)</code>
-Select a subset of columns
+### pipeline.collapse(fieldSpec, name, reducer, append) ⇒ <code>[Pipeline](#Pipeline)</code>
+Collapse a subset of columns using a reducer function
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  
 **Params**
 
-- fieldSpec <code>array</code> | <code>String</code> - The columns to include in the output
-- name <code>string</code> - The result column name
+- fieldSpec <code>array</code> | <code>String</code> - The columns to collapse into the output
+- name <code>string</code> - The resulting output column's name
+- reducer <code>function</code> - Function to use to do the reduction
 - append <code>boolean</code> - Add the new column to the existing ones, or replace them.
 
+**Example**  
+```
+ const timeseries = new TimeSeries(inOutData);
+ Pipeline()
+     .from(timeseries)
+     .collapse(["in", "out"], "in_out_sum", sum)
+     .emitOn("flush")
+     .to(CollectionOut, c => {
+          const ts = new TimeSeries({name: "subset", collection: c});
+          ...
+     }, true);
+```
 <a name="Pipeline+take"></a>
 
 ### pipeline.take(limit) ⇒ <code>[Pipeline](#Pipeline)</code>
@@ -431,8 +457,7 @@ Take events up to the supplied limit, per key.
 <a name="Pipeline+asTimeRangeEvents"></a>
 
 ### pipeline.asTimeRangeEvents(options) ⇒ <code>[Pipeline](#Pipeline)</code>
-Converts incoming Events or IndexedEvents to
-TimeRangeEvents.
+Converts incoming Events or IndexedEvents to TimeRangeEvents.
 
 **Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
 **Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -169,6 +169,7 @@ of collection data.
     * [.offsetBy(by, fieldSpec)](#Pipeline+offsetBy) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.aggregate(fields)](#Pipeline+aggregate) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.asEvents(options)](#Pipeline+asEvents) ⇒ <code>[Pipeline](#Pipeline)</code>
+    * [.map(op)](#Pipeline+map) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.filter(op)](#Pipeline+filter) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.select(fieldSpec)](#Pipeline+select) ⇒ <code>[Pipeline](#Pipeline)</code>
     * [.collapse(fieldSpec, name, append)](#Pipeline+collapse) ⇒ <code>[Pipeline](#Pipeline)</code>
@@ -369,6 +370,17 @@ to convert a time range to a single time. There are three options:
  1. use the beginning time (options = {alignment: "lag"})
  2. use the center time (options = {alignment: "center"})
  3. use the end time (options = {alignment: "lead"})
+
+<a name="Pipeline+map"></a>
+
+### pipeline.map(op) ⇒ <code>[Pipeline](#Pipeline)</code>
+Map the event stream using an operator
+
+**Kind**: instance method of <code>[Pipeline](#Pipeline)</code>  
+**Returns**: <code>[Pipeline](#Pipeline)</code> - The Pipeline  
+**Params**
+
+- op <code>function</code> - A function that returns a new Event
 
 <a name="Pipeline+filter"></a>
 

--- a/docs/series.md
+++ b/docs/series.md
@@ -117,6 +117,7 @@ series.avg("NASA_north", d => d.in);  // 250
         * [.sizeValid()](#TimeSeries+sizeValid)
         * [.count()](#TimeSeries+count) ⇒ <code>number</code>
         * [.pipeline()](#TimeSeries+pipeline) ⇒ <code>Pipeline</code>
+        * [.map(operator, cb)](#TimeSeries+map)
         * [.select(fieldSpec, cb)](#TimeSeries+select)
         * [.collapse(fieldSpec, name, reducer, append, cb)](#TimeSeries+collapse)
     * _static_
@@ -249,6 +250,19 @@ Returns a new Pipeline with input source being this TimeSeries.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
 **Returns**: <code>Pipeline</code> - The Pipeline.  
+<a name="TimeSeries+map"></a>
+
+### timeSeries.map(operator, cb)
+Takes an operator that is used to remap events from this TimeSeries to
+a new set of Events. The result is returned via the callback.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Params**
+
+- operator <code>function</code> - An operator which will be passed each event and
+                                   which should return a new event.
+- cb <code>function</code> - Callback containing a collapsed TimeSeries
+
 <a name="TimeSeries+select"></a>
 
 ### timeSeries.select(fieldSpec, cb)

--- a/docs/series.md
+++ b/docs/series.md
@@ -3,8 +3,9 @@
 ---
 
 A `TimeSeries` represents a series of events, with each event being a combination of:
-time (or `TimeRange`, or `Index`)
-data - corresponding set of key/values.
+
+ - time (or `TimeRange`, or `Index`)
+ - data - corresponding set of key/values.
 
 ### Construction
 
@@ -31,14 +32,16 @@ var series = new TimeSeries(data);
 ```
 
 The format of the data is as follows:
-**name** - optional, but a good practice
-**columns** - are necessary and give labels to the data in the points.
-**points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
+
+ - **name** - optional, but a good practice
+ - **columns** - are necessary and give labels to the data in the points.
+ - **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
    
-  As just hinted at, the first column may actually be:
-"time"
-"timeRange" represented by a `TimeRange`
-"index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
+As just hinted at, the first column may actually be:
+
+ - "time"
+ - "timeRange" represented by a `TimeRange`
+ - "index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
 
 ```javascript
 var availabilityData = {
@@ -104,18 +107,29 @@ series.avg("NASA_north", d => d.in);  // 250
         * [.timerange()](#TimeSeries+timerange)
         * [.begin()](#TimeSeries+begin) ⇒ <code>Date</code>
         * [.end()](#TimeSeries+end) ⇒ <code>Date</code>
-        * [.at()](#TimeSeries+at)
+        * [.at(pos)](#TimeSeries+at)
         * [.setCollection(collection)](#TimeSeries+setCollection) ⇒ <code>[TimeSeries](#TimeSeries)</code>
-        * [.bisect()](#TimeSeries+bisect)
-        * [.slice()](#TimeSeries+slice)
-        * [.clean()](#TimeSeries+clean)
+        * [.bisect(t, b)](#TimeSeries+bisect) ⇒ <code>number</code>
+        * [.slice(begin, end)](#TimeSeries+slice) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+        * [.clean(fieldSpec)](#TimeSeries+clean) ⇒ <code>[TimeSeries](#TimeSeries)</code>
         * [.events()](#TimeSeries+events)
-        * [.index()](#TimeSeries+index)
-        * [.collection()](#TimeSeries+collection)
-        * [.meta()](#TimeSeries+meta)
-        * [.size()](#TimeSeries+size)
-        * [.sizeValid()](#TimeSeries+sizeValid)
+        * [.name()](#TimeSeries+name) ⇒ <code>string</code>
+        * [.index()](#TimeSeries+index) ⇒ <code>Index</code>
+        * [.indexAsString()](#TimeSeries+indexAsString) ⇒ <code>string</code>
+        * [.indexAsRange()](#TimeSeries+indexAsRange) ⇒ <code>TimeRange</code>
+        * [.isUTC()](#TimeSeries+isUTC) ⇒ <code>TimeRange</code>
+        * [.columns()](#TimeSeries+columns) ⇒ <code>array</code>
+        * [.collection()](#TimeSeries+collection) ⇒ <code>Collection</code>
+        * [.meta(key)](#TimeSeries+meta) ⇒ <code>object</code>
+        * [.size()](#TimeSeries+size) ⇒ <code>number</code>
+        * [.sizeValid()](#TimeSeries+sizeValid) ⇒ <code>number</code>
         * [.count()](#TimeSeries+count) ⇒ <code>number</code>
+        * [.sum(fieldSpec)](#TimeSeries+sum) ⇒ <code>number</code>
+        * [.avg(fieldSpec)](#TimeSeries+avg) ⇒ <code>number</code>
+        * [.mean(fieldSpec)](#TimeSeries+mean) ⇒ <code>number</code>
+        * [.median(fieldSpec)](#TimeSeries+median) ⇒ <code>number</code>
+        * [.stdev(fieldSpec)](#TimeSeries+stdev) ⇒ <code>number</code>
+        * [.aggregate(func, fieldSpec)](#TimeSeries+aggregate) ⇒ <code>number</code>
         * [.pipeline()](#TimeSeries+pipeline) ⇒ <code>Pipeline</code>
         * [.map(operator, cb)](#TimeSeries+map)
         * [.select(fieldSpec, cb)](#TimeSeries+select)
@@ -123,7 +137,9 @@ series.avg("NASA_north", d => d.in);  // 250
     * _static_
         * [.equal(series1, series2)](#TimeSeries.equal) ⇒ <code>bool</code>
         * [.is(series1, series2)](#TimeSeries.is) ⇒ <code>bool</code>
-        * [.sum(data, seriesList, fieldSpec)](#TimeSeries.sum) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+        * [.timeseriesListReduce(data, seriesList, reducer, fieldSpec)](#TimeSeries.timeseriesListReduce) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+        * [.timeSeriesListMerge(data, seriesList)](#TimeSeries.timeSeriesListMerge) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+        * [.timeSeriesListSum(data, seriesList, fieldSpec)](#TimeSeries.timeSeriesListSum) ⇒ <code>[TimeSeries](#TimeSeries)</code>
 
 <a name="TimeSeries+toJSON"></a>
 
@@ -159,10 +175,14 @@ Gets the latest time represented in the TimeSeries.
 **Returns**: <code>Date</code> - End time  
 <a name="TimeSeries+at"></a>
 
-### timeSeries.at()
-Access the series events via index
+### timeSeries.at(pos)
+Access a specific TimeSeries event via its position
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Params**
+
+- pos <code>number</code> - The event position
+
 <a name="TimeSeries+setCollection"></a>
 
 ### timeSeries.setCollection(collection) ⇒ <code>[TimeSeries](#TimeSeries)</code>
@@ -176,81 +196,239 @@ Sets a new underlying collection for this TimeSeries.
 
 <a name="TimeSeries+bisect"></a>
 
-### timeSeries.bisect()
-Finds the index that is just less than the time t supplied.
-In other words every event at the returned index or less
-has a time before the supplied t, and every sample after the
-index has a time later than the supplied t.
-
-Optionally supply a begin index to start searching from.
+### timeSeries.bisect(t, b) ⇒ <code>number</code>
+Returns the index that bisects the TimeSeries at the time specified.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The row number that is the greatest, but still below t.  
+**Params**
+
+- t <code>Data</code> - The time to bisect the TimeSeries with
+- b <code>number</code> - The position to begin searching at
+
 <a name="TimeSeries+slice"></a>
 
-### timeSeries.slice()
+### timeSeries.slice(begin, end) ⇒ <code>[TimeSeries](#TimeSeries)</code>
 Perform a slice of events within the TimeSeries, returns a new
-TimeSeries representing a portion of this TimeSeries from begin up to
-but not including end.
+TimeSeries representing a portion of this TimeSeries from
+begin up to but not including end.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>[TimeSeries](#TimeSeries)</code> - The new, sliced, TimeSeries.  
+**Params**
+
+- begin <code>Number</code> - The position to begin slicing
+- end <code>Number</code> - The position to end slicing
+
 <a name="TimeSeries+clean"></a>
 
-### timeSeries.clean()
-Perform a basic cleaning operation of the fieldSpec specified
-by removing all events in the underlying collection which are
-NaN, null or undefined.
+### timeSeries.clean(fieldSpec) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+Returns a new Collection by testing the fieldSpec
+values for being valid (not NaN, null or undefined).
+
+The resulting TimeSeries will be clean (for that fieldSpec).
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>[TimeSeries](#TimeSeries)</code> - A new, modified, TimeSeries.  
+**Params**
+
+- fieldSpec <code>string</code> - The field to test
+
 <a name="TimeSeries+events"></a>
 
 ### timeSeries.events()
-Generator to allow for..of loops over series.events()
+Generator to return all the events in the collection.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Example**  
+```
+for (let event of timeseries.events()) {
+    console.log(event.toString());
+}
+```
+<a name="TimeSeries+name"></a>
+
+### timeSeries.name() ⇒ <code>string</code>
+Fetch the timeseries name
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>string</code> - The name given to this TimeSeries  
 <a name="TimeSeries+index"></a>
 
-### timeSeries.index()
-Access the Index, if this TimeSeries has one
+### timeSeries.index() ⇒ <code>Index</code>
+Fetch the timeseries Index, if it has one.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>Index</code> - The Index given to this TimeSeries  
+<a name="TimeSeries+indexAsString"></a>
+
+### timeSeries.indexAsString() ⇒ <code>string</code>
+Fetch the timeseries Index, as a string, if it has one.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>string</code> - The Index, as a string, given to this TimeSeries  
+<a name="TimeSeries+indexAsRange"></a>
+
+### timeSeries.indexAsRange() ⇒ <code>TimeRange</code>
+Fetch the timeseries Index, as a TimeRange, if it has one.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>TimeRange</code> - The Index, as a TimeRange, given to this TimeSeries  
+<a name="TimeSeries+isUTC"></a>
+
+### timeSeries.isUTC() ⇒ <code>TimeRange</code>
+Fetch the UTC flag, i.e. are the events in this TimeSeries in
+UTC or local time (if they are IndexedEvents an event might be
+"2014-08-31". The actual time range of that representation
+depends on where you are. Pond supports thinking about that in
+either as a UTC day, or a local day).
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>TimeRange</code> - The Index, as a TimeRange, given to this TimeSeries  
+<a name="TimeSeries+columns"></a>
+
+### timeSeries.columns() ⇒ <code>array</code>
+Fetch the list of column names. This is determined by
+traversing though the events and collecting the set.
+
+Note: the order is not defined
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>array</code> - List of columns  
 <a name="TimeSeries+collection"></a>
 
-### timeSeries.collection()
+### timeSeries.collection() ⇒ <code>Collection</code>
 Returns the internal collection of events for this TimeSeries
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>Collection</code> - The collection backing this TimeSeries  
 <a name="TimeSeries+meta"></a>
 
-### timeSeries.meta()
-Returns the meta data about this TimeSeries as a JSON object
+### timeSeries.meta(key) ⇒ <code>object</code>
+Returns the meta data about this TimeSeries as a JSON object.
+Any extra data supplied to the TimeSeries constructor will be
+placed in the meta data object. This returns either all of that
+data as a JSON object, or a specific key if `key` is supplied.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>object</code> - The meta data  
+**Params**
+
+- key <code>string</code> - Optional specific part of the meta data
+
 <a name="TimeSeries+size"></a>
 
-### timeSeries.size()
-Returns the number of rows in the series.
+### timeSeries.size() ⇒ <code>number</code>
+Returns the number of events in this TimeSeries
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - Count of events  
 <a name="TimeSeries+sizeValid"></a>
 
-### timeSeries.sizeValid()
-Returns the number of rows in the series.
+### timeSeries.sizeValid() ⇒ <code>number</code>
+Returns the number of valid items in this TimeSeries.
+
+Uses the fieldSpec to look up values in all events.
+It then counts the number that are considered valid, which
+specifically are not NaN, undefined or null.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - Count of valid events  
 <a name="TimeSeries+count"></a>
 
 ### timeSeries.count() ⇒ <code>number</code>
-Returns the number of rows in the series. (Same as size())
+Returns the number of events in this TimeSeries. Alias
+for size().
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
-**Returns**: <code>number</code> - Size of the series  
+**Returns**: <code>number</code> - Count of events  
+<a name="TimeSeries+sum"></a>
+
+### timeSeries.sum(fieldSpec) ⇒ <code>number</code>
+Returns the sum for the fieldspec
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The sum  
+**Params**
+
+- fieldSpec <code>string</code> - The field to sum over the TimeSeries
+
+<a name="TimeSeries+avg"></a>
+
+### timeSeries.avg(fieldSpec) ⇒ <code>number</code>
+Aggregates the events in the TimeSeries down to their average
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The average  
+**Params**
+
+- fieldSpec <code>String</code> - The field to average over in the TimeSeries
+
+<a name="TimeSeries+mean"></a>
+
+### timeSeries.mean(fieldSpec) ⇒ <code>number</code>
+Aggregates the events in the TimeSeries down to their mean (same as avg)
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The mean  
+**Params**
+
+- fieldSpec <code>String</code> - The field to find the mean of within the collection
+
+<a name="TimeSeries+median"></a>
+
+### timeSeries.median(fieldSpec) ⇒ <code>number</code>
+Aggregates the events down to their medium value
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The resulting median value  
+**Params**
+
+- fieldSpec <code>String</code> - The field to aggregate over
+
+<a name="TimeSeries+stdev"></a>
+
+### timeSeries.stdev(fieldSpec) ⇒ <code>number</code>
+Aggregates the events down to their stdev
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The resulting stdev value  
+**Params**
+
+- fieldSpec <code>String</code> - The field to aggregate over
+
+<a name="TimeSeries+aggregate"></a>
+
+### timeSeries.aggregate(func, fieldSpec) ⇒ <code>number</code>
+Aggregates the events down using a user defined function to
+do the reduction.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>number</code> - The resulting value  
+**Params**
+
+- func <code>function</code> - User defined reduction function. Will be
+                           passed a list of values. Should return a
+                           singe value.
+- fieldSpec <code>String</code> - The field to aggregate over
+
 <a name="TimeSeries+pipeline"></a>
 
 ### timeSeries.pipeline() ⇒ <code>Pipeline</code>
-Returns a new Pipeline with input source being this TimeSeries.
+Returns a new Pipeline with input source being initialized to
+this TimeSeries collection. This allows pipeline operations
+to be chained directly onto the TimeSeries to produce a new
+TimeSeries or Event result.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
 **Returns**: <code>Pipeline</code> - The Pipeline.  
+**Example**  
+```
+timeseries.pipeline()
+    .offsetBy(1)
+    .offsetBy(2)
+    .to(CollectionOut, c => out = c);
+```
 <a name="TimeSeries+map"></a>
 
 ### timeSeries.map(operator, cb)
@@ -323,9 +501,44 @@ are of the same value as each other then equals will return true.
 - series1 <code>[TimeSeries](#TimeSeries)</code>
 - series2 <code>[TimeSeries](#TimeSeries)</code>
 
-<a name="TimeSeries.sum"></a>
+<a name="TimeSeries.timeseriesListReduce"></a>
 
-### TimeSeries.sum(data, seriesList, fieldSpec) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+### TimeSeries.timeseriesListReduce(data, seriesList, reducer, fieldSpec) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+Reduces a list of TimeSeries objects using a reducer function. This works
+by taking each event in each TimeSeries and collecting them together
+based on timestamp. All events for a given time are then merged together
+using the reducer function to produce a new Event. Those Events are then
+collected together to form a new TimeSeries.
+
+**Kind**: static method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>[TimeSeries](#TimeSeries)</code> - The new TimeSeries  
+**Params**
+
+- data <code>object</code> - Meta data for the resulting TimeSeries
+- seriesList <code>array</code> - A list of TimeSeries objects
+- reducer <code>func</code> - The reducer function
+- fieldSpec <code>string</code> - The fields to map
+
+<a name="TimeSeries.timeSeriesListMerge"></a>
+
+### TimeSeries.timeSeriesListMerge(data, seriesList) ⇒ <code>[TimeSeries](#TimeSeries)</code>
+Takes a list of TimeSeries and merges them together to form a new
+Timeseries.
+
+Merging will produce a new Event only when events are conflict free, so
+it is useful to combine multiple TimeSeries which have different time ranges
+as well as combine TimeSeries which have different columns.
+
+**Kind**: static method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>[TimeSeries](#TimeSeries)</code> - The resulting TimeSeries  
+**Params**
+
+- data <code>object</code> - Meta data for the new TimeSeries
+- seriesList <code>array</code> - A list of TimeSeries
+
+<a name="TimeSeries.timeSeriesListSum"></a>
+
+### TimeSeries.timeSeriesListSum(data, seriesList, fieldSpec) ⇒ <code>[TimeSeries](#TimeSeries)</code>
 Takes a list of TimeSeries and sums them together to form a new
 Timeseries.
 

--- a/docs/series.md
+++ b/docs/series.md
@@ -109,7 +109,6 @@ series.avg("NASA_north", d => d.in);  // 250
         * [.bisect()](#TimeSeries+bisect)
         * [.slice()](#TimeSeries+slice)
         * [.clean()](#TimeSeries+clean)
-        * [.collapse(fieldSpecList, name, reducer, append)](#TimeSeries+collapse) ⇒ <code>Collection</code>
         * [.events()](#TimeSeries+events)
         * [.index()](#TimeSeries+index)
         * [.collection()](#TimeSeries+collection)
@@ -117,6 +116,9 @@ series.avg("NASA_north", d => d.in);  // 250
         * [.size()](#TimeSeries+size)
         * [.sizeValid()](#TimeSeries+sizeValid)
         * [.count()](#TimeSeries+count) ⇒ <code>number</code>
+        * [.pipeline()](#TimeSeries+pipeline) ⇒ <code>Pipeline</code>
+        * [.select(fieldSpec, cb)](#TimeSeries+select)
+        * [.collapse(fieldSpec, name, reducer, append, cb)](#TimeSeries+collapse)
     * _static_
         * [.equal()](#TimeSeries.equal)
         * [.sum(data, seriesList, fieldSpec)](#TimeSeries.sum) ⇒ <code>[TimeSeries](#TimeSeries)</code>
@@ -197,22 +199,6 @@ by removing all events in the underlying collection which are
 NaN, null or undefined.
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
-<a name="TimeSeries+collapse"></a>
-
-### timeSeries.collapse(fieldSpecList, name, reducer, append) ⇒ <code>Collection</code>
-Takes a fieldSpecList (list of column names) and collapses
-them to a new column which is the reduction of the matched columns
-in the fieldSpecList.
-
-**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
-**Returns**: <code>Collection</code> - A new, modified, Collection  
-**Params**
-
-- fieldSpecList <code>array</code> - The list of columns
-- name <code>string</code> - The resulting summed column name
-- reducer <code>function</code> - Reducer function e.g. sum
-- append <code>boolean</code> <code> = true</code> - Append the summed column, rather than replace
-
 <a name="TimeSeries+events"></a>
 
 ### timeSeries.events()
@@ -256,6 +242,46 @@ Returns the number of rows in the series. (Same as size())
 
 **Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
 **Returns**: <code>number</code> - Size of the series  
+<a name="TimeSeries+pipeline"></a>
+
+### timeSeries.pipeline() ⇒ <code>Pipeline</code>
+Returns a new Pipeline with input source being this TimeSeries.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Returns**: <code>Pipeline</code> - The Pipeline.  
+<a name="TimeSeries+select"></a>
+
+### timeSeries.select(fieldSpec, cb)
+Takes a fieldSpec (list of column names) and outputs to the callback just those
+columns in a new TimeSeries.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Params**
+
+- fieldSpec <code>array</code> - The list of columns
+- cb <code>function</code> - Callback containing a collapsed TimeSeries
+
+<a name="TimeSeries+collapse"></a>
+
+### timeSeries.collapse(fieldSpec, name, reducer, append, cb)
+Takes a fieldSpec (list of column names) and collapses
+them to a new column named `name` which is the reduction (using
+the `reducer` function) of the matched columns in the fieldSpecList.
+
+The column may be appended to the existing columns, or replace them,
+using the `append` boolean.
+
+The result, a new TimeSeries, will be passed to the supplied callback.
+
+**Kind**: instance method of <code>[TimeSeries](#TimeSeries)</code>  
+**Params**
+
+- fieldSpec <code>array</code> - The list of columns
+- name <code>string</code> - The resulting summed column name
+- reducer <code>function</code> - Reducer function e.g. sum
+- append <code>boolean</code> - Append the summed column, rather than replace
+- cb <code>function</code> - Callback containing a collapsed TimeSeries
+
 <a name="TimeSeries.equal"></a>
 
 ### TimeSeries.equal()

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -628,33 +628,6 @@ var Collection = function (_BoundedIn) {
             return new Collection(filteredEvents);
         }
 
-        /**
-         * Takes a fieldSpecList (list of column names) and collapses
-         * them to a new column which is the reduction of the matched columns
-         * in the fieldSpecList.
-         *
-         * @param  {array}      fieldSpecList  The list of columns
-         * @param  {string}     name           The resulting summed column name
-         * @param  {function}   reducer        Reducer function e.g. sum
-         * @param  {boolean}    append         Append the summed column, rather than replace
-         * @return {Collection}                A new, modified, Collection
-         */
-
-    }, {
-        key: "collapse",
-        value: function collapse(fieldSpecList, name, reducer) {
-            var _this2 = this;
-
-            var append = arguments.length <= 3 || arguments[3] === undefined ? true : arguments[3];
-
-            var fsl = fieldSpecList.map(function (fieldSpec) {
-                return _this2._fieldSpecToArray(fieldSpec);
-            });
-            return this.map(function (e) {
-                return e.collapse(fsl, name, reducer, append);
-            });
-        }
-
         //
         // Aggregate the event list to a single value
         //

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -75,10 +75,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * of the collection and access a specific element with at().
  *
  * You can also perform aggregations of the events, map them, filter them
- * and clean them.
+ * clean them, etc.
  *
  * Collections form the backing structure for a TimeSeries, as well as
- * in Pipeline event processing.
+ * in Pipeline event processing. They are an instance of a BoundedIn, so
+ * they can be used as a pipeline source.
  */
 /**
  *  Copyright (c) 2016, The Regents of the University of California,
@@ -103,6 +104,7 @@ var Collection = function (_BoundedIn) {
      * @param  {Boolean} [copyEvents] When using a the copy constructor
      * this specified whether or not to also copy all the events in this
      * collection. Generally you'll want to let it copy the events.
+     *
      * @return {Collection} The constructed Collection.
      */
 
@@ -144,6 +146,7 @@ var Collection = function (_BoundedIn) {
 
     /**
      * Returns the Collection as a regular JSON object.
+     *
      * @return {Object} The JSON representation of this Collection
      */
 
@@ -157,6 +160,7 @@ var Collection = function (_BoundedIn) {
         /**
          * Serialize out the Collection as a string. This will be the
          * string representation of `toJSON()`.
+         *
          * @return {string} The Collection serialized as a string.
          */
 
@@ -167,13 +171,15 @@ var Collection = function (_BoundedIn) {
         }
 
         /**
-         * Returns the Event object type in this collection. Since
-         * Collections my only have one type of Event (Event, IndexedEvent
-         * or TimeRangeEvent) this will return that type. If no events
-         * have been added to the Collection it will return undefined.
+         * Returns the Event object type in this Collection.
+         *
+         * Since Collections may only have one type of event (`Event`, `IndexedEvent`
+         * or `TimeRangeEvent`) this will return that type. If no events
+         * have been added to the Collection it will return `undefined`.
          *
          * @return {Event|IndexedEvent|TimeRangeEvent} - The class of the type
-         * of events contained in this Collection.
+         *                                               of events contained in
+         *                                               this Collection.
          */
 
     }, {
@@ -184,6 +190,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the number of events in this collection
+         *
          * @return {number} Count of events
          */
 
@@ -197,8 +204,8 @@ var Collection = function (_BoundedIn) {
          * Returns the number of valid items in this collection.
          *
          * Uses the fieldSpec to look up values in all events.
-         * It then counts the number that are considered valid,
-         * i.e. are not NaN, undefined or null.
+         * It then counts the number that are considered valid, which
+         * specifically are not NaN, undefined or null.
          *
          * @return {number} Count of valid events
          */
@@ -259,7 +266,9 @@ var Collection = function (_BoundedIn) {
         }
 
         /**
-         * Returns an event in the Collection by its time.
+         * Returns an event in the Collection by its time. This is the same
+         * as calling `bisect` first and then using `at` with the index.
+         *
          * @param  {Date} time The time of the event.
          * @return {Event|TimeRangeEvent|IndexedEvent}
          */
@@ -275,6 +284,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the first event in the Collection.
+         *
          * @return {Event|TimeRangeEvent|IndexedEvent}
          */
 
@@ -288,6 +298,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the last event in the Collection.
+         *
          * @return {Event|TimeRangeEvent|IndexedEvent}
          */
 
@@ -300,11 +311,12 @@ var Collection = function (_BoundedIn) {
         }
 
         /**
-         * Returns the index that bisects the Collection at
-         * the time specified
-         * @param  {Data} t The time to bisect the Collection with
-         * @param  {number} b The position to begin searching at
-         * @return {number}   The row number that is the greatest, but still below t.
+         * Returns the index that bisects the Collection at the time specified.
+         *
+         * @param  {Data}    t   The time to bisect the Collection with
+         * @param  {number}  b   The position to begin searching at
+         *
+         * @return {number}      The row number that is the greatest, but still below t.
          */
 
     }, {
@@ -331,6 +343,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Generator to return all the events in the collection.
+         * 
          * @example
          * ```
          * for (let event of series.events()) {
@@ -373,6 +386,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the raw Immutable event list
+         *
          * @return {Immutable.List} All events as an Immutable List.
          */
 
@@ -383,7 +397,8 @@ var Collection = function (_BoundedIn) {
         }
 
         /**
-         * Returns a Javascript array of events
+         * Returns a Javascript array representation of the event list
+         *
          * @return {Array} All events as a Javascript Array.
          */
 
@@ -425,7 +440,9 @@ var Collection = function (_BoundedIn) {
 
         /**
          * From the range of times, or Indexes within the TimeSeries, return
-         * the extents of the TimeSeries as a TimeRange.
+         * the extents of the TimeSeries as a TimeRange. This is currently implemented
+         * by walking the events.
+         *
          * @return {TimeRange} The extents of the TimeSeries
          */
 
@@ -468,9 +485,13 @@ var Collection = function (_BoundedIn) {
         //
 
         /**
-         * Adds an event to the collection, returns a new Collection
+         * Adds an event to the collection, returns a new Collection. The event added
+         * can be an Event, TimeRangeEvent or IndexedEvent, but it must be of the
+         * same type as other events within the Collection.
+         *
          * @param {Event|TimeRangeEvent|IndexedEvent} event The event being added.
-         * @return {Collection} A new, modified, Collection.
+         *
+         * @return {Collection} A new, modified, Collection containing the new event.
          */
 
     }, {
@@ -486,9 +507,11 @@ var Collection = function (_BoundedIn) {
          * Perform a slice of events within the Collection, returns a new
          * Collection representing a portion of this TimeSeries from begin up to
          * but not including end.
-         * @param {Number} begin The position to begin slicing
-         * @param {Number} end The position to end slicing
-         * @return {Collection} A new, modified, Collection.
+         *
+         * @param {Number} begin   The position to begin slicing
+         * @param {Number} end     The position to end slicing
+         *
+         * @return {Collection}    The new, sliced, Collection.
          */
 
     }, {
@@ -503,8 +526,9 @@ var Collection = function (_BoundedIn) {
          * Filter the collection's event list with the supplied function
          *
          * @param {function} func The filter function, that should return
-         * true or false when passed in an event.
-         * @return {Collection} A new, modified, Collection.
+         *                        true or false when passed in an event.
+         *
+         * @return {Collection}   A new, filtered, Collection.
          */
 
     }, {
@@ -634,6 +658,7 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the number of events in this collection
+         *
          * @return {number} The number of events
          */
 
@@ -645,6 +670,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the first value in the Collection for the fieldspec
+         *
+         * @param {string} fieldSpec The field to fetch
+         *
+         * @return {number} The first value
          */
 
     }, {
@@ -657,6 +686,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the last value in the Collection for the fieldspec
+         *
+         * @param {string} fieldSpec The field to fetch
+         *
+         * @return {number} The last value
          */
 
     }, {
@@ -669,6 +702,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Returns the sum Collection for the fieldspec
+         *
+         * @param {string} fieldSpec The field to sum over the collection
+         *
+         * @return {number} The sum
          */
 
     }, {
@@ -681,8 +718,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Aggregates the events down to their average
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         *
+         * @param  {String} fieldSpec The field to average over the collection
+         *
+         * @return {number}           The average
          */
 
     }, {
@@ -695,8 +734,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Aggregates the events down to their maximum value
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         *
+         * @param  {String} fieldSpec The field to find the max within the collection
+         *
+         * @return {number}           The max value for the field
          */
 
     }, {
@@ -709,8 +750,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Aggregates the events down to their minimum value
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         *
+         * @param  {String} fieldSpec The field to find the min within the collection
+         *
+         * @return {number}           The min value for the field
          */
 
     }, {
@@ -722,9 +765,11 @@ var Collection = function (_BoundedIn) {
         }
 
         /**
-         * Aggregates the events down to their mean
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         * Aggregates the events down to their mean (same as avg)
+         *
+         * @param  {String} fieldSpec The field to find the mean of within the collection
+         *
+         * @return {number}           The mean
          */
 
     }, {
@@ -737,8 +782,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Aggregates the events down to their medium value
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         *
+         * @param  {String} fieldSpec The field to aggregate over
+         *
+         * @return {number}           The resulting median value
          */
 
     }, {
@@ -751,8 +798,10 @@ var Collection = function (_BoundedIn) {
 
         /**
          * Aggregates the events down to their stdev
-         * @param  {String} fieldSpec The field to aggregate
-         * @return {number}           The resulting value
+         *
+         * @param  {String} fieldSpec The field to aggregate over
+         *
+         * @return {number}           The resulting stdev value
          */
 
     }, {
@@ -767,9 +816,11 @@ var Collection = function (_BoundedIn) {
          * Aggregates the events down using a user defined function to
          * do the reduction.
          *
-         * @param  {function} func User defined reduction function. Will be
-         * passed a list of values. Should return a singe value.
-         * @param  {String} fieldSpec The field to aggregate
+         * @param  {function} func    User defined reduction function. Will be
+         *                            passed a list of values. Should return a
+         *                            singe value.
+         * @param  {String} fieldSpec The field to aggregate over
+         *
          * @return {number}           The resulting value
          */
 
@@ -809,8 +860,10 @@ var Collection = function (_BoundedIn) {
         /**
          * Static function to compare two collections to each other. If the collections
          * are of the same instance as each other then equals will return true.
+         *
          * @param  {Collection} collection1
          * @param  {Collection} collection2
+         *
          * @return {bool} result
          */
 
@@ -823,8 +876,10 @@ var Collection = function (_BoundedIn) {
         /**
          * Static function to compare two collections to each other. If the collections
          * are of the same value as each other then equals will return true.
+         *
          * @param  {Collection} collection1
          * @param  {Collection} collection2
+         *
          * @return {bool} result
          */
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -1,0 +1,89 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _getPrototypeOf = require("babel-runtime/core-js/object/get-prototype-of");
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
+var _classCallCheck2 = require("babel-runtime/helpers/classCallCheck");
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require("babel-runtime/helpers/createClass");
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require("babel-runtime/helpers/possibleConstructorReturn");
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _inherits2 = require("babel-runtime/helpers/inherits");
+
+var _inherits3 = _interopRequireDefault(_inherits2);
+
+var _processor = require("./processor");
+
+var _processor2 = _interopRequireDefault(_processor);
+
+var _pipeline = require("./pipeline");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * A processor which takes an operator as its only option
+ * and uses that to either output a new event
+ */
+/**
+ *  Copyright (c) 2016, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+var Mapper = function (_Processor) {
+    (0, _inherits3.default)(Mapper, _Processor);
+
+    function Mapper(arg1, options, observer) {
+        (0, _classCallCheck3.default)(this, Mapper);
+
+        var _this = (0, _possibleConstructorReturn3.default)(this, (0, _getPrototypeOf2.default)(Mapper).call(this, arg1, options, observer));
+
+        if (arg1 instanceof Mapper) {
+            var other = arg1;
+            _this._op = other._op;
+        } else if ((0, _pipeline.isPipeline)(arg1)) {
+            _this._op = options.op;
+        } else {
+            throw new Error("Unknown arg to Mapper constructor", arg1);
+        }
+        return _this;
+    }
+
+    (0, _createClass3.default)(Mapper, [{
+        key: "clone",
+        value: function clone() {
+            return new Mapper(this);
+        }
+
+        /**
+         * Output an event that is remapped
+         */
+
+    }, {
+        key: "addEvent",
+        value: function addEvent(event) {
+            if (this.hasObservers()) {
+                this.emit(this._op(event));
+            }
+        }
+    }]);
+    return Mapper;
+}(_processor2.default);
+
+exports.default = Mapper;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -245,6 +245,7 @@ var Runner = function () {
  * of collection data.
  */
 
+
 var Pipeline = function () {
 
     /**
@@ -429,8 +430,10 @@ var Pipeline = function () {
          * is an object with {type, duration}.
          * type may be:
          *  * "Fixed"
+         *  * other types coming
+         *
          * duration is of the form:
-         *  * "30s", "5m" or "1d" etc
+         *  * "30s" or "1d" etc
          *
          * @return {Pipeline} The Pipeline
          */
@@ -504,11 +507,20 @@ var Pipeline = function () {
         }
 
         /**
-         * Sets the condition under which accumulated collection will
+         * Sets the condition under which an accumulated collection will
          * be emitted. If specified before an aggregation this will control
          * when the resulting event will be emitted relative to the
-         * window accumulation. Current options are to emit on every event
-         * or just when the collection is complete.
+         * window accumulation. Current options are:
+         *  * to emit on every event, or
+         *  * just when the collection is complete, or
+         *  * when a flush signal is received, either manually calling done(),
+         *    or at the end of a bounded source
+         *
+         * The difference will depend on the output you want, how often
+         * you want to get updated, and if you need to get a partial state.
+         * There's currently no support for late data or watermarks. If an
+         * event passes comes in after a collection window, that collection
+         * is considered finished.
          *
          * @param {string} trigger A string indicating how to trigger a
          * Collection should be emitted. May be:
@@ -516,6 +528,7 @@ var Pipeline = function () {
          *                     maintained collections will emit their result
          *     * "discard"   - when a collection is to be discarded,
          *                     first it will emit. But only then.
+         *     * "flush"     - when a flush signal is received
          *
          * @return {Pipeline} The Pipeline
          */
@@ -532,12 +545,13 @@ var Pipeline = function () {
         //
 
         /**
-         * The "In" to get events from. The In needs to be able to
-         * iterate its events using for..of loop for bounded Ins, or
-         * be able to emit for unbounded Ins. The actual batch, or stream
-         * connection occurs when an output is defined with to().
+         * The source to get events from. The source needs to be able to
+         * iterate its events using `for..of` loop for bounded Ins, or
+         * be able to emit() for unbounded Ins. The actual batch, or stream
+         * connection occurs when an output is defined with `to()`.
          *
-         * from() returns a new Pipeline.
+         * Pipelines can be chained together since a source may be another
+         * Pipeline.
          *
          * @param {BoundedIn|UnboundedIn|Pipeline} src The source for the
          *                                             Pipeline, or another
@@ -557,17 +571,17 @@ var Pipeline = function () {
         }
 
         /**
-         * Sets up the destination sink for the pipeline. The output should
-         * be a BatchOut subclass for a bounded input and a StreamOut subclass
-         * for an unbounded input.
+         * Sets up the destination sink for the pipeline.
          *
-         * For a batch mode connection, the output is connected and then the
-         * source input is iterated over to process all events into the pipeline and
-         * down to the out.
+         * For a batch mode connection, i.e. one with a Bounded source,
+         * the output is connected to a clone of the parts of the Pipeline dependencies
+         * that lead to this output. This is done by a Runner. The source input is
+         * then iterated over to process all events into the pipeline and though to the Out.
          *
          * For stream mode connections, the output is connected and from then on
          * any events added to the input will be processed down the pipeline to
          * the out.
+         *
          * @example
          * ```
          * const p = Pipeline()
@@ -622,6 +636,7 @@ var Pipeline = function () {
 
         /**
          * Outputs the count of events
+         *
          * @param  {function}  observer The callback function. This will be
          *                              passed the count, the windowKey and
          *                              the groupByKey
@@ -647,7 +662,8 @@ var Pipeline = function () {
 
         /**
          * Processor to offset a set of fields by a value. Mostly used for
-         * testing processor operations.
+         * testing processor and pipeline operations with a simple operation.
+         *
          * @param  {number} by              The amount to offset by
          * @param  {string|array} fieldSpec The field(s)
          *
@@ -669,6 +685,7 @@ var Pipeline = function () {
         /**
          * Uses the current Pipeline windowing and grouping
          * state to build collections of events and aggregate them.
+         *
          * `IndexedEvent`s will be emitted out of the aggregator based
          * on the `emitOn` state of the Pipeline.
          *
@@ -678,18 +695,21 @@ var Pipeline = function () {
          *
          * @example
          *
+         * ```
          * import { Pipeline, EventOut, functions } from "pondjs";
          * const { avg } = functions;
          *
          * const p = Pipeline()
          *   .from(input)
          *   .windowBy("1h")           // 1 day fixed windows
-         *   .emitOn("eachEvent")    // emit result on each event
+         *   .emitOn("eachEvent")      // emit result on each event
          *   .aggregate({in: avg, out: avg})
          *   .asEvents()
          *   .to(EventOut, {}, event => {
-         *      result[`${event.index()}`] = event;
+         *      result[`${event.index()}`] = event; // Result
          *   });
+         * ```
+         *
          * @param  {object} fields Fields and operators to be aggregated
          *
          * @return {Pipeline} The Pipeline
@@ -792,12 +812,27 @@ var Pipeline = function () {
         }
 
         /**
-         * Select a subset of columns
+         * Collapse a subset of columns using a reducer function
          *
-         * @param {array|String} fieldSpec The columns to include in the output
-         * @param {string} name The result column name
-         * @param {boolean} append Add the new column to the existing ones, or replace them.
-         * @return {Pipeline} The Pipeline
+         * @example
+         *
+         * ```
+         *  const timeseries = new TimeSeries(inOutData);
+         *  Pipeline()
+         *      .from(timeseries)
+         *      .collapse(["in", "out"], "in_out_sum", sum)
+         *      .emitOn("flush")
+         *      .to(CollectionOut, c => {
+         *           const ts = new TimeSeries({name: "subset", collection: c});
+         *           ...
+         *      }, true);
+         * ```
+         * @param {array|String} fieldSpec The columns to collapse into the output
+         * @param {string}       name      The resulting output column's name
+         * @param {function}     reducer   Function to use to do the reduction
+         * @param {boolean}      append    Add the new column to the existing ones, or replace them.
+         *
+         * @return {Pipeline}              The Pipeline
          */
 
     }, {
@@ -816,6 +851,7 @@ var Pipeline = function () {
 
         /**
          * Take events up to the supplied limit, per key.
+         *
          * @param  {number} limit Integer number of events to take
          *
          * @return {Pipeline} The Pipeline
@@ -833,8 +869,7 @@ var Pipeline = function () {
         }
 
         /**
-         * Converts incoming Events or IndexedEvents to
-         * TimeRangeEvents.
+         * Converts incoming Events or IndexedEvents to TimeRangeEvents.
          *
          * @param {object} options To convert from an Event you need
          * to convert a single time to a time range. To control this you

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -89,6 +89,10 @@ var _collapser = require("./collapser");
 
 var _collapser2 = _interopRequireDefault(_collapser);
 
+var _mapper = require("./mapper");
+
+var _mapper2 = _interopRequireDefault(_mapper);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
@@ -117,6 +121,15 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * NOTE: There's no current way to merge multiple sources, though
  *       a time series has a TimeSeries.merge() static method for
  *       this purpose.
+ */
+/**
+ *  Copyright (c) 2016, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
  */
 
 var Runner = function () {
@@ -230,16 +243,6 @@ var Runner = function () {
 /**
  * A pipeline manages a processing chain, for either batch or stream processing
  * of collection data.
- */
-
-/**
- *  Copyright (c) 2016, The Regents of the University of California,
- *  through Lawrence Berkeley National Laboratory (subject to receipt
- *  of any required approvals from the U.S. Dept. of Energy).
- *  All rights reserved.
- *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree.
  */
 
 var Pipeline = function () {
@@ -727,6 +730,25 @@ var Pipeline = function () {
             }, options, {
                 prev: this.last() ? this.last() : this
             }));
+
+            return this._append(p);
+        }
+
+        /**
+         * Map the event stream using an operator
+         *
+         * @param  {function} op A function that returns a new Event
+         *
+         * @return {Pipeline} The Pipeline
+         */
+
+    }, {
+        key: "map",
+        value: function map(op) {
+            var p = new _mapper2.default(this, {
+                op: op,
+                prev: this.last() ? this.last() : this
+            });
 
             return this._append(p);
         }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -56,6 +56,10 @@ function addPrevToChain(n, chain) {
     }
 }
 
+/**
+ * Base class for all Pipeline processors
+ */
+
 var Processor = function (_Observable) {
     (0, _inherits3.default)(Processor, _Observable);
 

--- a/lib/series.js
+++ b/lib/series.js
@@ -466,27 +466,6 @@ var TimeSeries = function () {
         }
 
         /**
-         * Takes a fieldSpecList (list of column names) and collapses
-         * them to a new column which is the reduction of the matched columns
-         * in the fieldSpecList.
-         *
-         * @param  {array}      fieldSpecList  The list of columns
-         * @param  {string}     name           The resulting summed column name
-         * @param  {function}   reducer        Reducer function e.g. sum
-         * @param  {boolean}    append         Append the summed column, rather than replace
-         * @return {Collection}                A new, modified, Collection
-         */
-
-    }, {
-        key: "collapse",
-        value: function collapse(fieldSpecList, name, reducer) {
-            var append = arguments.length <= 3 || arguments[3] === undefined ? true : arguments[3];
-
-            var collapsed = this._collection.collapse(fieldSpecList, name, reducer, append);
-            return this.setCollection(collapsed);
-        }
-
-        /**
          *  Generator to allow for..of loops over series.events()
          */
 
@@ -689,19 +668,61 @@ var TimeSeries = function () {
         value: function aggregate(func, fieldSpec) {
             return this._collection.aggregate(func, fieldSpec);
         }
+
+        /**
+         * Returns a new Pipeline with input source being this TimeSeries.
+         * @return {Pipeline} The Pipeline.
+         */
+
     }, {
         key: "pipeline",
         value: function pipeline() {
             return new _pipeline.Pipeline().from(this._collection);
         }
+
+        /**
+         * Takes a fieldSpec (list of column names) and outputs to the callback just those
+         * columns in a new TimeSeries.
+         *
+         * @param  {array}      fieldSpec     The list of columns
+         * @param  {function}   cb            Callback containing a collapsed TimeSeries
+         */
+
     }, {
         key: "select",
         value: function select(fieldSpec, cb) {
             var _this2 = this;
 
             this.pipeline().select(fieldSpec).to(_pipelineOutCollection2.default, function (collection) {
-                cb(new TimeSeries((0, _extends3.default)({}, _this2._data.toJSON(), { collection: collection })));
+                cb(_this2.setCollection(collection));
             });
+        }
+
+        /**
+         * Takes a fieldSpec (list of column names) and collapses
+         * them to a new column named `name` which is the reduction (using
+         * the `reducer` function) of the matched columns in the fieldSpecList.
+         *
+         * The column may be appended to the existing columns, or replace them,
+         * using the `append` boolean.
+         *
+         * The result, a new TimeSeries, will be passed to the supplied callback.
+         *
+         * @param  {array}      fieldSpec      The list of columns
+         * @param  {string}     name           The resulting summed column name
+         * @param  {function}   reducer        Reducer function e.g. sum
+         * @param  {boolean}    append         Append the summed column, rather than replace
+         * @param  {function}   cb             Callback containing a collapsed TimeSeries
+         */
+
+    }, {
+        key: "collapse",
+        value: function collapse(fieldSpec, name, reducer, append, cb) {
+            var _this3 = this;
+
+            this.pipeline().collapse(fieldSpec, name, reducer, append).emitOn("flush").to(_pipelineOutCollection2.default, function (collection) {
+                cb(_this3.setCollection(collection));
+            }, true);
         }
 
         /**

--- a/lib/series.js
+++ b/lib/series.js
@@ -681,6 +681,25 @@ var TimeSeries = function () {
         }
 
         /**
+         * Takes an operator that is used to remap events from this TimeSeries to
+         * a new set of Events. The result is returned via the callback.
+         *
+         * @param  {function}   operator      An operator which will be passed each event and
+         *                                    which should return a new event.
+         * @param  {function}   cb            Callback containing a collapsed TimeSeries
+         */
+
+    }, {
+        key: "map",
+        value: function map(op, cb) {
+            var _this2 = this;
+
+            this.pipeline().emitOn("flush").map(op).to(_pipelineOutCollection2.default, function (collection) {
+                cb(_this2.setCollection(collection));
+            }, true);
+        }
+
+        /**
          * Takes a fieldSpec (list of column names) and outputs to the callback just those
          * columns in a new TimeSeries.
          *
@@ -691,11 +710,11 @@ var TimeSeries = function () {
     }, {
         key: "select",
         value: function select(fieldSpec, cb) {
-            var _this2 = this;
+            var _this3 = this;
 
-            this.pipeline().select(fieldSpec).to(_pipelineOutCollection2.default, function (collection) {
-                cb(_this2.setCollection(collection));
-            });
+            this.pipeline().emitOn("flush").select(fieldSpec).to(_pipelineOutCollection2.default, function (collection) {
+                cb(_this3.setCollection(collection));
+            }, true);
         }
 
         /**
@@ -718,10 +737,10 @@ var TimeSeries = function () {
     }, {
         key: "collapse",
         value: function collapse(fieldSpec, name, reducer, append, cb) {
-            var _this3 = this;
+            var _this4 = this;
 
             this.pipeline().collapse(fieldSpec, name, reducer, append).emitOn("flush").to(_pipelineOutCollection2.default, function (collection) {
-                cb(_this3.setCollection(collection));
+                cb(_this4.setCollection(collection));
             }, true);
         }
 

--- a/lib/series.js
+++ b/lib/series.js
@@ -102,8 +102,9 @@ function buildMetaData(meta) {
 
 /**
 A `TimeSeries` represents a series of events, with each event being a combination of:
- * time (or `TimeRange`, or `Index`)
- * data - corresponding set of key/values.
+
+ - time (or `TimeRange`, or `Index`)
+ - data - corresponding set of key/values.
 
 ### Construction
 
@@ -131,15 +132,15 @@ var series = new TimeSeries(data);
 
 The format of the data is as follows:
 
-  * **name** - optional, but a good practice
-  * **columns** - are necessary and give labels to the data in the points.
-  * **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
+ - **name** - optional, but a good practice
+ - **columns** - are necessary and give labels to the data in the points.
+ - **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
    
-  As just hinted at, the first column may actually be:
+As just hinted at, the first column may actually be:
 
-   * "time"
-   * "timeRange" represented by a `TimeRange`
-   * "index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
+ - "time"
+ - "timeRange" represented by a `TimeRange`
+ - "index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
 
 ```javascript
 var availabilityData = {
@@ -380,6 +381,7 @@ var TimeSeries = function () {
 
         /**
          * Gets the earliest time represented in the TimeSeries.
+         *
          * @return {Date} Begin time
          */
 
@@ -391,6 +393,7 @@ var TimeSeries = function () {
 
         /**
          * Gets the latest time represented in the TimeSeries.
+         *
          * @return {Date} End time
          */
 
@@ -401,19 +404,23 @@ var TimeSeries = function () {
         }
 
         /**
-         * Access the series events via index
+         * Access a specific TimeSeries event via its position
+         *
+         * @param {number} pos The event position
          */
 
     }, {
         key: "at",
-        value: function at(i) {
-            return this._collection.at(i);
+        value: function at(pos) {
+            return this._collection.at(pos);
         }
 
         /**
          * Sets a new underlying collection for this TimeSeries.
-         * @param {Collection} collection The new collection
-         * @return {TimeSeries} A new TimeSeries
+         *
+         * @param {Collection}  collection The new collection
+         *
+         * @return {TimeSeries}            A new TimeSeries
          */
 
     }, {
@@ -425,12 +432,12 @@ var TimeSeries = function () {
         }
 
         /**
-         * Finds the index that is just less than the time t supplied.
-         * In other words every event at the returned index or less
-         * has a time before the supplied t, and every sample after the
-         * index has a time later than the supplied t.
+         * Returns the index that bisects the TimeSeries at the time specified.
          *
-         * Optionally supply a begin index to start searching from.
+         * @param  {Data}    t   The time to bisect the TimeSeries with
+         * @param  {number}  b   The position to begin searching at
+         *
+         * @return {number}      The row number that is the greatest, but still below t.
          */
 
     }, {
@@ -441,8 +448,13 @@ var TimeSeries = function () {
 
         /**
          * Perform a slice of events within the TimeSeries, returns a new
-         * TimeSeries representing a portion of this TimeSeries from begin up to
-         * but not including end.
+         * TimeSeries representing a portion of this TimeSeries from
+         * begin up to but not including end.
+         *
+         * @param {Number} begin   The position to begin slicing
+         * @param {Number} end     The position to end slicing
+         *
+         * @return {TimeSeries}    The new, sliced, TimeSeries.
          */
 
     }, {
@@ -453,9 +465,13 @@ var TimeSeries = function () {
         }
 
         /**
-         * Perform a basic cleaning operation of the fieldSpec specified
-         * by removing all events in the underlying collection which are
-         * NaN, null or undefined.
+         * Returns a new Collection by testing the fieldSpec
+         * values for being valid (not NaN, null or undefined).
+         *
+         * The resulting TimeSeries will be clean (for that fieldSpec).
+         *
+         * @param {string}      fieldSpec The field to test
+         * @return {TimeSeries}           A new, modified, TimeSeries.
          */
 
     }, {
@@ -466,7 +482,14 @@ var TimeSeries = function () {
         }
 
         /**
-         *  Generator to allow for..of loops over series.events()
+         * Generator to return all the events in the collection.
+         *
+         * @example
+         * ```
+         * for (let event of timeseries.events()) {
+         *     console.log(event.toString());
+         * }
+         * ```
          */
 
     }, {
@@ -505,6 +528,12 @@ var TimeSeries = function () {
         // Access meta data about the series
         //
 
+        /**
+         * Fetch the timeseries name
+         *
+         * @return {string} The name given to this TimeSeries
+         */
+
     }, {
         key: "name",
         value: function name() {
@@ -512,7 +541,9 @@ var TimeSeries = function () {
         }
 
         /**
-         * Access the Index, if this TimeSeries has one
+         * Fetch the timeseries Index, if it has one.
+         *
+         * @return {Index} The Index given to this TimeSeries
          */
 
     }, {
@@ -520,21 +551,56 @@ var TimeSeries = function () {
         value: function index() {
             return this._data.get("index");
         }
+
+        /**
+         * Fetch the timeseries Index, as a string, if it has one.
+         *
+         * @return {string} The Index, as a string, given to this TimeSeries
+         */
+
     }, {
         key: "indexAsString",
         value: function indexAsString() {
             return this.index() ? this.index().asString() : undefined;
         }
+
+        /**
+         * Fetch the timeseries Index, as a TimeRange, if it has one.
+         *
+         * @return {TimeRange} The Index, as a TimeRange, given to this TimeSeries
+         */
+
     }, {
         key: "indexAsRange",
         value: function indexAsRange() {
             return this.index() ? this.index().asTimerange() : undefined;
         }
+
+        /**
+         * Fetch the UTC flag, i.e. are the events in this TimeSeries in
+         * UTC or local time (if they are IndexedEvents an event might be
+         * "2014-08-31". The actual time range of that representation
+         * depends on where you are. Pond supports thinking about that in
+         * either as a UTC day, or a local day).
+         *
+         * @return {TimeRange} The Index, as a TimeRange, given to this TimeSeries
+         */
+
     }, {
         key: "isUTC",
         value: function isUTC() {
             return this._data.get("utc");
         }
+
+        /**
+         * Fetch the list of column names. This is determined by
+         * traversing though the events and collecting the set.
+         *
+         * Note: the order is not defined
+         *
+         * @return {array} List of columns
+         */
+
     }, {
         key: "columns",
         value: function columns() {
@@ -572,6 +638,8 @@ var TimeSeries = function () {
 
         /**
          * Returns the internal collection of events for this TimeSeries
+         *
+         * @return {Collection} The collection backing this TimeSeries
          */
 
     }, {
@@ -581,7 +649,13 @@ var TimeSeries = function () {
         }
 
         /**
-         * Returns the meta data about this TimeSeries as a JSON object
+         * Returns the meta data about this TimeSeries as a JSON object.
+         * Any extra data supplied to the TimeSeries constructor will be
+         * placed in the meta data object. This returns either all of that
+         * data as a JSON object, or a specific key if `key` is supplied.
+         *
+         * @param {string}   key   Optional specific part of the meta data
+         * @return {object}        The meta data
          */
 
     }, {
@@ -599,7 +673,9 @@ var TimeSeries = function () {
         //
 
         /**
-         * Returns the number of rows in the series.
+         * Returns the number of events in this TimeSeries
+         *
+         * @return {number} Count of events
          */
 
     }, {
@@ -609,7 +685,13 @@ var TimeSeries = function () {
         }
 
         /**
-         * Returns the number of rows in the series.
+         * Returns the number of valid items in this TimeSeries.
+         *
+         * Uses the fieldSpec to look up values in all events.
+         * It then counts the number that are considered valid, which
+         * specifically are not NaN, undefined or null.
+         *
+         * @return {number} Count of valid events
          */
 
     }, {
@@ -619,8 +701,10 @@ var TimeSeries = function () {
         }
 
         /**
-         * Returns the number of rows in the series. (Same as size())
-         * @return {number} Size of the series
+         * Returns the number of events in this TimeSeries. Alias
+         * for size().
+         *
+         * @return {number} Count of events
          */
 
     }, {
@@ -628,6 +712,15 @@ var TimeSeries = function () {
         value: function count() {
             return this.size();
         }
+
+        /**
+         * Returns the sum for the fieldspec
+         *
+         * @param {string} fieldSpec The field to sum over the TimeSeries
+         *
+         * @return {number} The sum
+         */
+
     }, {
         key: "sum",
         value: function sum(fieldSpec) {
@@ -643,26 +736,75 @@ var TimeSeries = function () {
         value: function min(fieldSpec) {
             return this._collection.min(fieldSpec);
         }
+
+        /**
+         * Aggregates the events in the TimeSeries down to their average
+         *
+         * @param  {String} fieldSpec The field to average over in the TimeSeries
+         *
+         * @return {number}           The average
+         */
+
     }, {
         key: "avg",
         value: function avg(fieldSpec) {
             return this._collection.avg(fieldSpec);
         }
+
+        /**
+         * Aggregates the events in the TimeSeries down to their mean (same as avg)
+         *
+         * @param  {String} fieldSpec The field to find the mean of within the collection
+         *
+         * @return {number}           The mean
+         */
+
     }, {
         key: "mean",
         value: function mean(fieldSpec) {
             return this._collection.mean(fieldSpec);
         }
+
+        /**
+         * Aggregates the events down to their medium value
+         *
+         * @param  {String} fieldSpec The field to aggregate over
+         *
+         * @return {number}           The resulting median value
+         */
+
     }, {
         key: "median",
         value: function median(fieldSpec) {
             return this._collection.median(fieldSpec);
         }
+
+        /**
+         * Aggregates the events down to their stdev
+         *
+         * @param  {String} fieldSpec The field to aggregate over
+         *
+         * @return {number}           The resulting stdev value
+         */
+
     }, {
         key: "stdev",
         value: function stdev(fieldSpec) {
             return this._collection.stdev(fieldSpec);
         }
+
+        /**
+         * Aggregates the events down using a user defined function to
+         * do the reduction.
+         *
+         * @param  {function} func    User defined reduction function. Will be
+         *                            passed a list of values. Should return a
+         *                            singe value.
+         * @param  {String} fieldSpec The field to aggregate over
+         *
+         * @return {number}           The resulting value
+         */
+
     }, {
         key: "aggregate",
         value: function aggregate(func, fieldSpec) {
@@ -670,7 +812,20 @@ var TimeSeries = function () {
         }
 
         /**
-         * Returns a new Pipeline with input source being this TimeSeries.
+         * Returns a new Pipeline with input source being initialized to
+         * this TimeSeries collection. This allows pipeline operations
+         * to be chained directly onto the TimeSeries to produce a new
+         * TimeSeries or Event result.
+         *
+         * @example
+         *
+         * ```
+         * timeseries.pipeline()
+         *     .offsetBy(1)
+         *     .offsetBy(2)
+         *     .to(CollectionOut, c => out = c);
+         * ```
+         *
          * @return {Pipeline} The Pipeline.
          */
 
@@ -775,9 +930,25 @@ var TimeSeries = function () {
         value: function is(series1, series2) {
             return _immutable2.default.is(series1._data, series2._data) && _collection2.default.is(series1._collection, series2._collection);
         }
+
+        /**
+         * Reduces a list of TimeSeries objects using a reducer function. This works
+         * by taking each event in each TimeSeries and collecting them together
+         * based on timestamp. All events for a given time are then merged together
+         * using the reducer function to produce a new Event. Those Events are then
+         * collected together to form a new TimeSeries.
+         *
+         * @param  {object}   data        Meta data for the resulting TimeSeries
+         * @param  {array}    seriesList  A list of TimeSeries objects
+         * @param  {func}     reducer     The reducer function
+         * @param  {string}   fieldSpec   The fields to map
+         *
+         * @return {TimeSeries}        The new TimeSeries
+         */
+
     }, {
-        key: "map",
-        value: function map(data, seriesList, mapper, fieldSpec) {
+        key: "timeseriesListReduce",
+        value: function timeseriesListReduce(data, seriesList, reducer, fieldSpec) {
             // for each series, map events to the same timestamp/index
             var eventMap = {};
             _underscore2.default.each(seriesList, function (series) {
@@ -820,24 +991,41 @@ var TimeSeries = function () {
                 }
             });
 
-            // for each key, merge the events associated with that key
+            // For each key, reduce the events associated with that key
+            // to a single new event
             var events = [];
             _underscore2.default.each(eventMap, function (eventsList) {
-                var event = mapper(eventsList, fieldSpec);
+                var event = reducer(eventsList, fieldSpec);
                 events.push(event);
             });
 
             return new TimeSeries((0, _extends3.default)({}, data, { events: events }));
         }
+
+        /**
+         * Takes a list of TimeSeries and merges them together to form a new
+         * Timeseries.
+         *
+         * Merging will produce a new Event only when events are conflict free, so
+         * it is useful to combine multiple TimeSeries which have different time ranges
+         * as well as combine TimeSeries which have different columns.
+         *
+         * @param  {object}              data       Meta data for the new TimeSeries
+         * @param  {array}               seriesList A list of TimeSeries
+         *
+         * @return {TimeSeries}                     The resulting TimeSeries
+         */
+
     }, {
-        key: "merge",
-        value: function merge(data, seriesList, fieldSpec) {
-            return TimeSeries.map(data, seriesList, _event2.default.merge, fieldSpec);
+        key: "timeSeriesListMerge",
+        value: function timeSeriesListMerge(data, seriesList) {
+            return TimeSeries.timeseriesListReduce(data, seriesList, _event2.default.merge);
         }
 
         /**
          * Takes a list of TimeSeries and sums them together to form a new
          * Timeseries.
+         *
          * @example
          *
          * ```
@@ -853,9 +1041,9 @@ var TimeSeries = function () {
          */
 
     }, {
-        key: "sum",
-        value: function sum(data, seriesList, fieldSpec) {
-            return TimeSeries.map(data, seriesList, _event2.default.sum, fieldSpec);
+        key: "timeSeriesListSum",
+        value: function timeSeriesListSum(data, seriesList, fieldSpec) {
+            return TimeSeries.timeseriesListReduce(data, seriesList, _event2.default.sum, fieldSpec);
         }
     }]);
     return TimeSeries;

--- a/src/collection.js
+++ b/src/collection.js
@@ -10,6 +10,7 @@
 
 import _ from "underscore";
 import Immutable from "immutable";
+
 import TimeRange from "./range";
 import Event from "./event";
 import BoundedIn from "./pipeline-in-bounded";
@@ -30,10 +31,11 @@ import { sum, avg, max, min, first, last, median, stdev } from "./functions";
  * of the collection and access a specific element with at().
  *
  * You can also perform aggregations of the events, map them, filter them
- * and clean them.
+ * clean them, etc.
  *
  * Collections form the backing structure for a TimeSeries, as well as
- * in Pipeline event processing.
+ * in Pipeline event processing. They are an instance of a BoundedIn, so
+ * they can be used as a pipeline source.
  */
 class Collection extends BoundedIn {
 
@@ -46,6 +48,7 @@ class Collection extends BoundedIn {
      * @param  {Boolean} [copyEvents] When using a the copy constructor
      * this specified whether or not to also copy all the events in this
      * collection. Generally you'll want to let it copy the events.
+     *
      * @return {Collection} The constructed Collection.
      */
     constructor(arg1, copyEvents = true) {
@@ -80,6 +83,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the Collection as a regular JSON object.
+     *
      * @return {Object} The JSON representation of this Collection
      */
     toJSON() {
@@ -89,6 +93,7 @@ class Collection extends BoundedIn {
     /**
      * Serialize out the Collection as a string. This will be the
      * string representation of `toJSON()`.
+     *
      * @return {string} The Collection serialized as a string.
      */
     toString() {
@@ -96,13 +101,15 @@ class Collection extends BoundedIn {
     }
 
     /**
-     * Returns the Event object type in this collection. Since
-     * Collections my only have one type of Event (Event, IndexedEvent
-     * or TimeRangeEvent) this will return that type. If no events
-     * have been added to the Collection it will return undefined.
+     * Returns the Event object type in this Collection.
+     *
+     * Since Collections may only have one type of event (`Event`, `IndexedEvent`
+     * or `TimeRangeEvent`) this will return that type. If no events
+     * have been added to the Collection it will return `undefined`.
      *
      * @return {Event|IndexedEvent|TimeRangeEvent} - The class of the type
-     * of events contained in this Collection.
+     *                                               of events contained in
+     *                                               this Collection.
      */
     type() {
         return this._type;
@@ -110,6 +117,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the number of events in this collection
+     *
      * @return {number} Count of events
      */
     size() {
@@ -120,8 +128,8 @@ class Collection extends BoundedIn {
      * Returns the number of valid items in this collection.
      *
      * Uses the fieldSpec to look up values in all events.
-     * It then counts the number that are considered valid,
-     * i.e. are not NaN, undefined or null.
+     * It then counts the number that are considered valid, which
+     * specifically are not NaN, undefined or null.
      *
      * @return {number} Count of valid events
      */
@@ -152,7 +160,9 @@ class Collection extends BoundedIn {
     }
 
     /**
-     * Returns an event in the Collection by its time.
+     * Returns an event in the Collection by its time. This is the same
+     * as calling `bisect` first and then using `at` with the index.
+     *
      * @param  {Date} time The time of the event.
      * @return {Event|TimeRangeEvent|IndexedEvent}
      */
@@ -165,6 +175,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the first event in the Collection.
+     *
      * @return {Event|TimeRangeEvent|IndexedEvent}
      */
     atFirst() {
@@ -175,6 +186,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the last event in the Collection.
+     *
      * @return {Event|TimeRangeEvent|IndexedEvent}
      */
     atLast() {
@@ -184,11 +196,12 @@ class Collection extends BoundedIn {
     }
 
     /**
-     * Returns the index that bisects the Collection at
-     * the time specified
-     * @param  {Data} t The time to bisect the Collection with
-     * @param  {number} b The position to begin searching at
-     * @return {number}   The row number that is the greatest, but still below t.
+     * Returns the index that bisects the Collection at the time specified.
+     *
+     * @param  {Data}    t   The time to bisect the Collection with
+     * @param  {number}  b   The position to begin searching at
+     *
+     * @return {number}      The row number that is the greatest, but still below t.
      */
     bisect(t, b) {
         const tms = t.getTime();
@@ -212,6 +225,7 @@ class Collection extends BoundedIn {
 
     /**
      * Generator to return all the events in the collection.
+     * 
      * @example
      * ```
      * for (let event of series.events()) {
@@ -227,6 +241,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the raw Immutable event list
+     *
      * @return {Immutable.List} All events as an Immutable List.
      */
     eventList() {
@@ -234,7 +249,8 @@ class Collection extends BoundedIn {
     }
 
     /**
-     * Returns a Javascript array of events
+     * Returns a Javascript array representation of the event list
+     *
      * @return {Array} All events as a Javascript Array.
      */
     eventListAsArray() {
@@ -251,7 +267,9 @@ class Collection extends BoundedIn {
 
     /**
      * From the range of times, or Indexes within the TimeSeries, return
-     * the extents of the TimeSeries as a TimeRange.
+     * the extents of the TimeSeries as a TimeRange. This is currently implemented
+     * by walking the events.
+     *
      * @return {TimeRange} The extents of the TimeSeries
      */
     range() {
@@ -269,9 +287,13 @@ class Collection extends BoundedIn {
     //
 
     /**
-     * Adds an event to the collection, returns a new Collection
+     * Adds an event to the collection, returns a new Collection. The event added
+     * can be an Event, TimeRangeEvent or IndexedEvent, but it must be of the
+     * same type as other events within the Collection.
+     *
      * @param {Event|TimeRangeEvent|IndexedEvent} event The event being added.
-     * @return {Collection} A new, modified, Collection.
+     *
+     * @return {Collection} A new, modified, Collection containing the new event.
      */
     addEvent(event) {
         this._check(event);
@@ -284,9 +306,11 @@ class Collection extends BoundedIn {
      * Perform a slice of events within the Collection, returns a new
      * Collection representing a portion of this TimeSeries from begin up to
      * but not including end.
-     * @param {Number} begin The position to begin slicing
-     * @param {Number} end The position to end slicing
-     * @return {Collection} A new, modified, Collection.
+     *
+     * @param {Number} begin   The position to begin slicing
+     * @param {Number} end     The position to end slicing
+     *
+     * @return {Collection}    The new, sliced, Collection.
      */
     slice(begin, end) {
         const sliced = new Collection(this._eventList.slice(begin, end));
@@ -298,8 +322,9 @@ class Collection extends BoundedIn {
      * Filter the collection's event list with the supplied function
      *
      * @param {function} func The filter function, that should return
-     * true or false when passed in an event.
-     * @return {Collection} A new, modified, Collection.
+     *                        true or false when passed in an event.
+     *
+     * @return {Collection}   A new, filtered, Collection.
      */
     filter(filterFunc) {
         const filteredEventList = [];
@@ -352,6 +377,7 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the number of events in this collection
+     *
      * @return {number} The number of events
      */
     count() {
@@ -360,6 +386,10 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the first value in the Collection for the fieldspec
+     *
+     * @param {string} fieldSpec The field to fetch
+     *
+     * @return {number} The first value
      */
     first(fieldSpec = "value") {
         return this.aggregate(first, fieldSpec);
@@ -367,6 +397,10 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the last value in the Collection for the fieldspec
+     *
+     * @param {string} fieldSpec The field to fetch
+     *
+     * @return {number} The last value
      */
     last(fieldSpec = "value") {
         return this.aggregate(last, fieldSpec);
@@ -374,6 +408,10 @@ class Collection extends BoundedIn {
 
     /**
      * Returns the sum Collection for the fieldspec
+     *
+     * @param {string} fieldSpec The field to sum over the collection
+     *
+     * @return {number} The sum
      */
     sum(fieldSpec = "value") {
         return this.aggregate(sum, fieldSpec);
@@ -381,8 +419,10 @@ class Collection extends BoundedIn {
 
     /**
      * Aggregates the events down to their average
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     *
+     * @param  {String} fieldSpec The field to average over the collection
+     *
+     * @return {number}           The average
      */
     avg(fieldSpec = "value") {
         return this.aggregate(avg, fieldSpec);
@@ -390,8 +430,10 @@ class Collection extends BoundedIn {
 
     /**
      * Aggregates the events down to their maximum value
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     *
+     * @param  {String} fieldSpec The field to find the max within the collection
+     *
+     * @return {number}           The max value for the field
      */
     max(fieldSpec = "value") {
         return this.aggregate(max, fieldSpec);
@@ -399,17 +441,21 @@ class Collection extends BoundedIn {
 
     /**
      * Aggregates the events down to their minimum value
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     *
+     * @param  {String} fieldSpec The field to find the min within the collection
+     *
+     * @return {number}           The min value for the field
      */
     min(fieldSpec = "value") {
         return this.aggregate(min, fieldSpec);
     }
 
     /**
-     * Aggregates the events down to their mean
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     * Aggregates the events down to their mean (same as avg)
+     *
+     * @param  {String} fieldSpec The field to find the mean of within the collection
+     *
+     * @return {number}           The mean
      */
     mean(fieldSpec = "value") {
         return this.avg(fieldSpec);
@@ -417,8 +463,10 @@ class Collection extends BoundedIn {
 
     /**
      * Aggregates the events down to their medium value
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     *
+     * @param  {String} fieldSpec The field to aggregate over
+     *
+     * @return {number}           The resulting median value
      */
     median(fieldSpec = "value") {
         return this.aggregate(median, fieldSpec);
@@ -426,8 +474,10 @@ class Collection extends BoundedIn {
 
     /**
      * Aggregates the events down to their stdev
-     * @param  {String} fieldSpec The field to aggregate
-     * @return {number}           The resulting value
+     *
+     * @param  {String} fieldSpec The field to aggregate over
+     *
+     * @return {number}           The resulting stdev value
      */
     stdev(fieldSpec = "value") {
         return this.aggregate(stdev, fieldSpec);
@@ -437,9 +487,11 @@ class Collection extends BoundedIn {
      * Aggregates the events down using a user defined function to
      * do the reduction.
      *
-     * @param  {function} func User defined reduction function. Will be
-     * passed a list of values. Should return a singe value.
-     * @param  {String} fieldSpec The field to aggregate
+     * @param  {function} func    User defined reduction function. Will be
+     *                            passed a list of values. Should return a
+     *                            singe value.
+     * @param  {String} fieldSpec The field to aggregate over
+     *
      * @return {number}           The resulting value
      */
     aggregate(func, fieldSpec = "value") {
@@ -471,8 +523,10 @@ class Collection extends BoundedIn {
      /**
       * Static function to compare two collections to each other. If the collections
       * are of the same instance as each other then equals will return true.
+      *
       * @param  {Collection} collection1
       * @param  {Collection} collection2
+      *
       * @return {bool} result
       */
     static equal(collection1, collection2) {
@@ -483,8 +537,10 @@ class Collection extends BoundedIn {
      /**
       * Static function to compare two collections to each other. If the collections
       * are of the same value as each other then equals will return true.
+      *
       * @param  {Collection} collection1
       * @param  {Collection} collection2
+      *
       * @return {bool} result
       */
     static is(collection1, collection2) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -346,22 +346,6 @@ class Collection extends BoundedIn {
         return new Collection(filteredEvents);
     }
 
-    /**
-     * Takes a fieldSpecList (list of column names) and collapses
-     * them to a new column which is the reduction of the matched columns
-     * in the fieldSpecList.
-     *
-     * @param  {array}      fieldSpecList  The list of columns
-     * @param  {string}     name           The resulting summed column name
-     * @param  {function}   reducer        Reducer function e.g. sum
-     * @param  {boolean}    append         Append the summed column, rather than replace
-     * @return {Collection}                A new, modified, Collection
-     */
-    collapse(fieldSpecList, name, reducer, append = true) {
-        const fsl = fieldSpecList.map(fieldSpec => this._fieldSpecToArray(fieldSpec));
-        return this.map(e => e.collapse(fsl, name, reducer, append));
-    }
-
     //
     // Aggregate the event list to a single value
     //

--- a/src/mapper.js
+++ b/src/mapper.js
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (c) 2016, The Regents of the University of California,
+ *  through Lawrence Berkeley National Laboratory (subject to receipt
+ *  of any required approvals from the U.S. Dept. of Energy).
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import Processor from "./processor";
+import { isPipeline } from "./pipeline";
+
+/**
+ * A processor which takes an operator as its only option
+ * and uses that to either output a new event
+ */
+export default class Mapper extends Processor {
+
+    constructor(arg1, options, observer) {
+        super(arg1, options, observer);
+
+        if (arg1 instanceof Mapper) {
+            const other = arg1;
+            this._op = other._op;
+        } else if (isPipeline(arg1)) {
+            this._op = options.op;
+        } else {
+            throw new Error("Unknown arg to Mapper constructor", arg1);
+        }
+    }
+
+    clone() {
+        return new Mapper(this);
+    }
+
+    /**
+     * Output an event that is remapped
+     */
+    addEvent(event) {
+        if (this.hasObservers()) {
+            this.emit(this._op(event));
+        }
+    }
+}

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -134,7 +134,6 @@ class Runner {
  * A pipeline manages a processing chain, for either batch or stream processing
  * of collection data.
  */
-
 class Pipeline {
 
     /**
@@ -295,8 +294,10 @@ class Pipeline {
      * is an object with {type, duration}.
      * type may be:
      *  * "Fixed"
+     *  * other types coming
+     *
      * duration is of the form:
-     *  * "30s", "5m" or "1d" etc
+     *  * "30s" or "1d" etc
      *
      * @return {Pipeline} The Pipeline
      */
@@ -359,11 +360,20 @@ class Pipeline {
     }
 
     /**
-     * Sets the condition under which accumulated collection will
+     * Sets the condition under which an accumulated collection will
      * be emitted. If specified before an aggregation this will control
      * when the resulting event will be emitted relative to the
-     * window accumulation. Current options are to emit on every event
-     * or just when the collection is complete.
+     * window accumulation. Current options are:
+     *  * to emit on every event, or
+     *  * just when the collection is complete, or
+     *  * when a flush signal is received, either manually calling done(),
+     *    or at the end of a bounded source
+     *
+     * The difference will depend on the output you want, how often
+     * you want to get updated, and if you need to get a partial state.
+     * There's currently no support for late data or watermarks. If an
+     * event passes comes in after a collection window, that collection
+     * is considered finished.
      *
      * @param {string} trigger A string indicating how to trigger a
      * Collection should be emitted. May be:
@@ -371,6 +381,7 @@ class Pipeline {
      *                     maintained collections will emit their result
      *     * "discard"   - when a collection is to be discarded,
      *                     first it will emit. But only then.
+     *     * "flush"     - when a flush signal is received
      *
      * @return {Pipeline} The Pipeline
      */
@@ -384,12 +395,13 @@ class Pipeline {
     //
 
     /**
-     * The "In" to get events from. The In needs to be able to
-     * iterate its events using for..of loop for bounded Ins, or
-     * be able to emit for unbounded Ins. The actual batch, or stream
-     * connection occurs when an output is defined with to().
+     * The source to get events from. The source needs to be able to
+     * iterate its events using `for..of` loop for bounded Ins, or
+     * be able to emit() for unbounded Ins. The actual batch, or stream
+     * connection occurs when an output is defined with `to()`.
      *
-     * from() returns a new Pipeline.
+     * Pipelines can be chained together since a source may be another
+     * Pipeline.
      *
      * @param {BoundedIn|UnboundedIn|Pipeline} src The source for the
      *                                             Pipeline, or another
@@ -406,17 +418,17 @@ class Pipeline {
     }
 
     /**
-     * Sets up the destination sink for the pipeline. The output should
-     * be a BatchOut subclass for a bounded input and a StreamOut subclass
-     * for an unbounded input.
+     * Sets up the destination sink for the pipeline.
      *
-     * For a batch mode connection, the output is connected and then the
-     * source input is iterated over to process all events into the pipeline and
-     * down to the out.
+     * For a batch mode connection, i.e. one with a Bounded source,
+     * the output is connected to a clone of the parts of the Pipeline dependencies
+     * that lead to this output. This is done by a Runner. The source input is
+     * then iterated over to process all events into the pipeline and though to the Out.
      *
      * For stream mode connections, the output is connected and from then on
      * any events added to the input will be processed down the pipeline to
      * the out.
+     *
      * @example
      * ```
      * const p = Pipeline()
@@ -468,6 +480,7 @@ class Pipeline {
 
     /**
      * Outputs the count of events
+     *
      * @param  {function}  observer The callback function. This will be
      *                              passed the count, the windowKey and
      *                              the groupByKey
@@ -488,7 +501,8 @@ class Pipeline {
     
     /**
      * Processor to offset a set of fields by a value. Mostly used for
-     * testing processor operations.
+     * testing processor and pipeline operations with a simple operation.
+     *
      * @param  {number} by              The amount to offset by
      * @param  {string|array} fieldSpec The field(s)
      *
@@ -507,6 +521,7 @@ class Pipeline {
     /**
      * Uses the current Pipeline windowing and grouping
      * state to build collections of events and aggregate them.
+     *
      * `IndexedEvent`s will be emitted out of the aggregator based
      * on the `emitOn` state of the Pipeline.
      *
@@ -516,18 +531,21 @@ class Pipeline {
      *
      * @example
      *
+     * ```
      * import { Pipeline, EventOut, functions } from "pondjs";
      * const { avg } = functions;
      *
      * const p = Pipeline()
      *   .from(input)
      *   .windowBy("1h")           // 1 day fixed windows
-     *   .emitOn("eachEvent")    // emit result on each event
+     *   .emitOn("eachEvent")      // emit result on each event
      *   .aggregate({in: avg, out: avg})
      *   .asEvents()
      *   .to(EventOut, {}, event => {
-     *      result[`${event.index()}`] = event;
+     *      result[`${event.index()}`] = event; // Result
      *   });
+     * ```
+     *
      * @param  {object} fields Fields and operators to be aggregated
      *
      * @return {Pipeline} The Pipeline
@@ -615,12 +633,27 @@ class Pipeline {
     }
 
     /**
-     * Select a subset of columns
+     * Collapse a subset of columns using a reducer function
      *
-     * @param {array|String} fieldSpec The columns to include in the output
-     * @param {string} name The result column name
-     * @param {boolean} append Add the new column to the existing ones, or replace them.
-     * @return {Pipeline} The Pipeline
+     * @example
+     *
+     * ```
+     *  const timeseries = new TimeSeries(inOutData);
+     *  Pipeline()
+     *      .from(timeseries)
+     *      .collapse(["in", "out"], "in_out_sum", sum)
+     *      .emitOn("flush")
+     *      .to(CollectionOut, c => {
+     *           const ts = new TimeSeries({name: "subset", collection: c});
+     *           ...
+     *      }, true);
+     * ```
+     * @param {array|String} fieldSpec The columns to collapse into the output
+     * @param {string}       name      The resulting output column's name
+     * @param {function}     reducer   Function to use to do the reduction
+     * @param {boolean}      append    Add the new column to the existing ones, or replace them.
+     *
+     * @return {Pipeline}              The Pipeline
      */
     collapse(fieldSpec, name, reducer, append) {
         const p = new Collapser(this, {
@@ -636,6 +669,7 @@ class Pipeline {
 
     /**
      * Take events up to the supplied limit, per key.
+     *
      * @param  {number} limit Integer number of events to take
      *
      * @return {Pipeline} The Pipeline
@@ -650,8 +684,7 @@ class Pipeline {
     }
 
     /**
-     * Converts incoming Events or IndexedEvents to
-     * TimeRangeEvents.
+     * Converts incoming Events or IndexedEvents to TimeRangeEvents.
      *
      * @param {object} options To convert from an Event you need
      * to convert a single time to a time range. To control this you

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -26,6 +26,8 @@ import TimeRangeEvent from "./timerangeevent";
 import IndexedEvent from "./indexedevent";
 import Selector from "./selector";
 import Collapser from "./collapser";
+import Mapper from "./mapper";
+
 
 /**
  * A runner is used to extract the chain of processing operations
@@ -561,6 +563,22 @@ class Pipeline {
             prev: this.last() ? this.last() : this
         });
         
+        return this._append(p);
+    }
+
+    /**
+     * Map the event stream using an operator
+     *
+     * @param  {function} op A function that returns a new Event
+     *
+     * @return {Pipeline} The Pipeline
+     */
+    map(op) {
+        const p = new Mapper(this, {
+            op,
+            prev: this.last() ? this.last() : this
+        });
+
         return this._append(p);
     }
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -21,6 +21,9 @@ function addPrevToChain(n, chain) {
     }
 }
 
+/**
+ * Base class for all Pipeline processors
+ */
 class Processor extends Observable {
 
     constructor(arg1, options) {

--- a/src/series.js
+++ b/src/series.js
@@ -458,6 +458,23 @@ class TimeSeries {
     }
 
     /**
+     * Takes an operator that is used to remap events from this TimeSeries to
+     * a new set of Events. The result is returned via the callback.
+     *
+     * @param  {function}   operator      An operator which will be passed each event and
+     *                                    which should return a new event.
+     * @param  {function}   cb            Callback containing a collapsed TimeSeries
+     */
+    map(op, cb) {
+        this.pipeline()
+            .emitOn("flush")
+            .map(op)
+            .to(CollectionOut, collection => {
+                cb(this.setCollection(collection));
+            }, true);
+    }
+
+    /**
      * Takes a fieldSpec (list of column names) and outputs to the callback just those
      * columns in a new TimeSeries.
      *
@@ -466,10 +483,11 @@ class TimeSeries {
      */
     select(fieldSpec, cb) {
         this.pipeline()
+            .emitOn("flush")
             .select(fieldSpec)
             .to(CollectionOut, collection => {
                 cb(this.setCollection(collection));
-            });
+            }, true);
     }
 
     /**

--- a/src/series.js
+++ b/src/series.js
@@ -45,8 +45,9 @@ function buildMetaData(meta) {
 
 /**
 A `TimeSeries` represents a series of events, with each event being a combination of:
- * time (or `TimeRange`, or `Index`)
- * data - corresponding set of key/values.
+
+ - time (or `TimeRange`, or `Index`)
+ - data - corresponding set of key/values.
 
 ### Construction
 
@@ -74,15 +75,15 @@ var series = new TimeSeries(data);
 
 The format of the data is as follows:
 
-  * **name** - optional, but a good practice
-  * **columns** - are necessary and give labels to the data in the points.
-  * **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
+ - **name** - optional, but a good practice
+ - **columns** - are necessary and give labels to the data in the points.
+ - **points** - are an array of tuples. Each row is at a different time (or timerange), and each value corresponds to the column labels.
    
-  As just hinted at, the first column may actually be:
+As just hinted at, the first column may actually be:
 
-   * "time"
-   * "timeRange" represented by a `TimeRange`
-   * "index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
+ - "time"
+ - "timeRange" represented by a `TimeRange`
+ - "index" - a time range represented by an `Index`. By using an index it is possible, for example, to refer to a specific month:
 
 ```javascript
 var availabilityData = {
@@ -261,6 +262,7 @@ class TimeSeries {
 
     /**
      * Gets the earliest time represented in the TimeSeries.
+     *
      * @return {Date} Begin time
      */
     begin() {
@@ -269,6 +271,7 @@ class TimeSeries {
 
     /**
      * Gets the latest time represented in the TimeSeries.
+     *
      * @return {Date} End time
      */
     end() {
@@ -276,16 +279,20 @@ class TimeSeries {
     }
 
     /**
-     * Access the series events via index
+     * Access a specific TimeSeries event via its position
+     *
+     * @param {number} pos The event position
      */
-    at(i) {
-        return this._collection.at(i);
+    at(pos) {
+        return this._collection.at(pos);
     }
 
     /**
      * Sets a new underlying collection for this TimeSeries.
-     * @param {Collection} collection The new collection
-     * @return {TimeSeries} A new TimeSeries
+     *
+     * @param {Collection}  collection The new collection
+     *
+     * @return {TimeSeries}            A new TimeSeries
      */
     setCollection(collection) {
         const result = new TimeSeries(this);
@@ -294,12 +301,12 @@ class TimeSeries {
     }
 
     /**
-     * Finds the index that is just less than the time t supplied.
-     * In other words every event at the returned index or less
-     * has a time before the supplied t, and every sample after the
-     * index has a time later than the supplied t.
+     * Returns the index that bisects the TimeSeries at the time specified.
      *
-     * Optionally supply a begin index to start searching from.
+     * @param  {Data}    t   The time to bisect the TimeSeries with
+     * @param  {number}  b   The position to begin searching at
+     *
+     * @return {number}      The row number that is the greatest, but still below t.
      */
     bisect(t, b) {
         return this._collection.bisect(t, b);
@@ -307,8 +314,13 @@ class TimeSeries {
 
     /**
      * Perform a slice of events within the TimeSeries, returns a new
-     * TimeSeries representing a portion of this TimeSeries from begin up to
-     * but not including end.
+     * TimeSeries representing a portion of this TimeSeries from
+     * begin up to but not including end.
+     *
+     * @param {Number} begin   The position to begin slicing
+     * @param {Number} end     The position to end slicing
+     *
+     * @return {TimeSeries}    The new, sliced, TimeSeries.
      */
     slice(begin, end) {
         const sliced = this._collection.slice(begin, end);
@@ -316,9 +328,13 @@ class TimeSeries {
     }
 
     /**
-     * Perform a basic cleaning operation of the fieldSpec specified
-     * by removing all events in the underlying collection which are
-     * NaN, null or undefined.
+     * Returns a new Collection by testing the fieldSpec
+     * values for being valid (not NaN, null or undefined).
+     *
+     * The resulting TimeSeries will be clean (for that fieldSpec).
+     *
+     * @param {string}      fieldSpec The field to test
+     * @return {TimeSeries}           A new, modified, TimeSeries.
      */
     clean(fieldSpec) {
         const cleaned = this._collection.clean(fieldSpec);
@@ -326,7 +342,14 @@ class TimeSeries {
     }
 
     /**
-     *  Generator to allow for..of loops over series.events()
+     * Generator to return all the events in the collection.
+     *
+     * @example
+     * ```
+     * for (let event of timeseries.events()) {
+     *     console.log(event.toString());
+     * }
+     * ```
      */
     * events() {
         for (let i = 0; i < this.size(); i++) {
@@ -339,30 +362,63 @@ class TimeSeries {
     // Access meta data about the series
     //
 
+    /**
+     * Fetch the timeseries name
+     *
+     * @return {string} The name given to this TimeSeries
+     */
     name() {
         return this._data.get("name");
     }
 
     /**
-     * Access the Index, if this TimeSeries has one
+     * Fetch the timeseries Index, if it has one.
+     *
+     * @return {Index} The Index given to this TimeSeries
      */
-
     index() {
         return this._data.get("index");
     }
 
+    /**
+     * Fetch the timeseries Index, as a string, if it has one.
+     *
+     * @return {string} The Index, as a string, given to this TimeSeries
+     */
     indexAsString() {
         return this.index() ? this.index().asString() : undefined;
     }
 
+    /**
+     * Fetch the timeseries Index, as a TimeRange, if it has one.
+     *
+     * @return {TimeRange} The Index, as a TimeRange, given to this TimeSeries
+     */
     indexAsRange() {
         return this.index() ? this.index().asTimerange() : undefined;
     }
 
+    /**
+     * Fetch the UTC flag, i.e. are the events in this TimeSeries in
+     * UTC or local time (if they are IndexedEvents an event might be
+     * "2014-08-31". The actual time range of that representation
+     * depends on where you are. Pond supports thinking about that in
+     * either as a UTC day, or a local day).
+     *
+     * @return {TimeRange} The Index, as a TimeRange, given to this TimeSeries
+     */
     isUTC() {
         return this._data.get("utc");
     }
 
+    /**
+     * Fetch the list of column names. This is determined by
+     * traversing though the events and collecting the set.
+     *
+     * Note: the order is not defined
+     *
+     * @return {array} List of columns
+     */
     columns() {
         const c = {};
         for (const e of this._collection.events()) {
@@ -374,13 +430,21 @@ class TimeSeries {
 
     /**
      * Returns the internal collection of events for this TimeSeries
+     *
+     * @return {Collection} The collection backing this TimeSeries
      */
     collection() {
         return this._collection;
     }
 
     /**
-     * Returns the meta data about this TimeSeries as a JSON object
+     * Returns the meta data about this TimeSeries as a JSON object.
+     * Any extra data supplied to the TimeSeries constructor will be
+     * placed in the meta data object. This returns either all of that
+     * data as a JSON object, or a specific key if `key` is supplied.
+     *
+     * @param {string}   key   Optional specific part of the meta data
+     * @return {object}        The meta data
      */
     meta(key) {
         if (!key) {
@@ -395,27 +459,44 @@ class TimeSeries {
     //
 
     /**
-     * Returns the number of rows in the series.
+     * Returns the number of events in this TimeSeries
+     *
+     * @return {number} Count of events
      */
     size() {
         return this._collection.size();
     }
 
     /**
-     * Returns the number of rows in the series.
+     * Returns the number of valid items in this TimeSeries.
+     *
+     * Uses the fieldSpec to look up values in all events.
+     * It then counts the number that are considered valid, which
+     * specifically are not NaN, undefined or null.
+     *
+     * @return {number} Count of valid events
      */
     sizeValid(fieldSpec) {
         return this._collection.sizeValid(fieldSpec);
     }
 
     /**
-     * Returns the number of rows in the series. (Same as size())
-     * @return {number} Size of the series
+     * Returns the number of events in this TimeSeries. Alias
+     * for size().
+     *
+     * @return {number} Count of events
      */
     count() {
         return this.size();
     }
 
+    /**
+     * Returns the sum for the fieldspec
+     *
+     * @param {string} fieldSpec The field to sum over the TimeSeries
+     *
+     * @return {number} The sum
+     */
     sum(fieldSpec) {
         return this._collection.sum(fieldSpec);
     }
@@ -428,28 +509,80 @@ class TimeSeries {
         return this._collection.min(fieldSpec);
     }
 
+    /**
+     * Aggregates the events in the TimeSeries down to their average
+     *
+     * @param  {String} fieldSpec The field to average over in the TimeSeries
+     *
+     * @return {number}           The average
+     */
     avg(fieldSpec) {
         return this._collection.avg(fieldSpec);
     }
 
+    /**
+     * Aggregates the events in the TimeSeries down to their mean (same as avg)
+     *
+     * @param  {String} fieldSpec The field to find the mean of within the collection
+     *
+     * @return {number}           The mean
+     */
     mean(fieldSpec) {
         return this._collection.mean(fieldSpec);
     }
 
+    /**
+     * Aggregates the events down to their medium value
+     *
+     * @param  {String} fieldSpec The field to aggregate over
+     *
+     * @return {number}           The resulting median value
+     */
     median(fieldSpec) {
         return this._collection.median(fieldSpec);
     }
 
+    /**
+     * Aggregates the events down to their stdev
+     *
+     * @param  {String} fieldSpec The field to aggregate over
+     *
+     * @return {number}           The resulting stdev value
+     */
     stdev(fieldSpec) {
         return this._collection.stdev(fieldSpec);
     }
 
+    /**
+     * Aggregates the events down using a user defined function to
+     * do the reduction.
+     *
+     * @param  {function} func    User defined reduction function. Will be
+     *                            passed a list of values. Should return a
+     *                            singe value.
+     * @param  {String} fieldSpec The field to aggregate over
+     *
+     * @return {number}           The resulting value
+     */
     aggregate(func, fieldSpec) {
         return this._collection.aggregate(func, fieldSpec);
     }
 
     /**
-     * Returns a new Pipeline with input source being this TimeSeries.
+     * Returns a new Pipeline with input source being initialized to
+     * this TimeSeries collection. This allows pipeline operations
+     * to be chained directly onto the TimeSeries to produce a new
+     * TimeSeries or Event result.
+     *
+     * @example
+     *
+     * ```
+     * timeseries.pipeline()
+     *     .offsetBy(1)
+     *     .offsetBy(2)
+     *     .to(CollectionOut, c => out = c);
+     * ```
+     *
      * @return {Pipeline} The Pipeline.
      */
     pipeline() {
@@ -543,7 +676,21 @@ class TimeSeries {
                 Collection.is(series1._collection, series2._collection));
     }
 
-    static map(data, seriesList, mapper, fieldSpec) {
+    /**
+     * Reduces a list of TimeSeries objects using a reducer function. This works
+     * by taking each event in each TimeSeries and collecting them together
+     * based on timestamp. All events for a given time are then merged together
+     * using the reducer function to produce a new Event. Those Events are then
+     * collected together to form a new TimeSeries.
+     *
+     * @param  {object}   data        Meta data for the resulting TimeSeries
+     * @param  {array}    seriesList  A list of TimeSeries objects
+     * @param  {func}     reducer     The reducer function
+     * @param  {string}   fieldSpec   The fields to map
+     *
+     * @return {TimeSeries}        The new TimeSeries
+     */
+    static timeseriesListReduce(data, seriesList, reducer, fieldSpec) {
         // for each series, map events to the same timestamp/index
         const eventMap = {};
         _.each(seriesList, (series) => {
@@ -565,23 +712,40 @@ class TimeSeries {
             }
         });
 
-        // for each key, merge the events associated with that key
+        // For each key, reduce the events associated with that key
+        // to a single new event
         const events = [];
         _.each(eventMap, (eventsList) => {
-            const event = mapper(eventsList, fieldSpec);
+            const event = reducer(eventsList, fieldSpec);
             events.push(event);
         });
 
         return new TimeSeries({...data, events});
     }
 
-    static merge(data, seriesList, fieldSpec) {
-        return TimeSeries.map(data, seriesList, Event.merge, fieldSpec);
+    /**
+     * Takes a list of TimeSeries and merges them together to form a new
+     * Timeseries.
+     *
+     * Merging will produce a new Event only when events are conflict free, so
+     * it is useful to combine multiple TimeSeries which have different time ranges
+     * as well as combine TimeSeries which have different columns.
+     *
+     * @param  {object}              data       Meta data for the new TimeSeries
+     * @param  {array}               seriesList A list of TimeSeries
+     *
+     * @return {TimeSeries}                     The resulting TimeSeries
+     */
+    static timeSeriesListMerge(data, seriesList) {
+        return TimeSeries.timeseriesListReduce(data,
+                                               seriesList,
+                                               Event.merge);
     }
 
     /**
      * Takes a list of TimeSeries and sums them together to form a new
      * Timeseries.
+     *
      * @example
      *
      * ```
@@ -595,8 +759,11 @@ class TimeSeries {
      * @param  {object|array|string} fieldSpec  Which fields to use in the sum
      * @return {TimeSeries}                     The resulting TimeSeries
      */
-    static sum(data, seriesList, fieldSpec) {
-        return TimeSeries.map(data, seriesList, Event.sum, fieldSpec);
+    static timeSeriesListSum(data, seriesList, fieldSpec) {
+        return TimeSeries.timeseriesListReduce(data,
+                                               seriesList,
+                                               Event.sum,
+                                               fieldSpec);
     }
 }
 

--- a/test/tests/pipeline.test.js
+++ b/test/tests/pipeline.test.js
@@ -757,6 +757,25 @@ describe("Pipeline", () => {
 
     });
 
+    describe("Mapping in batch", () => {
+
+        it("should be able map one event to a modified event", done => {
+
+            const timeseries = new TimeSeries(inOutData);
+            Pipeline()
+                .from(timeseries)
+                .map(e => e.setData({in: e.get("out"), out: e.get("in")}))
+                .emitOn("flush")
+                .to(CollectionOut, c => {
+                    const ts = new TimeSeries({name: "subset", collection: c});
+                    expect(ts.at(0).get("in")).to.equal(37);
+                    expect(ts.at(0).get("out")).to.equal(80);
+                    expect(ts.size()).to.equal(3);
+                    done();
+                }, /*flush=*/true);
+        });
+    });
+
     describe("Take n events in batch", () => {
 
         it("should be able to take 10 events from a TimeSeries", done => {

--- a/test/tests/pipeline.test.js
+++ b/test/tests/pipeline.test.js
@@ -27,7 +27,7 @@ import Event from "../../src/event";
 import TimeRangeEvent from "../../src/timerangeevent";
 import IndexedEvent from "../../src/indexedevent";
 
-import { keep, avg, sum } from "../../src/functions.js";
+import { keep, avg, sum, max } from "../../src/functions.js";
 
 const eventList1 = [
     new Event(new Date("2015-04-22T03:30:00Z"), {in: 1, out: 2}),
@@ -730,6 +730,31 @@ describe("Pipeline", () => {
                     done();
                 }, /*flush=*/true);
         });
+
+        it("should be able chain collapse operations together", done => {
+
+            const timeseries = new TimeSeries(inOutData);
+            Pipeline()
+                .from(timeseries)
+                .collapse(["in", "out"], "in_out_sum", sum, true)
+                .collapse(["in", "out"], "in_out_max", max, true)
+                .emitOn("flush")
+                .to(CollectionOut, c => {
+                    
+                    const ts = new TimeSeries({name: "subset", collection: c});
+                    
+                    expect(ts.at(0).get("in_out_sum")).to.equal(117);
+                    expect(ts.at(1).get("in_out_sum")).to.equal(110);
+                    expect(ts.at(2).get("in_out_sum")).to.equal(108);
+
+                    expect(ts.at(0).get("in_out_max")).to.equal(80);
+                    expect(ts.at(1).get("in_out_max")).to.equal(88);
+                    expect(ts.at(2).get("in_out_max")).to.equal(56);
+
+                    done();
+                }, /*flush=*/true);
+        });
+
     });
 
     describe("Take n events in batch", () => {

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -163,9 +163,9 @@ const trafficNEWYtoBNL = {
     name: "NEWY to BNL",
     columns: ["time","out"],
     points: [
-        [1441051950000,22034579982.4],
-        [1441051980000,24783871443.2],
-        [1441052010000,26907368572.800003]
+        [1441051950000, 22034579982.4],
+        [1441051980000, 24783871443.2],
+        [1441052010000, 26907368572.800003]
     ]
 };
 
@@ -897,6 +897,23 @@ describe("TimeSeries", () => {
 
             done();
         }));
+    });
+
+    describe("TimeSeries remapping", () => {
+
+        it("can reverse the values in this timeseries", (done) => {
+            const timeseries = new TimeSeries(interfaceData);
+            expect(timeseries.columns()).to.eql(["in", "out"]);
+
+            timeseries.map(e => e.setData({in: e.get("out"), out: e.get("in")}), ts => {
+                expect(ts.at(0).get("in")).to.equal(34);
+                expect(ts.at(0).get("out")).to.equal(52);
+                expect(ts.size()).to.equal(timeseries.size());
+            });
+
+            done();
+        });
+
     });
 
 });

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -19,7 +19,7 @@ import Event from "../../src/event";
 import TimeRangeEvent from "../../src/timerangeevent";
 import TimeSeries from "../../src/series.js";
 import TimeRange from "../../src/range.js";
-import { sum, max, avg } from "../../src/functions";
+import { sum, max } from "../../src/functions";
 
 const data = {
     name: "traffic",
@@ -848,35 +848,28 @@ describe("TimeSeries", () => {
 
         it("can collapse a timeseries into a new timeseries that is the sum of two columns", (done) => {
             const ts = new TimeSeries(sumPart1);
-            const sums = ts.collapse(["in", "out"], "sum", sum, false);
+            ts.collapse(["in", "out"], "sum", sum, false, sums => {
+                expect(sums.at(0).get("sum")).to.equal(7);
+                expect(sums.at(1).get("sum")).to.equal(9);
+                expect(sums.at(2).get("sum")).to.equal(11);
+                expect(sums.at(3).get("sum")).to.equal(13);
 
-            // 7, 9, 11, 13
-            expect(sums.at(0).get("sum")).to.equal(7);
-            expect(sums.at(1).get("sum")).to.equal(9);
-            expect(sums.at(2).get("sum")).to.equal(11);
-            expect(sums.at(3).get("sum")).to.equal(13);
-
-            done();
+                done();
+            });
         });
 
         it("can collapse a timeseries into a new timeseries that is the max of two columns", (done) => {
-            const ts = new TimeSeries(sumPart2);
-            const tss = ts
-                .collapse(["in", "out"], "max_in_out", max)
-                .collapse(["in", "out"], "avg_in_out", avg);
-
-            expect(tss.at(0).get("max_in_out")).to.equal(9);
-            expect(tss.at(1).get("max_in_out")).to.equal(7);
-            expect(tss.at(2).get("max_in_out")).to.equal(5);
-            expect(tss.at(3).get("max_in_out")).to.equal(4);
-
-            expect(tss.at(0).get("avg_in_out")).to.equal(5);
-            expect(tss.at(1).get("avg_in_out")).to.equal(4.5);
-            expect(tss.at(2).get("avg_in_out")).to.equal(4);
-            expect(tss.at(3).get("avg_in_out")).to.equal(3.5);
-
-            done();
+            const timeseries = new TimeSeries(sumPart2);
+            timeseries
+                .collapse(["in", "out"], "max_in_out", max, true, ts => {
+                    expect(ts.at(0).get("max_in_out")).to.equal(9);
+                    expect(ts.at(1).get("max_in_out")).to.equal(7);
+                    expect(ts.at(2).get("max_in_out")).to.equal(5);
+                    expect(ts.at(3).get("max_in_out")).to.equal(4);
+                    done();
+                });
         });
+
     });
 
     describe("TimeSeries column selection", () => {

--- a/test/tests/series.test.js
+++ b/test/tests/series.test.js
@@ -787,7 +787,8 @@ describe("TimeSeries", () => {
         it("can merge two timeseries columns together using merge", (done) => {
             const inTraffic = new TimeSeries(trafficDataIn);
             const outTraffic = new TimeSeries(trafficDataOut);
-            const trafficSeries = TimeSeries.merge({name: "traffic"}, [inTraffic, outTraffic]);
+            const trafficSeries = TimeSeries.timeSeriesListMerge(
+                {name: "traffic"}, [inTraffic, outTraffic]);
             expect(trafficSeries.at(2).get("in")).to.equal(26);
             expect(trafficSeries.at(2).get("out")).to.equal(67);
             done();
@@ -796,7 +797,9 @@ describe("TimeSeries", () => {
         it("can append two timeseries together using merge", (done) => {
             const tile1 = new TimeSeries(partialTraffic1);
             const tile2 = new TimeSeries(partialTraffic2);
-            const trafficSeries = TimeSeries.merge({name: "traffic", source: "router"}, [tile1, tile2]);
+            const trafficSeries = TimeSeries.timeSeriesListMerge(
+                {name: "traffic", source: "router"}, [tile1, tile2]
+            );
             expect(trafficSeries.size()).to.equal(8);
             expect(trafficSeries.at(0).get()).to.equal(34);
             expect(trafficSeries.at(1).get()).to.equal(13);
@@ -814,7 +817,9 @@ describe("TimeSeries", () => {
         it("can merge two series and preserve the correct time format", (done) => {
             const inTraffic = new TimeSeries(trafficBNLtoNEWY);
             const outTraffic = new TimeSeries(trafficNEWYtoBNL);
-            const trafficSeries = TimeSeries.merge({name: "traffic"}, [inTraffic, outTraffic]);
+            const trafficSeries = TimeSeries.timeSeriesListMerge(
+                {name: "traffic"}, [inTraffic, outTraffic]
+            );
             expect(trafficSeries.at(0).timestampAsUTCString()).to.equal("Mon, 31 Aug 2015 20:12:30 GMT");
             expect(trafficSeries.at(1).timestampAsUTCString()).to.equal("Mon, 31 Aug 2015 20:13:00 GMT");
             expect(trafficSeries.at(2).timestampAsUTCString()).to.equal("Mon, 31 Aug 2015 20:13:30 GMT");
@@ -827,7 +832,11 @@ describe("TimeSeries", () => {
         it("can merge two timeseries into a new timeseries that is the sum", (done) => {
             const part1 = new TimeSeries(sumPart1);
             const part2 = new TimeSeries(sumPart2);
-            const sum = TimeSeries.sum({name: "sum"}, [part1, part2], ["in", "out"]);
+            const sum = TimeSeries.timeSeriesListSum(
+                {name: "sum"},
+                [part1, part2],
+                ["in", "out"]
+            );
 
             //10, 9, 8, 7
             expect(sum.at(0).get("in")).to.equal(10);

--- a/website/styles/app.css
+++ b/website/styles/app.css
@@ -14,6 +14,10 @@ pre {
     border-radius: 0px !important;
 }
 
+h3 {
+  font-size: 18px
+}
+
 .navbar-fixed-top {
     background: #000000 !important;
     border-bottom-style: solid !important;


### PR DESCRIPTION
As discussed on slack, this uses the pipeline code within TimeSeries. This has the advantage of the API adapting to multiprocessor and async operations in the future, especially when run in node.js. It also unifies the code to one place.

 * Added map() pipeline processor for general remapping of events
 * collapse(), select() and map() on the TimeSeries API are now implemented with Pipeline chains
 * TimeSeries static functions for dealing with lists of TimeSeries objects are renamed so that PyPond can use the same names