### PR TITLE
Restore array constructor for Timerange 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 examples-bundle.js
 coverage
 .vscode
+.idea

--- a/packages/pond/src/timerange.ts
+++ b/packages/pond/src/timerange.ts
@@ -52,6 +52,7 @@ export class TimeRange extends Key {
      *     a `Moment`, or a `ms` timestamp.
      */
     constructor(arg: TimeRange | Immutable.List<Date>);
+    constructor(arg: Array<number>);
     constructor(begin: Date, end: Date);
     constructor(begin: Time, end: Time);
     constructor(begin: Moment, end: Moment);
@@ -64,6 +65,12 @@ export class TimeRange extends Key {
         } else if (arg1 instanceof Immutable.List) {
             const rangeList = arg1;
             this._range = rangeList;
+        } else if (arg1 instanceof Array) {
+            const rangeArray = arg1;
+            this._range = new Immutable.List([
+                new Date(rangeArray[0]),
+                new Date(rangeArray[1])
+            ]);
         } else {
             const b = arg1;
             const e = arg2;
@@ -287,6 +294,7 @@ export class TimeRange extends Key {
  * to maintain consistency across an application.
  */
 function timerange(arg: TimeRange | Immutable.List<Date>);
+function timerange(arg: Array<number>)
 function timerange(begin: Date, end: Date);
 function timerange(begin: Time, end: Time);
 function timerange(begin: Moment, end: Moment);

--- a/packages/pond/tests/timerange.test.ts
+++ b/packages/pond/tests/timerange.test.ts
@@ -38,6 +38,11 @@ it("can create a new range with two millisecond timestamps", () => {
     expect(range.toJSON()).toEqual({ timerange: [1326309060000, 1329941520000] });
 });
 
+it("can create a new range with two millisecond tiemstamps as an array", () => {
+    const range = timerange([1326309060000, 1329941520000]);
+    expect(range.toJSON()).toEqual({ timerange: [1326309060000, 1329941520000] });
+})
+
 it("can be used to give a new range", () => {
     const beginTime = moment("2012-01-11 1:11", fmt).toDate();
     const endTime = moment("2012-02-12 2:12", fmt).toDate();


### PR DESCRIPTION
v1.0 lacked support for constructing a time range with a JavaScript array of milliseconds (see issue #97), even though this was [documented](https://esnet-pondjs.appspot.com/#/timerange) as one of the primary constructor methods in v0.8.7, including remaining in the docstring for the constructor in v1.0. 

This PR restores that constructor, and adds an accompanying test. 