### PR TITLE
Allow branching and filtering of event streams

### DIFF
--- a/packages/pond/src/stream.ts
+++ b/packages/pond/src/stream.ts
@@ -332,6 +332,15 @@ class AggregationNode<T extends Key> extends Node<KeyedCollection<T>, Event<Inde
 // Stream interfaces
 //
 
+export class StreamInterface<T extends Key, U extends Key> {
+    // tslint:disable-line:max-classes-per-file
+    constructor(protected stream: Stream<U>) {}
+
+    getStream() {
+        return this.stream;
+    }
+}
+
 /**
  * An `EventStream` is the interface to the stream provided for manipulation of
  * parts of the streaming pipeline that map a stream of Events of type <T>.
@@ -348,9 +357,11 @@ class AggregationNode<T extends Key> extends Node<KeyedCollection<T>, Event<Inde
  * nodes created by the API at this point of the stream will expect Events of type T,
  * and will output new Events, potentially of a different type.
  */
-export class EventStream<T extends Key, U extends Key> {
+export class EventStream<T extends Key, U extends Key> extends StreamInterface<T, U> {
     // tslint:disable-line:max-classes-per-file
-    constructor(private stream: Stream<U>) {}
+    constructor(stream: Stream<U>) {
+        super(stream);
+    }
 
     /**
      * @private
@@ -584,8 +595,11 @@ export class EventStream<T extends Key, U extends Key> {
  *
  */
 // tslint:disable-next-line:max-classes-per-file
-export class KeyedCollectionStream<T extends Key, U extends Key> {
-    constructor(private stream: Stream<U>) {}
+export class KeyedCollectionStream<T extends Key, U extends Key> extends StreamInterface<T, U> {
+    // tslint:disable-line:max-classes-per-file
+    constructor(stream: Stream<U>) {
+        super(stream);
+    }
 
     /**
      * @private
@@ -804,6 +818,10 @@ export class Stream<U extends Key = Time> {
     private head: Node<Base, Base>;
     private tail: Node<Base, Base>;
 
+    constructor(upstream?: Stream<U>) {
+        this.head = this.tail = upstream ? upstream.tail : null;
+    }
+
     /**
      * @private
      */
@@ -859,8 +877,8 @@ export class Stream<U extends Key = Time> {
     }
 }
 
-function streamFactory<T extends Key>(): EventStream<T, T> {
-    const s = new Stream<T>();
+function streamFactory<T extends Key>(upstream?: StreamInterface<T, T>): EventStream<T, T> {
+    const s = upstream ? new Stream<T>(upstream.getStream()) : new Stream<T>();
     return s.addEventMappingNode(new EventInputNode<T>());
 }
 

--- a/packages/pond/tests/stream.test.ts
+++ b/packages/pond/tests/stream.test.ts
@@ -202,6 +202,7 @@ describe("Streaming", () => {
         expect(result[1].get("a")).toEqual(4);
         expect(result[2].get("a")).toEqual(6);
     });
+
     it("can do streaming event flatmap", () => {
         const eventsIn = [
             event(time(Date.UTC(2015, 2, 14, 7, 57, 0)), Immutable.Map({ a: 1 })),
@@ -237,6 +238,31 @@ describe("Streaming", () => {
         expect(result[3].get("a")).toEqual(30);
         expect(result[4].get("a")).toEqual(31);
         expect(result[5].get("a")).toEqual(32);
+    });
+
+    it("can do filtering on a stream of events", () => {
+        const eventsIn = [
+            event(time(Date.UTC(2015, 2, 14, 7, 31, 0)), Immutable.Map({ a: 1 })),
+            event(time(Date.UTC(2015, 2, 14, 7, 32, 0)), Immutable.Map({ a: 2 })),
+            event(time(Date.UTC(2015, 2, 14, 7, 33, 0)), Immutable.Map({ a: 3 })),
+            event(time(Date.UTC(2015, 2, 14, 7, 34, 0)), Immutable.Map({ a: 4 })),
+            event(time(Date.UTC(2015, 2, 14, 7, 35, 0)), Immutable.Map({ a: 5 }))
+        ];
+
+        const result: Event[] = [];
+
+        const source = stream<Time>()
+            .filter(e => e.get("a") % 2 !== 0)
+            .output(evt => {
+                const e = evt as Event<Time>;
+                result.push(e);
+            });
+
+        eventsIn.forEach(e => source.addEvent(e));
+
+        expect(result[0].get("a")).toEqual(1);
+        expect(result[1].get("a")).toEqual(3);
+        expect(result[2].get("a")).toEqual(5);
     });
 
     it("can selection of specific event fields", () => {


### PR DESCRIPTION
Fixes #101 to Extended the `Stream()` constructor to optionally accept another upstream `Stream`. This allows streams to be branched. Also adds a `filter()` function to the stream API.

### Branches

For the user, the `stream()` factory function accepts either of the two interfaces (`EventStream` or `KeyedCollectionStream`) in the form of the new base class `StreamInterface`. A `StreamInterface` holds just the reference back to the `Stream` itself that both interfaces before maintained. In this way, either interface can be passed into the `stream()` factory function and the nodes in that interface's `Stream` can be connected correctly to the new `Stream`.

Here is an example:

```typescript
const eventsIn = [
    event(time(Date.UTC(2015, 2, 14, 7, 57, 0)), Immutable.Map({ a: 1 })),
    event(time(Date.UTC(2015, 2, 14, 7, 58, 0)), Immutable.Map({ a: 2 })),
    event(time(Date.UTC(2015, 2, 14, 7, 59, 0)), Immutable.Map({ a: 3 }))
];

const result1: Event[] = [];
const result2: Event[] = [];

const source = stream<Time>().map(
    e => event(e.getKey(), Immutable.Map({ a: e.get("a") * 2 })) // 2, 4, 6
);

stream<Time>(source)
    .map(e => event(e.getKey(), Immutable.Map({ a: e.get("a") * 3 }))) // 6, 12, 18
    .output(evt => {
        const e = evt as Event<Time>;
        result1.push(e);
    });

stream<Time>(source)
    .map(e => event(e.getKey(), Immutable.Map({ a: e.get("a") * 4 }))) // 8, 16, 24
    .output(evt => {
        const e = evt as Event<Time>;
        result2.push(e);
    });

eventsIn.forEach(e => source.addEvent(e));
```

### Filtering

Also adds a `filter()` function to `stream` API.

```typescript
const source = stream<Time>()
    .filter(e => e.get("a") % 2 !== 0)
    .output(evt => {
         // -> 1, 3, 5
    });
source.addEvent(...); // <- 1, 2, 3, 4, 5
```