### PR TITLE
Fix #83 - TimeSeries.crop slices to incorrect indexes

### DIFF
--- a/src/pond/lib/timeseries.js
+++ b/src/pond/lib/timeseries.js
@@ -420,9 +420,12 @@ class TimeSeries {
      * @return {TimeSeries}    The new, cropped, TimeSeries.
      */
     crop(timerange) {
-        const beginPos = this.bisect(timerange.begin());
+        const timerangeBegin = timerange.begin();
+        let beginPos = this.bisect(timerangeBegin);
+        const bisectedEventOutsideRange = this.at(beginPos).timestamp() < timerangeBegin;
+        beginPos = bisectedEventOutsideRange ? beginPos + 1 : beginPos;
         const endPos = this.bisect(timerange.end(), beginPos);
-        return this.slice(beginPos, endPos);
+        return this.slice(beginPos, endPos + 1);
     }
 
     /**


### PR DESCRIPTION
Assumptions:
- any event with a timestamp at or before the last one in the passed range should be included
- any event before the first one in the passed range should be excluded

This always adds 1 to the final index (since `.slice` is not inclusive) and it checks the bisected event's timestamp against the start of the given timerange, adding 1 if the bisected event comes before the start of the requested range.

---

This doesn't address an existing issue (might not be a bug, but it seems un-ideal) where calling `toJSON()` for an empty TimeSeries will return undefined.
```js
var ts1 = new TimeSeries({name:'foo',columns:['time','value'],points:[[1504014065240,1],[1504014065243,2],[1504014065244,3],[1504014065245,4],[1504014065249,5]]})

var ts2 = ts1.crop(new TimeRange([1504014065246,1504014065247]));
// ts2.toJSON() is undefined in both the old and new implementation
```