### PR TITLE
Don't ignore the typescript definitions when packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 src
+!src/index.d.ts
 test
 docs
 website


### PR DESCRIPTION
This PR prevents the removal of the typescript definitions from the published npm package.

```
!src/index.d.ts
```

Closes #134