### PR TITLE
Fixes period.within() to be exclusive of end time

### DIFF
--- a/packages/pond/src/align.ts
+++ b/packages/pond/src/align.ts
@@ -12,13 +12,11 @@ import * as Immutable from "immutable";
 import * as _ from "lodash";
 
 import { Event } from "./event";
-import { Index } from "./index";
 import { Key } from "./key";
 import { Period } from "./period";
 import { Processor } from "./processor";
 import { time, Time } from "./time";
 import { timerange } from "./timerange";
-import util from "./util";
 
 import { AlignmentMethod, AlignmentOptions } from "./types";
 
@@ -92,6 +90,7 @@ export class Align<T extends Key> extends Processor<T, T> {
         }
 
         const boundaries: Immutable.List<Time> = this.getBoundaries(event);
+
         boundaries.forEach(boundaryTime => {
             let outputEvent;
             if (this._limit && boundaries.size > this._limit) {
@@ -129,6 +128,10 @@ export class Align<T extends Key> extends Processor<T, T> {
      * they are in the same window, return an empty list.
      */
     private getBoundaries(event: Event<T>): Immutable.List<Time> {
+        if (+this._previous.timestamp() === +event.timestamp()) {
+            return Immutable.List<Time>([]);
+        }
+
         const range = timerange(this._previous.timestamp(), event.timestamp());
         return this._period.within(range);
     }

--- a/packages/pond/src/base.ts
+++ b/packages/pond/src/base.ts
@@ -8,23 +8,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import * as Immutable from "immutable";
 import * as _ from "lodash";
-
-import { Event } from "./event";
-import { grouped, GroupedCollection, GroupingFunction } from "./groupedcollection";
-import { Index } from "./index";
-import { Key } from "./key";
-import { Period } from "./period";
-import { Time } from "./time";
-import { timerange, TimeRange } from "./timerange";
-import { windowed, WindowedCollection } from "./windowedcollection";
-
-import { Align } from "./align";
-import { Collapse } from "./collapse";
-import { Rate } from "./rate";
-
-import { AlignmentMethod, AlignmentOptions, CollapseOptions, RateOptions } from "./types";
 
 /**
  * Abstract base class used by classes which maybe passed within the streaming code.

--- a/packages/pond/src/collapse.ts
+++ b/packages/pond/src/collapse.ts
@@ -14,7 +14,6 @@ import * as _ from "lodash";
 import { Event } from "./event";
 import { Key } from "./key";
 import { Processor } from "./processor";
-import util from "./util";
 
 import { CollapseOptions } from "./types";
 

--- a/packages/pond/src/collection.ts
+++ b/packages/pond/src/collection.ts
@@ -11,31 +11,14 @@
 import * as Immutable from "immutable";
 import * as _ from "lodash";
 
-import { Align } from "./align";
 import { Base } from "./base";
 import { Collapse } from "./collapse";
 import { Event } from "./event";
-import { Fill } from "./fill";
-import { grouped, GroupedCollection, GroupingFunction } from "./groupedcollection";
-import { Index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
-import { Rate } from "./rate";
 import { Select } from "./select";
-import { Time } from "./time";
 import { timerange, TimeRange } from "./timerange";
 
-import {
-    AlignmentMethod,
-    AlignmentOptions,
-    CollapseOptions,
-    FillOptions,
-    RateOptions,
-    SelectOptions,
-    WindowingOptions
-} from "./types";
-
-import util from "./util";
+import { CollapseOptions, SelectOptions } from "./types";
 
 import { DedupFunction, ReducerFunction, ValueMap } from "./types";
 

--- a/packages/pond/src/groupedcollection.ts
+++ b/packages/pond/src/groupedcollection.ts
@@ -11,27 +11,17 @@
 import * as Immutable from "immutable";
 import * as _ from "lodash";
 
-import { Align } from "./align";
-import { Base } from "./base";
 import { Event } from "./event";
-import { Index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
-import { Rate } from "./rate";
 import { SortedCollection } from "./sortedcollection";
-import { Time } from "./time";
-import { timerange, TimeRange } from "./timerange";
+import { TimeRange } from "./timerange";
 import { WindowedCollection } from "./windowedcollection";
 
 import {
     Aggregation,
-    AggregationMapFunction,
     AggregationTuple,
     AlignmentOptions,
-    CollapseOptions,
-    DedupFunction,
     RateOptions,
-    ReducerFunction,
     WindowingOptions
 } from "./types";
 

--- a/packages/pond/src/node.ts
+++ b/packages/pond/src/node.ts
@@ -2,8 +2,7 @@ import * as Immutable from "immutable";
 import * as _ from "lodash";
 
 import { Base } from "./base";
-import { Collection } from "./collection";
-import { Event, event } from "./event";
+import { Event } from "./event";
 import { Index, index } from "./index";
 import { Key } from "./key";
 import { TimeRange } from "./timerange";
@@ -15,7 +14,6 @@ import { Rate } from "./rate";
 import { Reducer } from "./reduce";
 import { Select } from "./select";
 
-import { GroupedCollection } from "./groupedcollection";
 import { WindowedCollection } from "./windowedcollection";
 
 import {

--- a/packages/pond/src/period.ts
+++ b/packages/pond/src/period.ts
@@ -10,10 +10,8 @@
 
 import * as Immutable from "immutable";
 import * as _ from "lodash";
-import * as moment from "moment";
 
 import { Duration, duration } from "./duration";
-import { Index } from "./index";
 import { Time, time } from "./time";
 import { TimeRange } from "./timerange";
 
@@ -110,7 +108,8 @@ export class Period {
 
     /**
      * Returns an `Immutable.List` of `Time`s within the given `TimeRange`
-     * that align with this `Period`.
+     * that align with this `Period`. Not this will potentially include
+     * the start time of the timerange but never the end time of the timerange.
      *
      * Example:
      * ```
@@ -132,7 +131,7 @@ export class Period {
         const t2 = time(timerange.end());
 
         let scan = this.isAligned(t1) ? t1 : this.next(t1);
-        while (+scan <= +t2) {
+        while (+scan < +t2) {
             result = result.push(scan);
             scan = this.next(scan);
         }

--- a/packages/pond/src/rate.ts
+++ b/packages/pond/src/rate.ts
@@ -12,11 +12,8 @@ import * as Immutable from "immutable";
 import * as _ from "lodash";
 
 import { Event } from "./event";
-import { Index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
 import { Processor } from "./processor";
-import { time, Time } from "./time";
 import { TimeRange, timerange } from "./timerange";
 import util from "./util";
 

--- a/packages/pond/src/reduce.ts
+++ b/packages/pond/src/reduce.ts
@@ -12,15 +12,10 @@ import * as Immutable from "immutable";
 import * as _ from "lodash";
 
 import { Event } from "./event";
-import { Index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
 import { Processor } from "./processor";
-import { time, Time } from "./time";
-import { TimeRange, timerange } from "./timerange";
-import util from "./util";
 
-import { ListReducer, ReduceOptions, ReducerFunction } from "./types";
+import { ListReducer, ReduceOptions } from "./types";
 
 /**
  * A `Processor` to take a rolling set of incoming `Event`s, a

--- a/packages/pond/src/select.ts
+++ b/packages/pond/src/select.ts
@@ -14,7 +14,6 @@ import * as _ from "lodash";
 import { Event } from "./event";
 import { Key } from "./key";
 import { Processor } from "./processor";
-import { TimeRange } from "./timerange";
 
 import { SelectOptions } from "./types";
 

--- a/packages/pond/src/stream.ts
+++ b/packages/pond/src/stream.ts
@@ -12,19 +12,10 @@ import * as Immutable from "immutable";
 import * as _ from "lodash";
 
 import { Base } from "./base";
-import { Collection } from "./collection";
 import { Event, event } from "./event";
-import { Index, index } from "./index";
+import { Index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
-import { Processor } from "./processor";
-import { Time, time } from "./time";
-import { TimeRange } from "./timerange";
-
-import { Trigger } from "./types";
-
-import { GroupedCollection } from "./groupedcollection";
-import { WindowedCollection } from "./windowedcollection";
+import { Time } from "./time";
 
 import {
     AggregationNode,
@@ -241,6 +232,7 @@ export class EventStream<IN extends Key, S extends Key> extends StreamInterface<
     coalesce(options: CoalesceOptions) {
         const { fields } = options;
         function keyIn(...keys) {
+            // @ts-ignore
             const keySet = Immutable.Set(...keys);
             return (v, k) => {
                 return keySet.has(k);

--- a/packages/pond/src/timerange.ts
+++ b/packages/pond/src/timerange.ts
@@ -14,7 +14,6 @@ import * as moment from "moment";
 import Moment = moment.Moment;
 
 import { Key } from "./key";
-import { Period } from "./period";
 import { Time } from "./time";
 
 /**

--- a/packages/pond/src/timeseries.ts
+++ b/packages/pond/src/timeseries.ts
@@ -1102,11 +1102,15 @@ export class TimeSeries<T extends Key> {
      *
      * Example:
      * ```
-     * const aligned = ts.align({
-     *     fieldSpec: "value",
-     *     period: "1m",
-     *     method: "linear"
-     * });
+     *  const alignOptions: AlignmentOptions = {
+     *       fieldSpec: ["value"],
+     *       period: period(duration("30s")),
+     *       method: AlignmentMethod.Linear,
+     *       limit: 3
+     *   };
+     *
+     *   const aligned = series.align(alignOptions);
+     *
      * ```
      */
     align(options: AlignmentOptions) {
@@ -1364,10 +1368,10 @@ export class TimeSeries<T extends Key> {
      * });
      * ```
      */
-    static timeSeriesListReduce(options: TimeSeriesOptions) {
+    static timeSeriesListReduce<T extends Key>(options: TimeSeriesOptions): TimeSeries<T> {
         const { seriesList, fieldSpec, reducer, ...data } = options;
         const combiner = Event.combiner(fieldSpec, reducer);
-        return TimeSeries.timeSeriesListEventReduce({
+        return TimeSeries.timeSeriesListEventReduce<T>({
             seriesList,
             fieldSpec,
             reducer: combiner,
@@ -1397,10 +1401,10 @@ export class TimeSeries<T extends Key> {
      * });
      * ```
      */
-    static timeSeriesListMerge(options: TimeSeriesOptions) {
+    static timeSeriesListMerge<T extends Key>(options: TimeSeriesOptions): TimeSeries<T> {
         const { seriesList, fieldSpec, reducer, deep = false, ...data } = options;
         const merger = Event.merger(deep);
-        return TimeSeries.timeSeriesListEventReduce({
+        return TimeSeries.timeSeriesListEventReduce<T>({
             seriesList,
             fieldSpec,
             reducer: merger,
@@ -1411,7 +1415,9 @@ export class TimeSeries<T extends Key> {
     /**
      * @private
      */
-    static timeSeriesListEventReduce(options: TimeSeriesListReducerOptions) {
+    static timeSeriesListEventReduce<T extends Key>(
+        options: TimeSeriesListReducerOptions
+    ): TimeSeries<T> {
         const { seriesList, fieldSpec, reducer, ...data } = options;
         if (!seriesList || !_.isArray(seriesList)) {
             throw new Error("A list of TimeSeries must be supplied to reduce");
@@ -1437,7 +1443,7 @@ export class TimeSeries<T extends Key> {
         // on the start times of the series, along with it the series
         // have missing data, so I think we don't have a choice here.
         const collection = new SortedCollection(events);
-        const timeseries = new TimeSeries({ ...data, collection });
+        const timeseries = new TimeSeries<T>({ ...data, collection });
 
         return timeseries;
     }

--- a/packages/pond/src/types.ts
+++ b/packages/pond/src/types.ts
@@ -16,7 +16,7 @@ import { Event } from "./event";
 import { Key } from "./key";
 import { Period } from "./period";
 import { TimeSeries } from "./timeseries";
-import { Window, WindowBase } from "./window";
+import { WindowBase } from "./window";
 
 //
 // General types
@@ -215,8 +215,7 @@ export interface SelectOptions {
  */
 export interface RenameColumnOptions {
     renameMap: {
-        key: string;
-        value: string;
+        [key: string]: string;
     };
 }
 

--- a/packages/pond/src/window.ts
+++ b/packages/pond/src/window.ts
@@ -9,11 +9,10 @@
  */
 
 import * as Immutable from "immutable";
-import { OrderedSet } from "immutable";
 import * as _ from "lodash";
 import * as moment from "moment-timezone";
 
-import { Duration, duration } from "./duration";
+import { Duration } from "./duration";
 import { Index, index } from "./index";
 import { Period } from "./period";
 import { Time, time } from "./time";

--- a/packages/pond/src/windowedcollection.ts
+++ b/packages/pond/src/windowedcollection.ts
@@ -11,29 +11,19 @@
 import * as Immutable from "immutable";
 import * as _ from "lodash";
 
-import { Align } from "./align";
 import { Base } from "./base";
 import { Event } from "./event";
 import { GroupedCollection, GroupingFunction } from "./groupedcollection";
 import { Index, index } from "./index";
 import { Key } from "./key";
-import { Period } from "./period";
-import { Processor } from "./processor";
-import { Rate } from "./rate";
 import { SortedCollection } from "./sortedcollection";
-import { Time, time } from "./time";
-import { timerange, TimeRange } from "./timerange";
-
+import { time } from "./time";
 import util from "./util";
 
 import {
     AggregationSpec,
     AggregationTuple,
-    AlignmentOptions,
-    DedupFunction,
     KeyedCollection,
-    RateOptions,
-    ReducerFunction,
     Trigger,
     WindowingOptions
 } from "./types";

--- a/packages/pond/tests/align.test.ts
+++ b/packages/pond/tests/align.test.ts
@@ -24,7 +24,8 @@ import { period } from "../src/period";
 import { sortedCollection } from "../src/sortedcollection";
 import { time } from "../src/time";
 
-import { AlignmentMethod } from "../src/types";
+import { timeSeries } from "../src/timeseries";
+import { AlignmentMethod, AlignmentOptions } from "../src/types";
 
 const SIMPLE_GAP_DATA = [
     [1471824030000, 0.75], // 00:00:30
@@ -88,4 +89,27 @@ it("can do basic hold alignment", () => {
     expect(aligned.at(5).get("value")).toBe(1);
     expect(aligned.at(6).get("value")).toBe(1);
     expect(aligned.at(7).get("value")).toBe(1);
+});
+
+it("can do alignment on already align data", () => {
+    const alignOptions: AlignmentOptions = {
+        fieldSpec: ["value"],
+        period: period(duration("30s")),
+        method: AlignmentMethod.Linear,
+        limit: 3
+    };
+
+    const ts = timeSeries({
+        name: "aligned",
+        tz: "Etc/UTC",
+        columns: ["time", "value"],
+        points: [[90000, 5], [120000, 10], [185000, 12]]
+    });
+
+    const aligned = ts.align(alignOptions);
+
+    expect(aligned.at(0).get("value")).toBe(5);
+    expect(aligned.at(1).get("value")).toBe(10);
+    expect(aligned.at(2).get("value")).toBe(10.923076923076923);
+    expect(aligned.at(3).get("value")).toBe(11.846153846153847);
 });

--- a/packages/pond/tests/collection.test.ts
+++ b/packages/pond/tests/collection.test.ts
@@ -89,8 +89,8 @@ describe("Collection", () => {
             const e2 = event(time("2015-04-22T02:30:00Z"), Immutable.Map({ a: 4, b: 2 }));
             const c = collection(Immutable.List([e1, e2]));
 
-            // tslint:disable-next-line:max-line-length
             const expected =
+                // tslint:disable-next-line:max-line-length
                 '[{"time":1429673400000,"data":{"a":5,"b":6}},{"time":1429669800000,"data":{"a":4,"b":2}}]';
             expect(c.toString()).toEqual(expected);
         });

--- a/packages/pond/tests/event.test.ts
+++ b/packages/pond/tests/event.test.ts
@@ -3,17 +3,12 @@ declare const it: any;
 declare const expect: any;
 
 import * as Immutable from "immutable";
-// import * as Joda from "js-joda";
 
-import Collection from "../src/collection";
 import { event, Event, timeEvent } from "../src/event";
 import { avg, sum } from "../src/functions";
 import { index } from "../src/index";
-import Key from "../src/key";
-import { Time, time } from "../src/time";
+import { time } from "../src/time";
 import { timerange } from "../src/timerange";
-
-const fmt = "YYYY-MM-DD HH:mm";
 
 const DATE = new Date("2015-04-22T03:30:00Z");
 
@@ -142,8 +137,10 @@ describe("TimeRange Events", () => {
         // Pick one event
         const sampleEvent = Immutable.Map(OUTAGE_EVENT_LIST.outageList[0]);
 
-        // Extract the begin and end times
+        // Extract the begin and end times  TODO: Fix the ts warning here
+        // @ts-ignore
         const beginTime = new Date(sampleEvent.get("start_time"));
+        // @ts-ignore
         const endTime = new Date(sampleEvent.get("end_time"));
         const e = event(timerange(beginTime, endTime), sampleEvent);
 

--- a/packages/pond/tests/fill.test.ts
+++ b/packages/pond/tests/fill.test.ts
@@ -8,56 +8,17 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
 
 import * as Immutable from "immutable";
 
-import { collection } from "../src/collection";
 import { event, Event } from "../src/event";
 import { stream } from "../src/stream";
 import { time } from "../src/time";
 import { timeSeries } from "../src/timeseries";
 
 import { FillMethod } from "../src/types";
-
-// import Stream from "../stream";
-
-const EVENT_LIST = [
-    event(time(1429673400000), Immutable.Map({ in: 1, out: 2 })),
-    event(time(1429673460000), Immutable.Map({ in: 3, out: 4 })),
-    event(time(1429673520000), Immutable.Map({ in: 5, out: 6 }))
-];
-
-const TICKET_RANGE = {
-    name: "outages",
-    columns: ["timerange", "title", "esnet_ticket"],
-    points: [
-        [[1429673400000, 1429707600000], "BOOM", "ESNET-20080101-001"],
-        [[1429673400000, 1429707600000], "BAM!", "ESNET-20080101-002"]
-    ]
-};
-
-const AVAILABILITY_DATA = {
-    name: "availability",
-    columns: ["index", "uptime"],
-    points: [
-        ["2014-07", "100%"],
-        ["2014-08", "88%"],
-        ["2014-09", "95%"],
-        ["2014-10", "99%"],
-        ["2014-11", "91%"],
-        ["2014-12", "99%"],
-        ["2015-01", "100%"],
-        ["2015-02", "92%"],
-        ["2015-03", "99%"],
-        ["2015-04", "87%"],
-        ["2015-05", "92%"],
-        ["2015-06", "100%"]
-    ]
-};
 
 it("can use the TimeSeries.fill() to fill missing values with zero", () => {
     const ts = timeSeries({

--- a/packages/pond/tests/index.test.ts
+++ b/packages/pond/tests/index.test.ts
@@ -8,13 +8,10 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-declare const describe: any;
 declare const it: any;
 declare const expect: any;
 
-import { Index, index } from "../src/index";
-import { time } from "../src/time";
-import { daily } from "../src/window";
+import { index } from "../src/index";
 
 it("can create a daily index", done => {
     const idx = index("1d-12355");

--- a/packages/pond/tests/period.test.ts
+++ b/packages/pond/tests/period.test.ts
@@ -51,7 +51,6 @@ describe("Period", () => {
         expect(+result.get(0)).toBe(1500629400000); // 2017-07-21 9:30am
         expect(+result.get(1)).toBe(1500629700000); // 2017-07-21 9:35am
         expect(+result.get(2)).toBe(1500630000000); // 2017-07-21 9:40am
-        expect(+result.get(3)).toBe(1500630300000); // 2017-07-21 9:45am
     });
 
     it("can find the list of times aligned to a period with offset within a timerange", () => {
@@ -85,6 +84,6 @@ describe("Period", () => {
             timerange(time("2017-07-21T09:38:00.000Z"), time("2017-07-21T09:43:00.000Z"))
         );
         expect(+result.get(0)).toBe(1500629880000); // 2017-07-21 9:38am
-        expect(+result.get(1)).toBe(1500630180000); // 2017-07-21 9:43am
+        // expect(+result.get(1)).toBe(1500630180000); // 2017-07-21 9:43am
     });
 });

--- a/packages/pond/tests/rate.test.ts
+++ b/packages/pond/tests/rate.test.ts
@@ -1,13 +1,10 @@
-declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
 
 import * as Immutable from "immutable";
 import * as moment from "moment";
 import Moment = moment.Moment;
 
-import { collection } from "../src/collection";
 import { duration } from "../src/duration";
 import { event } from "../src/event";
 import { period } from "../src/period";

--- a/packages/pond/tests/sorted.test.ts
+++ b/packages/pond/tests/sorted.test.ts
@@ -1,7 +1,6 @@
 declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
 
 import * as Immutable from "immutable";
 import * as moment from "moment";

--- a/packages/pond/tests/stream.test.ts
+++ b/packages/pond/tests/stream.test.ts
@@ -1,27 +1,24 @@
 declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
 
 import * as Immutable from "immutable";
 import Moment = moment.Moment;
 import * as _ from "lodash";
 import * as moment from "moment";
 
-import { collection, Collection } from "../src/collection";
+import { Collection } from "../src/collection";
 import { duration } from "../src/duration";
 import { event, Event } from "../src/event";
-import { avg, count, keep, sum } from "../src/functions";
-import { grouped, GroupedCollection } from "../src/groupedcollection";
-import { index, Index } from "../src/index";
+import { avg, count, sum } from "../src/functions";
+import { Index } from "../src/index";
 import { period } from "../src/period";
 import { stream } from "../src/stream";
 import { time, Time } from "../src/time";
-import { TimeRange } from "../src/timerange";
-import { Trigger, WindowingOptions } from "../src/types";
+import { Trigger } from "../src/types";
 import { window } from "../src/window";
 
-import { AlignmentMethod, TimeAlignment } from "../src/types";
+import { AlignmentMethod } from "../src/types";
 
 const streamingEvents = [
     event(time(0), Immutable.Map({ count: 5, value: 1 })),

--- a/packages/pond/tests/time.test.ts
+++ b/packages/pond/tests/time.test.ts
@@ -3,7 +3,7 @@ declare const it: any;
 declare const expect: any;
 
 import { duration } from "../src/duration";
-import { now, time } from "../src/time";
+import { time } from "../src/time";
 
 import { TimeAlignment } from "../src/types";
 

--- a/packages/pond/tests/timerange.test.ts
+++ b/packages/pond/tests/timerange.test.ts
@@ -8,13 +8,12 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-declare const describe: any;
 declare const it: any;
 declare const expect: any;
 
 import * as moment from "moment";
 import { duration } from "../src/duration";
-import { timerange, TimeRange } from "../src/timerange";
+import { timerange } from "../src/timerange";
 import util from "../src/util";
 
 import Moment = moment.Moment;
@@ -41,7 +40,7 @@ it("can create a new range with two millisecond timestamps", () => {
 it("can create a new range with two millisecond tiemstamps as an array", () => {
     const range = timerange([1326309060000, 1329941520000]);
     expect(range.toJSON()).toEqual({ timerange: [1326309060000, 1329941520000] });
-})
+});
 
 it("can be used to give a new range", () => {
     const beginTime = moment("2012-01-11 1:11", fmt).toDate();

--- a/packages/pond/tests/timeseries.test.ts
+++ b/packages/pond/tests/timeseries.test.ts
@@ -11,7 +11,6 @@
 declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
 
 import * as Immutable from "immutable";
 import * as moment from "moment";
@@ -21,10 +20,9 @@ import { duration } from "../src/duration";
 import { event } from "../src/event";
 import { indexedEvent, timeEvent, timeRangeEvent } from "../src/event";
 import { avg, max, sum } from "../src/functions";
-import { index, Index } from "../src/index";
-import { period, Period } from "../src/period";
+import { index } from "../src/index";
 import { time, Time } from "../src/time";
-import { timerange, TimeRange } from "../src/timerange";
+import { timerange } from "../src/timerange";
 import { TimeSeries, TimeSeriesWireFormat } from "../src/timeseries";
 import { indexedSeries, timeRangeSeries, timeSeries } from "../src/timeseries";
 import { window } from "../src/window";
@@ -790,7 +788,7 @@ describe("Merging two timeseries together", () => {
     it("can merge two timeseries columns together using merge", () => {
         const inTraffic = timeSeries(TRAFFIC_DATA_IN);
         const outTraffic = timeSeries(TRAFFIC_DATA_OUT);
-        const trafficSeries = TimeSeries.timeSeriesListMerge({
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
             name: "traffic",
             seriesList: [inTraffic, outTraffic],
             fieldSpec: ["in", "out"]
@@ -803,7 +801,7 @@ describe("Merging two timeseries together", () => {
     it("can append two timeseries together using merge", () => {
         const tile1 = timeSeries(PARTIAL_TRAFFIC_PART_A);
         const tile2 = timeSeries(PARTIAL_TRAFFIC_PART_B);
-        const trafficSeries = TimeSeries.timeSeriesListMerge({
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
             name: "traffic",
             source: "router",
             seriesList: [tile1, tile2],
@@ -825,7 +823,7 @@ describe("Merging two timeseries together", () => {
     it("can merge two series and preserve the correct time format", () => {
         const inTraffic = timeSeries(TRAFFIC_BNL_TO_NEWY);
         const outTraffic = timeSeries(TRAFFIC_NEWY_TO_BNL);
-        const trafficSeries = TimeSeries.timeSeriesListMerge({
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
             name: "traffic",
             seriesList: [inTraffic, outTraffic]
         });

--- a/packages/pond/tests/util.test.ts
+++ b/packages/pond/tests/util.test.ts
@@ -11,10 +11,6 @@
 declare const describe: any;
 declare const it: any;
 declare const expect: any;
-declare const beforeEach: any;
-
-import * as Immutable from "immutable";
-import * as moment from "moment";
 
 import Util from "../src/util";
 

--- a/packages/pond/tests/window.test.ts
+++ b/packages/pond/tests/window.test.ts
@@ -2,12 +2,9 @@ declare const describe: any;
 declare const it: any;
 declare const expect: any;
 
-import * as moment from "moment";
-
 import { duration } from "../src/duration";
 import { period } from "../src/period";
-import { now, time } from "../src/time";
-import { TimeRange } from "../src/timerange";
+import { time } from "../src/time";
 import { daily, window } from "../src/window";
 
 import Util from "../src/util";

--- a/packages/pond/tests/windowed.test.ts
+++ b/packages/pond/tests/windowed.test.ts
@@ -9,21 +9,12 @@ import Moment = moment.Moment;
 
 const map = Immutable.Map;
 
-import { collection, Collection } from "../src/collection";
 import { duration } from "../src/duration";
 import { event } from "../src/event";
-import { avg, count, keep, sum } from "../src/functions";
-import { grouped, GroupedCollection } from "../src/groupedcollection";
-import { index } from "../src/index";
-import { period } from "../src/period";
+import { keep, sum } from "../src/functions";
 import { sortedCollection } from "../src/sortedcollection";
-import { time, Time } from "../src/time";
-import { TimeRange } from "../src/timerange";
+import { time } from "../src/time";
 import { window } from "../src/window";
-
-import { WindowedCollection } from "../src/windowedcollection";
-
-import { TimeAlignment } from "../src/types";
 
 describe("Windowed", () => {
     it("can build a WindowedCollection", () => {


### PR DESCRIPTION
Fixes period.within() to be exclusive of end time. Usually timeranges are defined as >= begin time to <end time, otherwise a to b and b to c includes b twice. But period.within() didn't follow that. This change is in period.ts
 
- Fixes repeated items in the timeseries alignment when points already fall on boundaries (regression from non-typescript version)
- Also removes a bunch of unused imports
- Also adds return types to the timeseries list merge etc (timeseries.ts) because otherwise the return type is just a TimeSeries<Key> which is annoying to use
