### PR TITLE
hourlyRollup wasn't using the _rollup method

### DIFF
--- a/src/pond/lib/timeseries.js
+++ b/src/pond/lib/timeseries.js
@@ -1115,7 +1115,7 @@ class TimeSeries {
             );
         }
 
-        return this.fixedWindowRollup("1h", aggregation, toTimeEvents);
+        return this._rollup("1h", aggregation, toTimeEvents);
     }
 
     /**


### PR DESCRIPTION
It appears that hourlyRollup was partially converted to use fixedWindowRollup, but the signature was wrong. Because dailyRollup, monthlyRollup, etc all use the _rollup method, and the current hourlyRollup was calling fixedWindowRollup with the _rollup signature, I simply switched this back.