### PR TITLE
fix: output of path invalid value in the case of null value

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": false,
+    "printWidth": 100
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-    - "5.6.0"
+    - "8.15.0"
 notifications:
-  email: false
+    email: false
 before_install:
     - export TZ=America/Los_Angeles
-script:
-    npm test -- --coverage
+script: npm test -- --coverage
 after_script:
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+    - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -1,15 +1,21 @@
 {
-    "scripts": {
-        "start": "cd packages/website && npm run start",
-        "build": "cd packages/pond && npm run build",
-        "docs": "cd packages/pond && npm run docs",
-        "build-website":
-            "echo \"*** Building website\n\" && rm -rf docs && cd packages/website && npm run build",
-        "prettier": "prettier --print-width 100 --tab-width 4 --write \"packages/pond/src/**/*.ts\""
-    },
-    "devDependencies": {
-        "lerna": "^2.5.1",
-        "prettier": "^1.7.0"
-    },
-    "dependencies": {}
+  "scripts": {
+    "start": "cd packages/website && npm run start",
+    "build": "cd packages/pond && npm run build",
+    "docs": "cd packages/pond && npm run docs",
+    "build-website": "echo \"*** Building website\n\" && rm -rf docs && cd packages/website && npm run build",
+    "prettier": "prettier --print-width 100 --tab-width 4 --write \"packages/pond/src/**/*.ts\""
+  },
+  "devDependencies": {
+    "husky": "^2.1.0",
+    "lerna": "^3.13.4",
+    "prettier": "^1.17.0",
+    "pretty-quick": "^1.10.0"
+  },
+  "dependencies": {},
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  }
 }

--- a/packages/pond/lib/rate.d.ts
+++ b/packages/pond/lib/rate.d.ts
@@ -35,18 +35,18 @@ import { RateOptions } from "./types";
  *  * `allowNegative` - allow emit of negative rates
  */
 export declare class Rate<T extends Key> extends Processor<T, TimeRange> {
-    private _fieldSpec;
-    private _allowNegative;
-    private _previous;
-    constructor(options: RateOptions);
-    /**
-     * Generate a new `TimeRangeEvent` containing the rate per second
-     * between two events.
-     */
-    getRate(event: any): Event<TimeRange>;
-    /**
-     * Perform the rate operation on the `Event` and the the `_previous`
-     * `Event` and emit the result.
-     */
-    addEvent(event: Event<T>): Immutable.List<Event<TimeRange>>;
+  private _fieldSpec;
+  private _allowNegative;
+  private _previous;
+  constructor(options: RateOptions);
+  /**
+   * Perform the rate operation on the `Event` and the the `_previous`
+   * `Event` and emit the result.
+   */
+  addEvent(event: Event<T>): Immutable.List<Event<TimeRange>>;
+  /**
+   * Generate a new `TimeRangeEvent` containing the rate per second
+   * between two events.
+   */
+  private getRate;
 }

--- a/packages/pond/lib/rate.js
+++ b/packages/pond/lib/rate.js
@@ -37,65 +37,71 @@ const util_1 = require("./util");
  *  * `allowNegative` - allow emit of negative rates
  */
 class Rate extends processor_1.Processor {
-    constructor(options) {
-        super();
-        const { fieldSpec, allowNegative = false } = options;
-        // Options
-        this._fieldSpec = _.isString(fieldSpec) ? [fieldSpec] : fieldSpec;
-        this._allowNegative = allowNegative;
-        // Previous event
-        this._previous = null;
+  constructor(options) {
+    super();
+    const { fieldSpec, allowNegative = false } = options;
+    // Options
+    this._fieldSpec = _.isString(fieldSpec) ? [fieldSpec] : fieldSpec;
+    this._allowNegative = allowNegative;
+    // Previous event
+    this._previous = null;
+  }
+  /**
+   * Perform the rate operation on the `Event` and the the `_previous`
+   * `Event` and emit the result.
+   */
+  addEvent(event) {
+    const eventList = new Array();
+    if (!this._previous) {
+      this._previous = event;
+      return Immutable.List();
     }
-    /**
-     * Generate a new `TimeRangeEvent` containing the rate per second
-     * between two events.
-     */
-    getRate(event) {
-        let d = Immutable.Map();
-        const previousTime = this._previous.timestamp().getTime();
-        const currentTime = event.timestamp().getTime();
-        const deltaTime = (currentTime - previousTime) / 1000;
-        this._fieldSpec.forEach(path => {
-            const fieldPath = util_1.default.fieldAsArray(path);
-            const ratePath = fieldPath.slice();
-            ratePath[ratePath.length - 1] += "_rate";
-            const previousVal = this._previous.get(fieldPath);
-            const currentVal = event.get(fieldPath);
-            let rate = null;
-            if (!_.isNumber(previousVal) || !_.isNumber(currentVal)) {
-                // tslint:disable-next-line
-                console.warn(`Path ${fieldPath} contains a non-numeric value or does not exist`);
-            }
-            else {
-                rate = (currentVal - previousVal) / deltaTime;
-            }
-            if (this._allowNegative === false && rate < 0) {
-                // don't allow negative differentials in certain cases
-                d = d.setIn(ratePath, null);
-            }
-            else {
-                d = d.setIn(ratePath, rate);
-            }
-        });
-        return new event_1.Event(timerange_1.timerange(previousTime, currentTime), d);
+    const rate = this.getRate(event);
+    if (rate) {
+      eventList.push(rate);
     }
-    /**
-     * Perform the rate operation on the `Event` and the the `_previous`
-     * `Event` and emit the result.
-     */
-    addEvent(event) {
-        const eventList = new Array();
-        if (!this._previous) {
-            this._previous = event;
-            return Immutable.List();
-        }
-        const rate = this.getRate(event);
-        if (rate) {
-            eventList.push(rate);
-        }
-        this._previous = event;
-        return Immutable.List(eventList);
-    }
+    this._previous = event;
+    return Immutable.List(eventList);
+  }
+  /**
+   * Generate a new `TimeRangeEvent` containing the rate per second
+   * between two events.
+   */
+  getRate(event) {
+    let d = Immutable.Map();
+    const previousTime = this._previous.timestamp().getTime();
+    const currentTime = event.timestamp().getTime();
+    const deltaTime = (currentTime - previousTime) / 1000;
+    this._fieldSpec.forEach(path => {
+      const fieldPath = util_1.default.fieldAsArray(path);
+      const ratePath = fieldPath.slice();
+      ratePath[ratePath.length - 1] += "_rate";
+      const previousVal = this._previous.get(fieldPath);
+      const currentVal = event.get(fieldPath);
+      let rate = null;
+      if (_.isNumber(currentVal) && _.isNumber(previousVal)) {
+        // Calculate the rate
+        rate = (currentVal - previousVal) / deltaTime;
+      } else if (
+        (previousVal !== null && !_.isNumber(previousVal)) ||
+        (currentVal !== null && !_.isNumber(currentVal))
+      ) {
+        // Only issue warning if the current or previous values are bad
+        // i.e. not a number or not null (null values result in null output)
+        console.warn(
+          `Event field "${fieldPath}" is a non-numeric or non-null value`
+        );
+      }
+      d =
+        this._allowNegative === false && rate < 0
+          ? (d = d.setIn(ratePath, null)) // don't allow negative differentials in certain cases
+          : (d = d.setIn(ratePath, rate));
+    });
+    return new event_1.Event(
+      timerange_1.timerange(previousTime, currentTime),
+      d
+    );
+  }
 }
 exports.Rate = Rate;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmF0ZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9yYXRlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQTs7Ozs7Ozs7R0FRRzs7QUFFSCx1Q0FBdUM7QUFDdkMsNEJBQTRCO0FBRTVCLG1DQUFnQztBQUVoQywyQ0FBd0M7QUFDeEMsMkNBQW1EO0FBQ25ELGlDQUEwQjtBQUkxQjs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FvQkc7QUFDSCxNQUFhLElBQW9CLFNBQVEscUJBQXVCO0lBTzVELFlBQVksT0FBb0I7UUFDNUIsS0FBSyxFQUFFLENBQUM7UUFDUixNQUFNLEVBQUUsU0FBUyxFQUFFLGFBQWEsR0FBRyxLQUFLLEVBQUUsR0FBRyxPQUFPLENBQUM7UUFFckQsVUFBVTtRQUNWLElBQUksQ0FBQyxVQUFVLEdBQUcsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1FBQ2xFLElBQUksQ0FBQyxjQUFjLEdBQUcsYUFBYSxDQUFDO1FBRXBDLGlCQUFpQjtRQUNqQixJQUFJLENBQUMsU0FBUyxHQUFHLElBQUksQ0FBQztJQUMxQixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsT0FBTyxDQUFDLEtBQUs7UUFDVCxJQUFJLENBQUMsR0FBRyxTQUFTLENBQUMsR0FBRyxFQUFlLENBQUM7UUFFckMsTUFBTSxZQUFZLEdBQUcsSUFBSSxDQUFDLFNBQVMsQ0FBQyxTQUFTLEVBQUUsQ0FBQyxPQUFPLEVBQUUsQ0FBQztRQUMxRCxNQUFNLFdBQVcsR0FBRyxLQUFLLENBQUMsU0FBUyxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUM7UUFDaEQsTUFBTSxTQUFTLEdBQUcsQ0FBQyxXQUFXLEdBQUcsWUFBWSxDQUFDLEdBQUcsSUFBSSxDQUFDO1FBRXRELElBQUksQ0FBQyxVQUFVLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxFQUFFO1lBQzNCLE1BQU0sU0FBUyxHQUFHLGNBQUksQ0FBQyxZQUFZLENBQUMsSUFBSSxDQUFDLENBQUM7WUFDMUMsTUFBTSxRQUFRLEdBQUcsU0FBUyxDQUFDLEtBQUssRUFBRSxDQUFDO1lBQ25DLFFBQVEsQ0FBQyxRQUFRLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQyxJQUFJLE9BQU8sQ0FBQztZQUV6QyxNQUFNLFdBQVcsR0FBRyxJQUFJLENBQUMsU0FBUyxDQUFDLEdBQUcsQ0FBQyxTQUFTLENBQUMsQ0FBQztZQUNsRCxNQUFNLFVBQVUsR0FBRyxLQUFLLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBRXhDLElBQUksSUFBSSxHQUFHLElBQUksQ0FBQztZQUNoQixJQUFJLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxXQUFXLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsVUFBVSxDQUFDLEVBQUU7Z0JBQ3JELDJCQUEyQjtnQkFDM0IsT0FBTyxDQUFDLElBQUksQ0FBQyxRQUFRLFNBQVMsaURBQWlELENBQUMsQ0FBQzthQUNwRjtpQkFBTTtnQkFDSCxJQUFJLEdBQUcsQ0FBQyxVQUFVLEdBQUcsV0FBVyxDQUFDLEdBQUcsU0FBUyxDQUFDO2FBQ2pEO1lBRUQsSUFBSSxJQUFJLENBQUMsY0FBYyxLQUFLLEtBQUssSUFBSSxJQUFJLEdBQUcsQ0FBQyxFQUFFO2dCQUMzQyxzREFBc0Q7Z0JBQ3RELENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxDQUFDLFFBQVEsRUFBRSxJQUFJLENBQUMsQ0FBQzthQUMvQjtpQkFBTTtnQkFDSCxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsSUFBSSxDQUFDLENBQUM7YUFDL0I7UUFDTCxDQUFDLENBQUMsQ0FBQztRQUVILE9BQU8sSUFBSSxhQUFLLENBQUMscUJBQVMsQ0FBQyxZQUFZLEVBQUUsV0FBVyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDOUQsQ0FBQztJQUVEOzs7T0FHRztJQUNILFFBQVEsQ0FBQyxLQUFlO1FBQ3BCLE1BQU0sU0FBUyxHQUFHLElBQUksS0FBSyxFQUFvQixDQUFDO1FBRWhELElBQUksQ0FBQyxJQUFJLENBQUMsU0FBUyxFQUFFO1lBQ2pCLElBQUksQ0FBQyxTQUFTLEdBQUcsS0FBSyxDQUFDO1lBQ3ZCLE9BQU8sU0FBUyxDQUFDLElBQUksRUFBb0IsQ0FBQztTQUM3QztRQUVELE1BQU0sSUFBSSxHQUFHLElBQUksQ0FBQyxPQUFPLENBQUMsS0FBSyxDQUFDLENBQUM7UUFDakMsSUFBSSxJQUFJLEVBQUU7WUFDTixTQUFTLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO1NBQ3hCO1FBRUQsSUFBSSxDQUFDLFNBQVMsR0FBRyxLQUFLLENBQUM7UUFFdkIsT0FBTyxTQUFTLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ3JDLENBQUM7Q0FDSjtBQTlFRCxvQkE4RUMifQ==
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicmF0ZS5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy9yYXRlLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQTs7Ozs7Ozs7R0FRRzs7QUFFSCx1Q0FBdUM7QUFDdkMsNEJBQTRCO0FBRTVCLG1DQUFnQztBQUVoQywyQ0FBd0M7QUFDeEMsMkNBQW1EO0FBQ25ELGlDQUEwQjtBQUkxQjs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FvQkc7QUFDSCxNQUFhLElBQW9CLFNBQVEscUJBQXVCO0lBTzVELFlBQVksT0FBb0I7UUFDNUIsS0FBSyxFQUFFLENBQUM7UUFDUixNQUFNLEVBQUUsU0FBUyxFQUFFLGFBQWEsR0FBRyxLQUFLLEVBQUUsR0FBRyxPQUFPLENBQUM7UUFFckQsVUFBVTtRQUNWLElBQUksQ0FBQyxVQUFVLEdBQUcsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO1FBQ2xFLElBQUksQ0FBQyxjQUFjLEdBQUcsYUFBYSxDQUFDO1FBRXBDLGlCQUFpQjtRQUNqQixJQUFJLENBQUMsU0FBUyxHQUFHLElBQUksQ0FBQztJQUMxQixDQUFDO0lBRUQ7OztPQUdHO0lBQ0ksUUFBUSxDQUFDLEtBQWU7UUFDM0IsTUFBTSxTQUFTLEdBQUcsSUFBSSxLQUFLLEVBQW9CLENBQUM7UUFFaEQsSUFBSSxDQUFDLElBQUksQ0FBQyxTQUFTLEVBQUU7WUFDakIsSUFBSSxDQUFDLFNBQVMsR0FBRyxLQUFLLENBQUM7WUFDdkIsT0FBTyxTQUFTLENBQUMsSUFBSSxFQUFvQixDQUFDO1NBQzdDO1FBRUQsTUFBTSxJQUFJLEdBQUcsSUFBSSxDQUFDLE9BQU8sQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUNqQyxJQUFJLElBQUksRUFBRTtZQUNOLFNBQVMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUM7U0FDeEI7UUFFRCxJQUFJLENBQUMsU0FBUyxHQUFHLEtBQUssQ0FBQztRQUV2QixPQUFPLFNBQVMsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDckMsQ0FBQztJQUVEOzs7T0FHRztJQUNLLE9BQU8sQ0FBQyxLQUFlO1FBQzNCLElBQUksQ0FBQyxHQUFHLFNBQVMsQ0FBQyxHQUFHLEVBQWUsQ0FBQztRQUVyQyxNQUFNLFlBQVksR0FBRyxJQUFJLENBQUMsU0FBUyxDQUFDLFNBQVMsRUFBRSxDQUFDLE9BQU8sRUFBRSxDQUFDO1FBQzFELE1BQU0sV0FBVyxHQUFHLEtBQUssQ0FBQyxTQUFTLEVBQUUsQ0FBQyxPQUFPLEVBQUUsQ0FBQztRQUNoRCxNQUFNLFNBQVMsR0FBRyxDQUFDLFdBQVcsR0FBRyxZQUFZLENBQUMsR0FBRyxJQUFJLENBQUM7UUFFdEQsSUFBSSxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLEVBQUU7WUFDM0IsTUFBTSxTQUFTLEdBQUcsY0FBSSxDQUFDLFlBQVksQ0FBQyxJQUFJLENBQUMsQ0FBQztZQUMxQyxNQUFNLFFBQVEsR0FBRyxTQUFTLENBQUMsS0FBSyxFQUFFLENBQUM7WUFDbkMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLElBQUksT0FBTyxDQUFDO1lBRXpDLE1BQU0sV0FBVyxHQUFHLElBQUksQ0FBQyxTQUFTLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDO1lBQ2xELE1BQU0sVUFBVSxHQUFHLEtBQUssQ0FBQyxHQUFHLENBQUMsU0FBUyxDQUFDLENBQUM7WUFFeEMsSUFBSSxJQUFJLEdBQUcsSUFBSSxDQUFDO1lBRWhCLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxVQUFVLENBQUMsSUFBSSxDQUFDLENBQUMsUUFBUSxDQUFDLFdBQVcsQ0FBQyxFQUFFO2dCQUNuRCxxQkFBcUI7Z0JBQ3JCLElBQUksR0FBRyxDQUFDLFVBQVUsR0FBRyxXQUFXLENBQUMsR0FBRyxTQUFTLENBQUM7YUFDakQ7aUJBQU0sSUFDSCxDQUFDLFdBQVcsS0FBSyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLFdBQVcsQ0FBQyxDQUFDO2dCQUNsRCxDQUFDLFVBQVUsS0FBSyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLFVBQVUsQ0FBQyxDQUFDLEVBQ2xEO2dCQUNFLCtEQUErRDtnQkFDL0Qsb0VBQW9FO2dCQUNwRSxPQUFPLENBQUMsSUFBSSxDQUFDLGdCQUFnQixTQUFTLHNDQUFzQyxDQUFDLENBQUM7YUFDakY7WUFFRCxDQUFDO2dCQUNHLElBQUksQ0FBQyxjQUFjLEtBQUssS0FBSyxJQUFJLElBQUksR0FBRyxDQUFDO29CQUNyQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsSUFBSSxDQUFDLENBQUMsQ0FBQyxzREFBc0Q7b0JBQ3RGLENBQUMsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxDQUFDLFFBQVEsRUFBRSxJQUFJLENBQUMsQ0FBQyxDQUFDO1FBQzVDLENBQUMsQ0FBQyxDQUFDO1FBRUgsT0FBTyxJQUFJLGFBQUssQ0FBQyxxQkFBUyxDQUFDLFlBQVksRUFBRSxXQUFXLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUM5RCxDQUFDO0NBQ0o7QUFsRkQsb0JBa0ZDIn0=

--- a/packages/pond/lib/timerange.js
+++ b/packages/pond/lib/timerange.js
@@ -36,240 +36,248 @@ const types_1 = require("./types");
  * ```
  */
 class TimeRange extends key_1.Key {
-    constructor(arg1, arg2) {
-        super();
-        if (arg1 instanceof TimeRange) {
-            const other = arg1;
-            this._range = other._range;
-        }
-        else if (arg1 instanceof Immutable.List) {
-            const rangeList = arg1;
-            this._range = rangeList;
-        }
-        else if (arg1 instanceof Array) {
-            const rangeArray = arg1;
-            this._range = Immutable.List([new Date(rangeArray[0]), new Date(rangeArray[1])]);
-        }
-        else {
-            const b = arg1;
-            const e = arg2;
-            if (_.isDate(b) && _.isDate(e)) {
-                this._range = Immutable.List([new Date(b.getTime()), new Date(e.getTime())]);
-            }
-            else if (moment.isMoment(b) && moment.isMoment(e)) {
-                this._range = Immutable.List([new Date(b.valueOf()), new Date(e.valueOf())]);
-            }
-            else if (time_1.Time.isTime(b) && time_1.Time.isTime(e)) {
-                this._range = Immutable.List([new Date(b.valueOf()), new Date(e.valueOf())]);
-            }
-            else if (_.isNumber(b) && _.isNumber(e)) {
-                this._range = Immutable.List([new Date(b), new Date(e)]);
-            }
-        }
+  constructor(arg1, arg2) {
+    super();
+    if (arg1 instanceof TimeRange) {
+      const other = arg1;
+      this._range = other._range;
+    } else if (arg1 instanceof Immutable.List) {
+      const rangeList = arg1;
+      this._range = rangeList;
+    } else if (arg1 instanceof Array) {
+      const rangeArray = arg1;
+      this._range = Immutable.List([
+        new Date(rangeArray[0]),
+        new Date(rangeArray[1])
+      ]);
+    } else {
+      const b = arg1;
+      const e = arg2;
+      if (_.isDate(b) && _.isDate(e)) {
+        this._range = Immutable.List([
+          new Date(b.getTime()),
+          new Date(e.getTime())
+        ]);
+      } else if (moment.isMoment(b) && moment.isMoment(e)) {
+        this._range = Immutable.List([
+          new Date(b.valueOf()),
+          new Date(e.valueOf())
+        ]);
+      } else if (time_1.Time.isTime(b) && time_1.Time.isTime(e)) {
+        this._range = Immutable.List([
+          new Date(b.valueOf()),
+          new Date(e.valueOf())
+        ]);
+      } else if (_.isNumber(b) && _.isNumber(e)) {
+        this._range = Immutable.List([new Date(b), new Date(e)]);
+      }
     }
-    type() {
-        return "timerange";
+  }
+  type() {
+    return "timerange";
+  }
+  /**
+   * Returns the internal range, which is an `Immutable.List` of two elements
+   * containing begin and end times as `Date`'s.
+   */
+  internal() {
+    return this._range;
+  }
+  /**
+   * Returns the `TimeRange` as JSON, which will be a Javascript array
+   * of two `ms` timestamps.
+   */
+  toJSON() {
+    return { timerange: [this.begin().getTime(), this.end().getTime()] };
+  }
+  /**
+   * Returns the `TimeRange` as a string, useful for serialization.
+   *
+   * @return {string} String representation of the TimeRange
+   */
+  toString() {
+    return JSON.stringify(this.toJSON());
+  }
+  /**
+   * Returns the `TimeRange` as a string expressed in local time
+   */
+  toLocalString() {
+    return `[${this.begin()}, ${this.end()}]`;
+  }
+  /**
+   * Returns the `TimeRange` as a string expressed in UTC time
+   */
+  toUTCString() {
+    return `[${this.begin().toUTCString()}, ${this.end().toUTCString()}]`;
+  }
+  /**
+   * Returns a human friendly version of the `TimeRange`, e.g.
+   * "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am"
+   */
+  humanize() {
+    const begin = moment(this.begin());
+    const end = moment(this.end());
+    const beginStr = begin.format("MMM D, YYYY hh:mm:ss a");
+    const endStr = end.format("MMM D, YYYY hh:mm:ss a");
+    return `${beginStr} to ${endStr}`;
+  }
+  /**
+   * Returns a human friendly version of the `TimeRange`
+   * @example
+   * Example: "a few seconds ago to a month ago"
+   */
+  relativeString() {
+    const begin = moment(this.begin());
+    const end = moment(this.end());
+    return `${begin.fromNow()} to ${end.fromNow()}`;
+  }
+  /**
+   * Returns the begin time of the `TimeRange`.
+   */
+  begin() {
+    return this._range.get(0);
+  }
+  /**
+   * Returns the end time of the `TimeRange`.
+   */
+  end() {
+    return this._range.get(1);
+  }
+  /**
+   * Returns the midpoint of the `TimeRange`.
+   */
+  mid() {
+    return new Date((+this.begin() + +this.end()) / 2);
+  }
+  /**
+   * Returns a `Time` that is either at the beginning,
+   * middle or end of this `TimeRange`. Specify the alignment
+   * of the output `Time` with the `align` parameter. This is
+   * either:
+   *  * TimeAlignment.Begin
+   *  * TimeAlignment.Middle
+   *  * TimeAlignment.End
+   */
+  toTime(align) {
+    switch (align) {
+      case types_1.TimeAlignment.Begin:
+        return time_1.time(this.begin());
+        break;
+      case types_1.TimeAlignment.Middle:
+        return time_1.time(this.mid());
+        break;
+      case types_1.TimeAlignment.End:
+        return time_1.time(this.end());
+        break;
     }
-    /**
-     * Returns the internal range, which is an `Immutable.List` of two elements
-     * containing begin and end times as `Date`'s.
-     */
-    internal() {
-        return this._range;
+  }
+  /**
+   * Returns the midpoint of the `TimeRange` as the representitive
+   * timestamp for the timerange.
+   */
+  timestamp() {
+    return this.mid();
+  }
+  /**
+   * Sets a new begin time on the `TimeRange`. The result will be
+   * a new `TimeRange`.
+   */
+  setBegin(t) {
+    return new TimeRange(this._range.set(0, t));
+  }
+  /**
+   * Sets a new end time on the `TimeRange`. The result will be
+   * a new `TimeRange`.
+   */
+  setEnd(t) {
+    return new TimeRange(this._range.set(1, t));
+  }
+  /**
+   * Returns if the two `TimeRange`'s can be considered equal,
+   * in that they have the same times.
+   */
+  equals(other) {
+    return (
+      this.begin().getTime() === other.begin().getTime() &&
+      this.end().getTime() === other.end().getTime()
+    );
+  }
+  /**
+   * Determine if a `Date` or a `TimeRange` is contained entirely
+   * within this `TimeRange`
+   */
+  contains(other) {
+    if (_.isDate(other)) {
+      return this.begin() <= other && this.end() >= other;
+    } else {
+      return this.begin() <= other.begin() && this.end() >= other.end();
     }
-    /**
-     * Returns the `TimeRange` as JSON, which will be a Javascript array
-     * of two `ms` timestamps.
-     */
-    toJSON() {
-        return { timerange: [this.begin().getTime(), this.end().getTime()] };
+  }
+  /**
+   * Returns true if this `TimeRange` is completely within the supplied
+   * other `TimeRange`.
+   */
+  within(other) {
+    return this.begin() >= other.begin() && this.end() <= other.end();
+  }
+  /**
+   * Returns true if the passed in other `TimeRange` overlaps
+   * this `TimeRange`.
+   */
+  overlaps(other) {
+    if (
+      (this.contains(other.begin()) && !this.contains(other.end())) ||
+      (this.contains(other.end()) && !this.contains(other.begin()))
+    ) {
+      return true;
+    } else {
+      return false;
     }
-    /**
-     * Returns the `TimeRange` as a string, useful for serialization.
-     *
-     * @return {string} String representation of the TimeRange
-     */
-    toString() {
-        return JSON.stringify(this.toJSON());
+  }
+  /**
+   * Returns true if the passed in other `TimeRange` in no way
+   * overlaps this `TimeRange`.
+   */
+  disjoint(other) {
+    return this.end() < other.begin() || this.begin() > other.end();
+  }
+  /**
+   * Returns a new `Timerange` which covers the extents of this and
+   * other combined.
+   */
+  extents(other) {
+    const b = this.begin() < other.begin() ? this.begin() : other.begin();
+    const e = this.end() > other.end() ? this.end() : other.end();
+    return new TimeRange(new Date(b.getTime()), new Date(e.getTime()));
+  }
+  /**
+   * Returns a new `TimeRange` which represents the intersection
+   * (overlapping) part of this and other.
+   */
+  intersection(other) {
+    if (this.disjoint(other)) {
+      return;
     }
-    /**
-     * Returns the `TimeRange` as a string expressed in local time
-     */
-    toLocalString() {
-        return `[${this.begin()}, ${this.end()}]`;
-    }
-    /**
-     * Returns the `TimeRange` as a string expressed in UTC time
-     */
-    toUTCString() {
-        return `[${this.begin().toUTCString()}, ${this.end().toUTCString()}]`;
-    }
-    /**
-     * Returns a human friendly version of the `TimeRange`, e.g.
-     * "Aug 1, 2014 05:19:59 am to Aug 1, 2014 07:41:06 am"
-     */
-    humanize() {
-        const begin = moment(this.begin());
-        const end = moment(this.end());
-        const beginStr = begin.format("MMM D, YYYY hh:mm:ss a");
-        const endStr = end.format("MMM D, YYYY hh:mm:ss a");
-        return `${beginStr} to ${endStr}`;
-    }
-    /**
-     * Returns a human friendly version of the `TimeRange`
-     * @example
-     * Example: "a few seconds ago to a month ago"
-     */
-    relativeString() {
-        const begin = moment(this.begin());
-        const end = moment(this.end());
-        return `${begin.fromNow()} to ${end.fromNow()}`;
-    }
-    /**
-     * Returns the begin time of the `TimeRange`.
-     */
-    begin() {
-        return this._range.get(0);
-    }
-    /**
-     * Returns the end time of the `TimeRange`.
-     */
-    end() {
-        return this._range.get(1);
-    }
-    /**
-     * Returns the midpoint of the `TimeRange`.
-     */
-    mid() {
-        return new Date((+this.begin() + +this.end()) / 2);
-    }
-    /**
-     * Returns a `Time` that is either at the beginning,
-     * middle or end of this `TimeRange`. Specify the alignment
-     * of the output `Time` with the `align` parameter. This is
-     * either:
-     *  * TimeAlignment.Begin
-     *  * TimeAlignment.Middle
-     *  * TimeAlignment.End
-     */
-    toTime(align) {
-        switch (align) {
-            case types_1.TimeAlignment.Begin:
-                return time_1.time(this.begin());
-                break;
-            case types_1.TimeAlignment.Middle:
-                return time_1.time(this.mid());
-                break;
-            case types_1.TimeAlignment.End:
-                return time_1.time(this.end());
-                break;
-        }
-    }
-    /**
-     * Returns the midpoint of the `TimeRange` as the representitive
-     * timestamp for the timerange.
-     */
-    timestamp() {
-        return this.mid();
-    }
-    /**
-     * Sets a new begin time on the `TimeRange`. The result will be
-     * a new `TimeRange`.
-     */
-    setBegin(t) {
-        return new TimeRange(this._range.set(0, t));
-    }
-    /**
-     * Sets a new end time on the `TimeRange`. The result will be
-     * a new `TimeRange`.
-     */
-    setEnd(t) {
-        return new TimeRange(this._range.set(1, t));
-    }
-    /**
-     * Returns if the two `TimeRange`'s can be considered equal,
-     * in that they have the same times.
-     */
-    equals(other) {
-        return (this.begin().getTime() === other.begin().getTime() &&
-            this.end().getTime() === other.end().getTime());
-    }
-    /**
-     * Determine if a `Date` or a `TimeRange` is contained entirely
-     * within this `TimeRange`
-     */
-    contains(other) {
-        if (_.isDate(other)) {
-            return this.begin() <= other && this.end() >= other;
-        }
-        else {
-            return this.begin() <= other.begin() && this.end() >= other.end();
-        }
-    }
-    /**
-     * Returns true if this `TimeRange` is completely within the supplied
-     * other `TimeRange`.
-     */
-    within(other) {
-        return this.begin() >= other.begin() && this.end() <= other.end();
-    }
-    /**
-     * Returns true if the passed in other `TimeRange` overlaps
-     * this `TimeRange`.
-     */
-    overlaps(other) {
-        if ((this.contains(other.begin()) && !this.contains(other.end())) ||
-            (this.contains(other.end()) && !this.contains(other.begin()))) {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-    /**
-     * Returns true if the passed in other `TimeRange` in no way
-     * overlaps this `TimeRange`.
-     */
-    disjoint(other) {
-        return this.end() < other.begin() || this.begin() > other.end();
-    }
-    /**
-     * Returns a new `Timerange` which covers the extents of this and
-     * other combined.
-     */
-    extents(other) {
-        const b = this.begin() < other.begin() ? this.begin() : other.begin();
-        const e = this.end() > other.end() ? this.end() : other.end();
-        return new TimeRange(new Date(b.getTime()), new Date(e.getTime()));
-    }
-    /**
-     * Returns a new `TimeRange` which represents the intersection
-     * (overlapping) part of this and other.
-     */
-    intersection(other) {
-        if (this.disjoint(other)) {
-            return;
-        }
-        const b = this.begin() > other.begin() ? this.begin() : other.begin();
-        const e = this.end() < other.end() ? this.end() : other.end();
-        return new TimeRange(new Date(b.getTime()), new Date(e.getTime()));
-    }
-    /**
-     * Returns the duration of the `TimeRange` in milliseconds
-     */
-    duration() {
-        return this.end().getTime() - this.begin().getTime();
-    }
-    /**
-     * A user friendly version of the duration.
-     */
-    humanizeDuration() {
-        return moment.duration(this.duration()).humanize();
-    }
+    const b = this.begin() > other.begin() ? this.begin() : other.begin();
+    const e = this.end() < other.end() ? this.end() : other.end();
+    return new TimeRange(new Date(b.getTime()), new Date(e.getTime()));
+  }
+  /**
+   * Returns the duration of the `TimeRange` in milliseconds
+   */
+  duration() {
+    return this.end().getTime() - this.begin().getTime();
+  }
+  /**
+   * A user friendly version of the duration.
+   */
+  humanizeDuration() {
+    return moment.duration(this.duration()).humanize();
+  }
 }
 exports.TimeRange = TimeRange;
 function timerange(arg1, arg2) {
-    return new TimeRange(arg1, arg2);
+  return new TimeRange(arg1, arg2);
 }
 exports.timerange = timerange;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGltZXJhbmdlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vc3JjL3RpbWVyYW5nZS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUE7Ozs7Ozs7O0dBUUc7O0FBRUgsdUNBQXVDO0FBQ3ZDLDRCQUE0QjtBQUM1QixpQ0FBaUM7QUFHakMsK0JBQTRCO0FBQzVCLGlDQUFvQztBQUNwQyxtQ0FBd0M7QUFFeEM7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FtQkc7QUFDSCxNQUFhLFNBQVUsU0FBUSxTQUFHO0lBbUI5QixZQUFZLElBQVMsRUFBRSxJQUFVO1FBQzdCLEtBQUssRUFBRSxDQUFDO1FBQ1IsSUFBSSxJQUFJLFlBQVksU0FBUyxFQUFFO1lBQzNCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQztZQUNuQixJQUFJLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUM7U0FDOUI7YUFBTSxJQUFJLElBQUksWUFBWSxTQUFTLENBQUMsSUFBSSxFQUFFO1lBQ3ZDLE1BQU0sU0FBUyxHQUFHLElBQUksQ0FBQztZQUN2QixJQUFJLENBQUMsTUFBTSxHQUFHLFNBQVMsQ0FBQztTQUMzQjthQUFNLElBQUksSUFBSSxZQUFZLEtBQUssRUFBRTtZQUM5QixNQUFNLFVBQVUsR0FBRyxJQUFJLENBQUM7WUFDeEIsSUFBSSxDQUFDLE1BQU0sR0FBRyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsVUFBVSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1NBQ3BGO2FBQU07WUFDSCxNQUFNLENBQUMsR0FBRyxJQUFJLENBQUM7WUFDZixNQUFNLENBQUMsR0FBRyxJQUFJLENBQUM7WUFDZixJQUFJLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsRUFBRTtnQkFDNUIsSUFBSSxDQUFDLE1BQU0sR0FBRyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO2FBQ2hGO2lCQUFNLElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsSUFBSSxNQUFNLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxFQUFFO2dCQUNqRCxJQUFJLENBQUMsTUFBTSxHQUFHLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsRUFBRSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7YUFDaEY7aUJBQU0sSUFBSSxXQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxJQUFJLFdBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUU7Z0JBQ3pDLElBQUksQ0FBQyxNQUFNLEdBQUcsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQzthQUNoRjtpQkFBTSxJQUFJLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsRUFBRTtnQkFDdkMsSUFBSSxDQUFDLE1BQU0sR0FBRyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO2FBQzVEO1NBQ0o7SUFDTCxDQUFDO0lBRUQsSUFBSTtRQUNBLE9BQU8sV0FBVyxDQUFDO0lBQ3ZCLENBQUM7SUFFRDs7O09BR0c7SUFDSCxRQUFRO1FBQ0osT0FBTyxJQUFJLENBQUMsTUFBTSxDQUFDO0lBQ3ZCLENBQUM7SUFFRDs7O09BR0c7SUFDSCxNQUFNO1FBQ0YsT0FBTyxFQUFFLFNBQVMsRUFBRSxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxPQUFPLEVBQUUsRUFBRSxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsT0FBTyxFQUFFLENBQUMsRUFBRSxDQUFDO0lBQ3pFLENBQUM7SUFFRDs7OztPQUlHO0lBQ0gsUUFBUTtRQUNKLE9BQU8sSUFBSSxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztJQUN6QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxhQUFhO1FBQ1QsT0FBTyxJQUFJLElBQUksQ0FBQyxLQUFLLEVBQUUsS0FBSyxJQUFJLENBQUMsR0FBRyxFQUFFLEdBQUcsQ0FBQztJQUM5QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxXQUFXO1FBQ1AsT0FBTyxJQUFJLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxXQUFXLEVBQUUsS0FBSyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsV0FBVyxFQUFFLEdBQUcsQ0FBQztJQUMxRSxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUTtRQUNKLE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztRQUNuQyxNQUFNLEdBQUcsR0FBRyxNQUFNLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7UUFDL0IsTUFBTSxRQUFRLEdBQUcsS0FBSyxDQUFDLE1BQU0sQ0FBQyx3QkFBd0IsQ0FBQyxDQUFDO1FBQ3hELE1BQU0sTUFBTSxHQUFHLEdBQUcsQ0FBQyxNQUFNLENBQUMsd0JBQXdCLENBQUMsQ0FBQztRQUNwRCxPQUFPLEdBQUcsUUFBUSxPQUFPLE1BQU0sRUFBRSxDQUFDO0lBQ3RDLENBQUM7SUFFRDs7OztPQUlHO0lBQ0gsY0FBYztRQUNWLE1BQU0sS0FBSyxHQUFHLE1BQU0sQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztRQUNuQyxNQUFNLEdBQUcsR0FBRyxNQUFNLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7UUFDL0IsT0FBTyxHQUFHLEtBQUssQ0FBQyxPQUFPLEVBQUUsT0FBTyxHQUFHLENBQUMsT0FBTyxFQUFFLEVBQUUsQ0FBQztJQUNwRCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxLQUFLO1FBQ0QsT0FBTyxJQUFJLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUM5QixDQUFDO0lBRUQ7O09BRUc7SUFDSCxHQUFHO1FBQ0MsT0FBTyxJQUFJLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUM5QixDQUFDO0lBRUQ7O09BRUc7SUFDSCxHQUFHO1FBQ0MsT0FBTyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxHQUFHLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUM7SUFDdkQsQ0FBQztJQUVEOzs7Ozs7OztPQVFHO0lBQ0gsTUFBTSxDQUFDLEtBQW9CO1FBQ3ZCLFFBQVEsS0FBSyxFQUFFO1lBQ1gsS0FBSyxxQkFBYSxDQUFDLEtBQUs7Z0JBQ3BCLE9BQU8sV0FBSSxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDO2dCQUMxQixNQUFNO1lBQ1YsS0FBSyxxQkFBYSxDQUFDLE1BQU07Z0JBQ3JCLE9BQU8sV0FBSSxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDO2dCQUN4QixNQUFNO1lBQ1YsS0FBSyxxQkFBYSxDQUFDLEdBQUc7Z0JBQ2xCLE9BQU8sV0FBSSxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDO2dCQUN4QixNQUFNO1NBQ2I7SUFDTCxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsU0FBUztRQUNMLE9BQU8sSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQ3RCLENBQUM7SUFFRDs7O09BR0c7SUFDSCxRQUFRLENBQUMsQ0FBTztRQUNaLE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDaEQsQ0FBQztJQUVEOzs7T0FHRztJQUNILE1BQU0sQ0FBQyxDQUFPO1FBQ1YsT0FBTyxJQUFJLFNBQVMsQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNoRCxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsTUFBTSxDQUFDLEtBQWdCO1FBQ25CLE9BQU8sQ0FDSCxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsT0FBTyxFQUFFLEtBQUssS0FBSyxDQUFDLEtBQUssRUFBRSxDQUFDLE9BQU8sRUFBRTtZQUNsRCxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsT0FBTyxFQUFFLEtBQUssS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLE9BQU8sRUFBRSxDQUNqRCxDQUFDO0lBQ04sQ0FBQztJQUVEOzs7T0FHRztJQUNILFFBQVEsQ0FBQyxLQUF1QjtRQUM1QixJQUFJLENBQUMsQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLEVBQUU7WUFDakIsT0FBTyxJQUFJLENBQUMsS0FBSyxFQUFFLElBQUksS0FBSyxJQUFJLElBQUksQ0FBQyxHQUFHLEVBQUUsSUFBSSxLQUFLLENBQUM7U0FDdkQ7YUFBTTtZQUNILE9BQU8sSUFBSSxDQUFDLEtBQUssRUFBRSxJQUFJLEtBQUssQ0FBQyxLQUFLLEVBQUUsSUFBSSxJQUFJLENBQUMsR0FBRyxFQUFFLElBQUksS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDO1NBQ3JFO0lBQ0wsQ0FBQztJQUVEOzs7T0FHRztJQUNILE1BQU0sQ0FBQyxLQUFnQjtRQUNuQixPQUFPLElBQUksQ0FBQyxLQUFLLEVBQUUsSUFBSSxLQUFLLENBQUMsS0FBSyxFQUFFLElBQUksSUFBSSxDQUFDLEdBQUcsRUFBRSxJQUFJLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUN0RSxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUSxDQUFDLEtBQWdCO1FBQ3JCLElBQ0ksQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQztZQUM3RCxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLEVBQy9EO1lBQ0UsT0FBTyxJQUFJLENBQUM7U0FDZjthQUFNO1lBQ0gsT0FBTyxLQUFLLENBQUM7U0FDaEI7SUFDTCxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUSxDQUFDLEtBQWdCO1FBQ3JCLE9BQU8sSUFBSSxDQUFDLEdBQUcsRUFBRSxHQUFHLEtBQUssQ0FBQyxLQUFLLEVBQUUsSUFBSSxJQUFJLENBQUMsS0FBSyxFQUFFLEdBQUcsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQ3BFLENBQUM7SUFFRDs7O09BR0c7SUFDSCxPQUFPLENBQUMsS0FBZ0I7UUFDcEIsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLEtBQUssRUFBRSxHQUFHLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUM7UUFDdEUsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLEdBQUcsRUFBRSxHQUFHLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUM7UUFDOUQsT0FBTyxJQUFJLFNBQVMsQ0FBQyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsRUFBRSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDO0lBQ3ZFLENBQUM7SUFFRDs7O09BR0c7SUFDSCxZQUFZLENBQUMsS0FBZ0I7UUFDekIsSUFBSSxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxFQUFFO1lBQ3RCLE9BQU87U0FDVjtRQUNELE1BQU0sQ0FBQyxHQUFHLElBQUksQ0FBQyxLQUFLLEVBQUUsR0FBRyxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3RFLE1BQU0sQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDO1FBQzlELE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQztJQUN2RSxDQUFDO0lBRUQ7O09BRUc7SUFDSCxRQUFRO1FBQ0osT0FBTyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsT0FBTyxFQUFFLEdBQUcsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLE9BQU8sRUFBRSxDQUFDO0lBQ3pELENBQUM7SUFFRDs7T0FFRztJQUNILGdCQUFnQjtRQUNaLE9BQU8sTUFBTSxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsUUFBUSxFQUFFLENBQUMsQ0FBQyxRQUFRLEVBQUUsQ0FBQztJQUN2RCxDQUFDO0NBQ0o7QUE3UUQsOEJBNlFDO0FBV0QsU0FBUyxTQUFTLENBQUMsSUFBUyxFQUFFLElBQVU7SUFDcEMsT0FBTyxJQUFJLFNBQVMsQ0FBQyxJQUFJLEVBQUUsSUFBSSxDQUFDLENBQUM7QUFDckMsQ0FBQztBQUVRLDhCQUFTIn0=
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGltZXJhbmdlLmpzIiwic291cmNlUm9vdCI6IiIsInNvdXJjZXMiOlsiLi4vc3JjL3RpbWVyYW5nZS50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUE7Ozs7Ozs7O0dBUUc7O0FBRUgsdUNBQXVDO0FBQ3ZDLDRCQUE0QjtBQUM1QixpQ0FBaUM7QUFHakMsK0JBQTRCO0FBQzVCLGlDQUFvQztBQUNwQyxtQ0FBd0M7QUFFeEM7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FtQkc7QUFDSCxNQUFhLFNBQVUsU0FBUSxTQUFHO0lBbUI5QixZQUFZLElBQVMsRUFBRSxJQUFVO1FBQzdCLEtBQUssRUFBRSxDQUFDO1FBQ1IsSUFBSSxJQUFJLFlBQVksU0FBUyxFQUFFO1lBQzNCLE1BQU0sS0FBSyxHQUFHLElBQUksQ0FBQztZQUNuQixJQUFJLENBQUMsTUFBTSxHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUM7U0FDOUI7YUFBTSxJQUFJLElBQUksWUFBWSxTQUFTLENBQUMsSUFBSSxFQUFFO1lBQ3ZDLE1BQU0sU0FBUyxHQUFHLElBQTRCLENBQUM7WUFDL0MsSUFBSSxDQUFDLE1BQU0sR0FBRyxTQUFTLENBQUM7U0FDM0I7YUFBTSxJQUFJLElBQUksWUFBWSxLQUFLLEVBQUU7WUFDOUIsTUFBTSxVQUFVLEdBQUcsSUFBSSxDQUFDO1lBQ3hCLElBQUksQ0FBQyxNQUFNLEdBQUcsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztTQUNwRjthQUFNO1lBQ0gsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDO1lBQ2YsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDO1lBQ2YsSUFBSSxDQUFDLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLEVBQUU7Z0JBQzVCLElBQUksQ0FBQyxNQUFNLEdBQUcsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQzthQUNoRjtpQkFBTSxJQUFJLE1BQU0sQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsRUFBRTtnQkFDakQsSUFBSSxDQUFDLE1BQU0sR0FBRyxTQUFTLENBQUMsSUFBSSxDQUFDLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO2FBQ2hGO2lCQUFNLElBQUksV0FBSSxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUMsSUFBSSxXQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxFQUFFO2dCQUN6QyxJQUFJLENBQUMsTUFBTSxHQUFHLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsRUFBRSxJQUFJLElBQUksQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7YUFDaEY7aUJBQU0sSUFBSSxDQUFDLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLEVBQUU7Z0JBQ3ZDLElBQUksQ0FBQyxNQUFNLEdBQUcsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQzthQUM1RDtTQUNKO0lBQ0wsQ0FBQztJQUVELElBQUk7UUFDQSxPQUFPLFdBQVcsQ0FBQztJQUN2QixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUTtRQUNKLE9BQU8sSUFBSSxDQUFDLE1BQU0sQ0FBQztJQUN2QixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsTUFBTTtRQUNGLE9BQU8sRUFBRSxTQUFTLEVBQUUsQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsT0FBTyxFQUFFLEVBQUUsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLE9BQU8sRUFBRSxDQUFDLEVBQUUsQ0FBQztJQUN6RSxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILFFBQVE7UUFDSixPQUFPLElBQUksQ0FBQyxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUM7SUFDekMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsYUFBYTtRQUNULE9BQU8sSUFBSSxJQUFJLENBQUMsS0FBSyxFQUFFLEtBQUssSUFBSSxDQUFDLEdBQUcsRUFBRSxHQUFHLENBQUM7SUFDOUMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsV0FBVztRQUNQLE9BQU8sSUFBSSxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsV0FBVyxFQUFFLEtBQUssSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLFdBQVcsRUFBRSxHQUFHLENBQUM7SUFDMUUsQ0FBQztJQUVEOzs7T0FHRztJQUNILFFBQVE7UUFDSixNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUM7UUFDbkMsTUFBTSxHQUFHLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQy9CLE1BQU0sUUFBUSxHQUFHLEtBQUssQ0FBQyxNQUFNLENBQUMsd0JBQXdCLENBQUMsQ0FBQztRQUN4RCxNQUFNLE1BQU0sR0FBRyxHQUFHLENBQUMsTUFBTSxDQUFDLHdCQUF3QixDQUFDLENBQUM7UUFDcEQsT0FBTyxHQUFHLFFBQVEsT0FBTyxNQUFNLEVBQUUsQ0FBQztJQUN0QyxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILGNBQWM7UUFDVixNQUFNLEtBQUssR0FBRyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUM7UUFDbkMsTUFBTSxHQUFHLEdBQUcsTUFBTSxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDO1FBQy9CLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxFQUFFLE9BQU8sR0FBRyxDQUFDLE9BQU8sRUFBRSxFQUFFLENBQUM7SUFDcEQsQ0FBQztJQUVEOztPQUVHO0lBQ0gsS0FBSztRQUNELE9BQU8sSUFBSSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDOUIsQ0FBQztJQUVEOztPQUVHO0lBQ0gsR0FBRztRQUNDLE9BQU8sSUFBSSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDOUIsQ0FBQztJQUVEOztPQUVHO0lBQ0gsR0FBRztRQUNDLE9BQU8sSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsR0FBRyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDO0lBQ3ZELENBQUM7SUFFRDs7Ozs7Ozs7T0FRRztJQUNILE1BQU0sQ0FBQyxLQUFvQjtRQUN2QixRQUFRLEtBQUssRUFBRTtZQUNYLEtBQUsscUJBQWEsQ0FBQyxLQUFLO2dCQUNwQixPQUFPLFdBQUksQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztnQkFDMUIsTUFBTTtZQUNWLEtBQUsscUJBQWEsQ0FBQyxNQUFNO2dCQUNyQixPQUFPLFdBQUksQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQztnQkFDeEIsTUFBTTtZQUNWLEtBQUsscUJBQWEsQ0FBQyxHQUFHO2dCQUNsQixPQUFPLFdBQUksQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQztnQkFDeEIsTUFBTTtTQUNiO0lBQ0wsQ0FBQztJQUVEOzs7T0FHRztJQUNILFNBQVM7UUFDTCxPQUFPLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUN0QixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUSxDQUFDLENBQU87UUFDWixPQUFPLElBQUksU0FBUyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDO0lBQ2hELENBQUM7SUFFRDs7O09BR0c7SUFDSCxNQUFNLENBQUMsQ0FBTztRQUNWLE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDaEQsQ0FBQztJQUVEOzs7T0FHRztJQUNILE1BQU0sQ0FBQyxLQUFnQjtRQUNuQixPQUFPLENBQ0gsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLE9BQU8sRUFBRSxLQUFLLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQyxPQUFPLEVBQUU7WUFDbEQsSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLE9BQU8sRUFBRSxLQUFLLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxPQUFPLEVBQUUsQ0FDakQsQ0FBQztJQUNOLENBQUM7SUFFRDs7O09BR0c7SUFDSCxRQUFRLENBQUMsS0FBdUI7UUFDNUIsSUFBSSxDQUFDLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxFQUFFO1lBQ2pCLE9BQU8sSUFBSSxDQUFDLEtBQUssRUFBRSxJQUFJLEtBQUssSUFBSSxJQUFJLENBQUMsR0FBRyxFQUFFLElBQUksS0FBSyxDQUFDO1NBQ3ZEO2FBQU07WUFDSCxPQUFPLElBQUksQ0FBQyxLQUFLLEVBQUUsSUFBSSxLQUFLLENBQUMsS0FBSyxFQUFFLElBQUksSUFBSSxDQUFDLEdBQUcsRUFBRSxJQUFJLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQztTQUNyRTtJQUNMLENBQUM7SUFFRDs7O09BR0c7SUFDSCxNQUFNLENBQUMsS0FBZ0I7UUFDbkIsT0FBTyxJQUFJLENBQUMsS0FBSyxFQUFFLElBQUksS0FBSyxDQUFDLEtBQUssRUFBRSxJQUFJLElBQUksQ0FBQyxHQUFHLEVBQUUsSUFBSSxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDdEUsQ0FBQztJQUVEOzs7T0FHRztJQUNILFFBQVEsQ0FBQyxLQUFnQjtRQUNyQixJQUNJLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUM7WUFDN0QsQ0FBQyxJQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxFQUMvRDtZQUNFLE9BQU8sSUFBSSxDQUFDO1NBQ2Y7YUFBTTtZQUNILE9BQU8sS0FBSyxDQUFDO1NBQ2hCO0lBQ0wsQ0FBQztJQUVEOzs7T0FHRztJQUNILFFBQVEsQ0FBQyxLQUFnQjtRQUNyQixPQUFPLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxLQUFLLENBQUMsS0FBSyxFQUFFLElBQUksSUFBSSxDQUFDLEtBQUssRUFBRSxHQUFHLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQztJQUNwRSxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsT0FBTyxDQUFDLEtBQWdCO1FBQ3BCLE1BQU0sQ0FBQyxHQUFHLElBQUksQ0FBQyxLQUFLLEVBQUUsR0FBRyxLQUFLLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3RFLE1BQU0sQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLEVBQUUsR0FBRyxLQUFLLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxHQUFHLEVBQUUsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDO1FBQzlELE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLEVBQUUsSUFBSSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQztJQUN2RSxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsWUFBWSxDQUFDLEtBQWdCO1FBQ3pCLElBQUksSUFBSSxDQUFDLFFBQVEsQ0FBQyxLQUFLLENBQUMsRUFBRTtZQUN0QixPQUFPO1NBQ1Y7UUFDRCxNQUFNLENBQUMsR0FBRyxJQUFJLENBQUMsS0FBSyxFQUFFLEdBQUcsS0FBSyxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUN0RSxNQUFNLENBQUMsR0FBRyxJQUFJLENBQUMsR0FBRyxFQUFFLEdBQUcsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsR0FBRyxFQUFFLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQztRQUM5RCxPQUFPLElBQUksU0FBUyxDQUFDLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxFQUFFLElBQUksSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDdkUsQ0FBQztJQUVEOztPQUVHO0lBQ0gsUUFBUTtRQUNKLE9BQU8sSUFBSSxDQUFDLEdBQUcsRUFBRSxDQUFDLE9BQU8sRUFBRSxHQUFHLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxPQUFPLEVBQUUsQ0FBQztJQUN6RCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxnQkFBZ0I7UUFDWixPQUFPLE1BQU0sQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUMsUUFBUSxFQUFFLENBQUM7SUFDdkQsQ0FBQztDQUNKO0FBN1FELDhCQTZRQztBQVdELFNBQVMsU0FBUyxDQUFDLElBQVMsRUFBRSxJQUFVO0lBQ3BDLE9BQU8sSUFBSSxTQUFTLENBQUMsSUFBSSxFQUFFLElBQUksQ0FBQyxDQUFDO0FBQ3JDLENBQUM7QUFFUSw4QkFBUyJ9

--- a/packages/pond/lib/timeseries.js
+++ b/packages/pond/lib/timeseries.js
@@ -8,15 +8,18 @@
  *  This source code is licensed under the BSD-style license found in the
  *  LICENSE file in the root directory of this source tree.
  */
-var __rest = (this && this.__rest) || function (s, e) {
+var __rest =
+  (this && this.__rest) ||
+  function(s, e) {
     var t = {};
-    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+    for (var p in s)
+      if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
         t[p] = s[p];
     if (s != null && typeof Object.getOwnPropertySymbols === "function")
-        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) if (e.indexOf(p[i]) < 0)
-            t[p[i]] = s[p[i]];
+      for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++)
+        if (e.indexOf(p[i]) < 0) t[p[i]] = s[p[i]];
     return t;
-};
+  };
 Object.defineProperty(exports, "__esModule", { value: true });
 const Immutable = require("immutable");
 const _ = require("lodash");
@@ -30,24 +33,23 @@ const window_1 = require("./window");
 const functions_1 = require("./functions");
 const types_1 = require("./types");
 function buildMetaData(meta) {
-    const d = meta ? meta : {};
-    // Name
-    d.name = meta.name ? meta.name : "";
-    // Index
-    if (meta.index) {
-        if (_.isString(meta.index)) {
-            d.index = new index_1.Index(meta.index).asString();
-        }
-        else if (meta.index instanceof index_1.Index) {
-            d.index = meta.index.asString();
-        }
+  const d = meta ? meta : {};
+  // Name
+  d.name = meta.name ? meta.name : "";
+  // Index
+  if (meta.index) {
+    if (_.isString(meta.index)) {
+      d.index = new index_1.Index(meta.index).asString();
+    } else if (meta.index instanceof index_1.Index) {
+      d.index = meta.index.asString();
     }
-    // Timezone
-    d.tz = "Etc/UTC";
-    if (_.isString(meta.tz)) {
-        d.tz = meta.tz;
-    }
-    return Immutable.Map(d);
+  }
+  // Timezone
+  d.tz = "Etc/UTC";
+  if (_.isString(meta.tz)) {
+    d.tz = meta.tz;
+  }
+  return Immutable.Map(d);
 }
 /**
  * Create a `Time` based `TimeSeries` using the wire format
@@ -64,15 +66,18 @@ function buildMetaData(meta) {
  * ```
  */
 function timeSeries(arg) {
-    const wireFormat = arg;
-    const { columns, points, tz = "Etc/UTC" } = wireFormat, meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
-    const [eventKey, ...eventFields] = columns;
-    const events = points.map(point => {
-        const [key, ...eventValues] = point;
-        const d = _.zipObject(eventFields, eventValues);
-        return new event_1.Event(time_1.time(key), Immutable.fromJS(d));
-    });
-    return new TimeSeries(Object.assign({ events: Immutable.List(events) }, meta2));
+  const wireFormat = arg;
+  const { columns, points, tz = "Etc/UTC" } = wireFormat,
+    meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
+  const [eventKey, ...eventFields] = columns;
+  const events = points.map(point => {
+    const [key, ...eventValues] = point;
+    const d = _.zipObject(eventFields, eventValues);
+    return new event_1.Event(time_1.time(key), Immutable.fromJS(d));
+  });
+  return new TimeSeries(
+    Object.assign({ events: Immutable.List(events) }, meta2)
+  );
 }
 exports.timeSeries = timeSeries;
 /**
@@ -90,15 +95,18 @@ exports.timeSeries = timeSeries;
  * ```
  */
 function indexedSeries(arg) {
-    const wireFormat = arg;
-    const { columns, points, tz = "Etc/UTC" } = wireFormat, meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
-    const [eventKey, ...eventFields] = columns;
-    const events = points.map(point => {
-        const [key, ...eventValues] = point;
-        const d = _.zipObject(eventFields, eventValues);
-        return new event_1.Event(index_1.index(key), Immutable.fromJS(d));
-    });
-    return new TimeSeries(Object.assign({ events: Immutable.List(events) }, meta2));
+  const wireFormat = arg;
+  const { columns, points, tz = "Etc/UTC" } = wireFormat,
+    meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
+  const [eventKey, ...eventFields] = columns;
+  const events = points.map(point => {
+    const [key, ...eventValues] = point;
+    const d = _.zipObject(eventFields, eventValues);
+    return new event_1.Event(index_1.index(key), Immutable.fromJS(d));
+  });
+  return new TimeSeries(
+    Object.assign({ events: Immutable.List(events) }, meta2)
+  );
 }
 exports.indexedSeries = indexedSeries;
 /**
@@ -116,15 +124,21 @@ exports.indexedSeries = indexedSeries;
  * ```
  */
 function timeRangeSeries(arg) {
-    const wireFormat = arg;
-    const { columns, points, tz = "Etc/UTC" } = wireFormat, meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
-    const [eventKey, ...eventFields] = columns;
-    const events = points.map(point => {
-        const [key, ...eventValues] = point;
-        const d = _.zipObject(eventFields, eventValues);
-        return new event_1.Event(timerange_1.timerange(key[0], key[1]), Immutable.fromJS(d));
-    });
-    return new TimeSeries(Object.assign({ events: Immutable.List(events) }, meta2));
+  const wireFormat = arg;
+  const { columns, points, tz = "Etc/UTC" } = wireFormat,
+    meta2 = __rest(wireFormat, ["columns", "points", "tz"]);
+  const [eventKey, ...eventFields] = columns;
+  const events = points.map(point => {
+    const [key, ...eventValues] = point;
+    const d = _.zipObject(eventFields, eventValues);
+    return new event_1.Event(
+      timerange_1.timerange(key[0], key[1]),
+      Immutable.fromJS(d)
+    );
+  });
+  return new TimeSeries(
+    Object.assign({ events: Immutable.List(events) }, meta2)
+  );
 }
 exports.timeRangeSeries = timeRangeSeries;
 /**
@@ -199,933 +213,980 @@ exports.timeRangeSeries = timeRangeSeries;
  *
  */
 class TimeSeries {
-    /**
-     * You can initialize a `TimeSeries` with either a list of `Event`'s, or with
-     * what we call the wire format. Usually you would want to construct a `TimeSeries`
-     * by converting your data into this format.
-     *
-     * The format of the data is an object which has several special keys,
-     * i.e. fields that have special meaning for the `TimeSeries` and additional keys
-     * that are optionally added to form the meta data for the `TimeSeries`:
-     *
-     * Special keys:
-     *
-     *  - **name** - The name of the series (optional)
-     *  - **columns** - are necessary and give labels to the data in the points. The first
-     *                  column is special, it is the the key for the row and should be
-     *                  either "time", "timerange" or "index". Other columns are user
-     *                  defined. (required)
-     *  - **points** - are an array of tuples. Each row is at a different time (or timerange),
-     *                 and each value corresponds to the column labels. (required)
-     *  - **tz** - timezone (optional)
-     *
-     * You can add additional fields as meta data custom to your application.
-     *
-     * To create a new `TimeSeries` object from the above data format, simply use one of
-     * the factory functions. For `Time` based `TimeSeries` you would use `timeSeries()`.
-     * Other options are `timeRangeSeries()` and `indexedSeries()`:
-     *
-     * Example:
-     *
-     * ```
-     * import { timeSeries } from "pondjs";
-     *
-     * const series = timeSeries({
-     *     name: "traffic",
-     *     columns: ["time", "in", "out"],
-     *     points: [
-     *         [1400425947000, 52, 12],
-     *         [1400425948000, 18, 42],
-     *         [1400425949000, 26, 81],
-     *         [1400425950000, 93, 11],
-     *         ...
-     *     ]
-     * });
-     * ```
-     *
-     * Another example:
-     *
-     * ```
-     * const availability = indexedSeries({
-     *     name: "Last 3 months",
-     *     columns: ["index", "uptime", incidents],
-     *     points: [
-     *         ["2015-06", "100%", 0], // 2015-06 specified here for June 2015
-     *         ["2015-05", "92%", 2],
-     *         ["2015-04", "87%", 5]
-     *     ]
-     * });
-     * ```
-     *
-     * Alternatively, you can construct a `TimeSeries` with a list of events.
-     * To do this you need to use the `TimeSeries` constructor directly.
-     *
-     * These may be `TimeEvents`, `TimeRangeEvents` or `IndexedEvents`:
-     *
-     * ```
-     * import { TimeSeries } from "pondjs"
-     * const events = [];
-     * events.push(timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 })));
-     * events.push(timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 })));
-     * const series = new TimeSeries({
-     *     name: "events",
-     *     events: Immutable.List(events)
-     * });
-     * ```
-     */
-    constructor(arg) {
-        this._collection = null;
-        this._data = null;
-        if (arg instanceof TimeSeries) {
-            //
-            // Copy another TimeSeries
-            //
-            const other = arg;
-            this._data = other._data;
-            this._collection = other._collection;
-        }
-        else if (_.isObject(arg)) {
-            if (_.has(arg, "collection")) {
-                //
-                // Initialized from a Collection
-                //
-                const { collection } = arg, meta3 = __rest(arg, ["collection"]);
-                this._collection = new sortedcollection_1.SortedCollection(collection);
-                this._data = buildMetaData(meta3);
-            }
-            else if (_.has(arg, "events")) {
-                //
-                // Has a list of events
-                //
-                const { events } = arg, meta1 = __rest(arg, ["events"]);
-                this._collection = new sortedcollection_1.SortedCollection(events);
-                this._data = buildMetaData(meta1);
-            }
-        }
+  /**
+   * You can initialize a `TimeSeries` with either a list of `Event`'s, or with
+   * what we call the wire format. Usually you would want to construct a `TimeSeries`
+   * by converting your data into this format.
+   *
+   * The format of the data is an object which has several special keys,
+   * i.e. fields that have special meaning for the `TimeSeries` and additional keys
+   * that are optionally added to form the meta data for the `TimeSeries`:
+   *
+   * Special keys:
+   *
+   *  - **name** - The name of the series (optional)
+   *  - **columns** - are necessary and give labels to the data in the points. The first
+   *                  column is special, it is the the key for the row and should be
+   *                  either "time", "timerange" or "index". Other columns are user
+   *                  defined. (required)
+   *  - **points** - are an array of tuples. Each row is at a different time (or timerange),
+   *                 and each value corresponds to the column labels. (required)
+   *  - **tz** - timezone (optional)
+   *
+   * You can add additional fields as meta data custom to your application.
+   *
+   * To create a new `TimeSeries` object from the above data format, simply use one of
+   * the factory functions. For `Time` based `TimeSeries` you would use `timeSeries()`.
+   * Other options are `timeRangeSeries()` and `indexedSeries()`:
+   *
+   * Example:
+   *
+   * ```
+   * import { timeSeries } from "pondjs";
+   *
+   * const series = timeSeries({
+   *     name: "traffic",
+   *     columns: ["time", "in", "out"],
+   *     points: [
+   *         [1400425947000, 52, 12],
+   *         [1400425948000, 18, 42],
+   *         [1400425949000, 26, 81],
+   *         [1400425950000, 93, 11],
+   *         ...
+   *     ]
+   * });
+   * ```
+   *
+   * Another example:
+   *
+   * ```
+   * const availability = indexedSeries({
+   *     name: "Last 3 months",
+   *     columns: ["index", "uptime", incidents],
+   *     points: [
+   *         ["2015-06", "100%", 0], // 2015-06 specified here for June 2015
+   *         ["2015-05", "92%", 2],
+   *         ["2015-04", "87%", 5]
+   *     ]
+   * });
+   * ```
+   *
+   * Alternatively, you can construct a `TimeSeries` with a list of events.
+   * To do this you need to use the `TimeSeries` constructor directly.
+   *
+   * These may be `TimeEvents`, `TimeRangeEvents` or `IndexedEvents`:
+   *
+   * ```
+   * import { TimeSeries } from "pondjs"
+   * const events = [];
+   * events.push(timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 })));
+   * events.push(timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 })));
+   * const series = new TimeSeries({
+   *     name: "events",
+   *     events: Immutable.List(events)
+   * });
+   * ```
+   */
+  constructor(arg) {
+    this._collection = null;
+    this._data = null;
+    if (arg instanceof TimeSeries) {
+      //
+      // Copy another TimeSeries
+      //
+      const other = arg;
+      this._data = other._data;
+      this._collection = other._collection;
+    } else if (_.isObject(arg)) {
+      if (_.has(arg, "collection")) {
+        //
+        // Initialized from a Collection
+        //
+        const { collection } = arg,
+          meta3 = __rest(arg, ["collection"]);
+        this._collection = new sortedcollection_1.SortedCollection(collection);
+        this._data = buildMetaData(meta3);
+      } else if (_.has(arg, "events")) {
+        //
+        // Has a list of events
+        //
+        const { events } = arg,
+          meta1 = __rest(arg, ["events"]);
+        this._collection = new sortedcollection_1.SortedCollection(events);
+        this._data = buildMetaData(meta1);
+      }
     }
-    /**
-     * Turn the `TimeSeries` into regular javascript objects
-     */
-    toJSON() {
-        const e = this.atFirst();
-        if (!e) {
-            return;
-        }
-        const columns = [e.keyType(), ...this.columns()];
-        const points = [];
-        for (const evt of this._collection.eventList()) {
-            points.push(evt.toPoint(this.columns()));
-        }
-        return _.extend(this._data.toJSON(), { columns, points });
+  }
+  /**
+   * Turn the `TimeSeries` into regular javascript objects
+   */
+  toJSON() {
+    const e = this.atFirst();
+    if (!e) {
+      return;
     }
-    /**
-     * Represent the `TimeSeries` as a string, which is useful for
-     * serializing it across the network.
-     */
-    toString() {
-        return JSON.stringify(this.toJSON());
+    const columnList = this.columns();
+    const columns = [e.keyType(), ...columnList];
+    const points = [];
+    for (const evt of this._collection.eventList()) {
+      points.push(evt.toPoint(columnList));
     }
-    /**
-     * Returns the extents of the `TimeSeries` as a `TimeRange`.
-     */
-    timerange() {
-        return this._collection.timerange();
+    return _.extend(this._data.toJSON(), { columns, points });
+  }
+  /**
+   * Represent the `TimeSeries` as a string, which is useful for
+   * serializing it across the network.
+   */
+  toString() {
+    return JSON.stringify(this.toJSON());
+  }
+  /**
+   * Returns the extents of the `TimeSeries` as a `TimeRange`.
+   */
+  timerange() {
+    return this._collection.timerange();
+  }
+  /**
+   * Alias for `timerange()`
+   */
+  range() {
+    return this.timerange();
+  }
+  /**
+   * Gets the earliest time represented in the `TimeSeries`.
+   */
+  begin() {
+    return this.range().begin();
+  }
+  /**
+   * Gets the latest time represented in the `TimeSeries`.
+   */
+  end() {
+    return this.range().end();
+  }
+  /**
+   * Access a specific `TimeSeries` event via its position
+   */
+  at(pos) {
+    return this._collection.at(pos);
+  }
+  /**
+   * Returns an event in the series by its time. This is the same
+   * as calling `bisect()` first and then using `at()` with the index.
+   */
+  atTime(t) {
+    const pos = this.bisect(t);
+    if (pos >= 0 && pos < this.size()) {
+      return this.at(pos);
     }
-    /**
-     * Alias for `timerange()`
-     */
-    range() {
-        return this.timerange();
+  }
+  /**
+   * Returns the first `Event` in the series.
+   */
+  atFirst() {
+    return this._collection.firstEvent();
+  }
+  /**
+   * Returns the last `Event` in the series.
+   */
+  atLast() {
+    return this._collection.lastEvent();
+  }
+  /**
+   * Sets a new underlying collection for this `TimeSeries` and retuns a
+   * new `TimeSeries`.
+   */
+  setCollection(collection) {
+    const result = new TimeSeries(this);
+    if (collection) {
+      result._collection = collection;
+    } else {
+      result._collection = new sortedcollection_1.SortedCollection();
     }
-    /**
-     * Gets the earliest time represented in the `TimeSeries`.
-     */
-    begin() {
-        return this.range().begin();
+    return result;
+  }
+  /**
+   * Returns the index that bisects the `TimeSeries` at the time specified.
+   */
+  bisect(t, b) {
+    return this._collection.bisect(t, b);
+  }
+  /**
+   * Perform a slice of events within the `TimeSeries`, returns a new
+   * `TimeSeries` representing a portion of this `TimeSeries` from
+   * `begin` up to but not including `end`.
+   */
+  slice(begin, end) {
+    const sliced = new sortedcollection_1.SortedCollection(
+      this._collection.slice(begin, end)
+    );
+    return this.setCollection(sliced);
+  }
+  /**
+   * Crop the `TimeSeries` to the specified `TimeRange` and return a new `TimeSeries`.
+   */
+  crop(tr) {
+    const timerangeBegin = tr.begin();
+    let beginPos = this.bisect(timerangeBegin);
+    const bisectedEventOutsideRange =
+      this.at(beginPos).timestamp() < timerangeBegin;
+    beginPos = bisectedEventOutsideRange ? beginPos + 1 : beginPos;
+    const endPos = this.bisect(tr.end(), beginPos);
+    return this.slice(beginPos, endPos + 1);
+  }
+  //
+  // Access meta data about the series
+  //
+  /**
+   * Fetch the `TimeSeries` name
+   */
+  name() {
+    return this._data.get("name");
+  }
+  /**
+   * Rename the `TimeSeries`
+   */
+  setName(name) {
+    return this.setMeta("name", name);
+  }
+  /**
+   * Fetch the timeSeries `Index`, if it has one. This is still in the
+   * API for historical reasons but is just a short cut to calling
+   * `series.getMeta("index")`.
+   */
+  index() {
+    return index_1.index(this._data.get("index"));
+  }
+  /**
+   * Fetch the timeSeries `Index`, as a `string`, if it has one.
+   */
+  indexAsString() {
+    return this.index() ? this.index().asString() : undefined;
+  }
+  /**
+   * Fetch the timeseries `Index`, as a `TimeRange`, if it has one.
+   */
+  indexAsRange() {
+    return this.index() ? this.index().toTimeRange() : undefined;
+  }
+  /**
+   * Fetch if the timezone is UTC
+   */
+  isUTC() {
+    return this._data.get("tz") === "Etc/UTC";
+  }
+  /**
+   * Returns the timezone set on this `TimeSeries`.
+   */
+  timezone() {
+    return this._data.get("tz");
+  }
+  /**
+   * Fetch the list of column names as a list of string.
+   * This is determined by traversing though the events and collecting the set.
+   * Note: the order is not defined
+   */
+  columns() {
+    const c = {};
+    for (const e of this._collection.eventList()) {
+      const d = e.getData();
+      d.forEach((val, key) => {
+        c[key] = true;
+      });
     }
-    /**
-     * Gets the latest time represented in the `TimeSeries`.
-     */
-    end() {
-        return this.range().end();
+    return _.keys(c);
+  }
+  /**
+   * Returns the list of Events in the `Collection` of events for this `TimeSeries`
+   * The result is an Immutable.List of the `Event`s.
+   */
+  eventList() {
+    return this.collection().eventList();
+  }
+  /**
+   * Returns the internal `SortedCollection` of events for this `TimeSeries`
+   */
+  collection() {
+    return this._collection;
+  }
+  /**
+   * Returns the meta data about this `TimeSeries` as a JSON object.
+   * Any extra data supplied to the `TimeSeries` constructor will be
+   * placed in the meta data object. This returns either all of that
+   * data as a JSON object, or a specific key if `key` is supplied.
+   */
+  meta(key) {
+    if (!key) {
+      return this._data.toJSON();
+    } else {
+      return this._data.get(key);
     }
-    /**
-     * Access a specific `TimeSeries` event via its position
-     */
-    at(pos) {
-        return this._collection.at(pos);
-    }
-    /**
-     * Returns an event in the series by its time. This is the same
-     * as calling `bisect()` first and then using `at()` with the index.
-     */
-    atTime(t) {
-        const pos = this.bisect(t);
-        if (pos >= 0 && pos < this.size()) {
-            return this.at(pos);
-        }
-    }
-    /**
-     * Returns the first `Event` in the series.
-     */
-    atFirst() {
-        return this._collection.firstEvent();
-    }
-    /**
-     * Returns the last `Event` in the series.
-     */
-    atLast() {
-        return this._collection.lastEvent();
-    }
-    /**
-     * Sets a new underlying collection for this `TimeSeries` and retuns a
-     * new `TimeSeries`.
-     */
-    setCollection(collection) {
-        const result = new TimeSeries(this);
-        if (collection) {
-            result._collection = collection;
-        }
-        else {
-            result._collection = new sortedcollection_1.SortedCollection();
-        }
-        return result;
-    }
-    /**
-     * Returns the index that bisects the `TimeSeries` at the time specified.
-     */
-    bisect(t, b) {
-        return this._collection.bisect(t, b);
-    }
-    /**
-     * Perform a slice of events within the `TimeSeries`, returns a new
-     * `TimeSeries` representing a portion of this `TimeSeries` from
-     * `begin` up to but not including `end`.
-     */
-    slice(begin, end) {
-        const sliced = new sortedcollection_1.SortedCollection(this._collection.slice(begin, end));
-        return this.setCollection(sliced);
-    }
-    /**
-     * Crop the `TimeSeries` to the specified `TimeRange` and return a new `TimeSeries`.
-     */
-    crop(tr) {
-        const timerangeBegin = tr.begin();
-        let beginPos = this.bisect(timerangeBegin);
-        const bisectedEventOutsideRange = this.at(beginPos).timestamp() < timerangeBegin;
-        beginPos = bisectedEventOutsideRange ? beginPos + 1 : beginPos;
-        const endPos = this.bisect(tr.end(), beginPos);
-        return this.slice(beginPos, endPos + 1);
-    }
-    //
-    // Access meta data about the series
-    //
-    /**
-     * Fetch the `TimeSeries` name
-     */
-    name() {
-        return this._data.get("name");
-    }
-    /**
-     * Rename the `TimeSeries`
-     */
-    setName(name) {
-        return this.setMeta("name", name);
-    }
-    /**
-     * Fetch the timeSeries `Index`, if it has one. This is still in the
-     * API for historical reasons but is just a short cut to calling
-     * `series.getMeta("index")`.
-     */
-    index() {
-        return index_1.index(this._data.get("index"));
-    }
-    /**
-     * Fetch the timeSeries `Index`, as a `string`, if it has one.
-     */
-    indexAsString() {
-        return this.index() ? this.index().asString() : undefined;
-    }
-    /**
-     * Fetch the timeseries `Index`, as a `TimeRange`, if it has one.
-     */
-    indexAsRange() {
-        return this.index() ? this.index().toTimeRange() : undefined;
-    }
-    /**
-     * Fetch if the timezone is UTC
-     */
-    isUTC() {
-        return this._data.get("tz") === "Etc/UTC";
-    }
-    /**
-     * Returns the timezone set on this `TimeSeries`.
-     */
-    timezone() {
-        return this._data.get("tz");
-    }
-    /**
-     * Fetch the list of column names as a list of string.
-     * This is determined by traversing though the events and collecting the set.
-     * Note: the order is not defined
-     */
-    columns() {
-        const c = {};
-        for (const e of this._collection.eventList()) {
-            const d = e.getData();
-            d.forEach((val, key) => {
-                c[key] = true;
-            });
-        }
-        return _.keys(c);
-    }
-    /**
-     * Returns the list of Events in the `Collection` of events for this `TimeSeries`
-     * The result is an Immutable.List of the `Event`s.
-     */
-    eventList() {
-        return this.collection().eventList();
-    }
-    /**
-     * Returns the internal `SortedCollection` of events for this `TimeSeries`
-     */
-    collection() {
-        return this._collection;
-    }
-    /**
-     * Returns the meta data about this `TimeSeries` as a JSON object.
-     * Any extra data supplied to the `TimeSeries` constructor will be
-     * placed in the meta data object. This returns either all of that
-     * data as a JSON object, or a specific key if `key` is supplied.
-     */
-    meta(key) {
-        if (!key) {
-            return this._data.toJSON();
-        }
-        else {
-            return this._data.get(key);
-        }
-    }
-    /**
-     * Set new meta data for the `TimeSeries` using a `key` and `value`.
-     * The result will be a new `TimeSeries`.
-     */
-    setMeta(key, value) {
-        const newTimeSeries = new TimeSeries(this);
-        const d = newTimeSeries._data;
-        const dd = d.set(key, value);
-        newTimeSeries._data = dd;
-        return newTimeSeries;
-    }
-    /**
-     * Returns the number of events in this `TimeSeries`
-     */
-    size() {
-        return this._collection ? this._collection.size() : 0;
-    }
-    /**
-     * Returns the number of valid items in this `TimeSeries`.
-     *
-     * Uses the `fieldSpec` to look up values in all events.
-     * It then counts the number that are considered valid, which
-     * specifically are not NaN, undefined or null.
-     */
-    sizeValid(fieldSpec) {
-        return this._collection.sizeValid(fieldSpec);
-    }
-    /**
-     * Returns the number of events in this `TimeSeries`. Alias
-     * for size().
-     */
-    count() {
-        return this.size();
-    }
-    /**
-     * Returns the sum of the `Event`'s in this `Collection`
-     * for the `fieldspec`. Optionally pass in a filter function.
-     */
-    sum(fieldPath = "value", filter) {
-        return this._collection.sum(fieldPath, filter);
-    }
-    /**
-     * Aggregates the `Event`'s in this `TimeSeries` down to
-     * their maximum value(s).
-     *
-     * The `fieldSpec` passed into the avg function is either a field name or
-     * a list of fields.
-     *
-     * The `filter` is one of the Pond filter functions that can be used to remove
-     * bad values in different ways before filtering.
-     *
-     * The result is the maximum value if the fieldSpec is for one field. If
-     * multiple fields then a map of fieldName -> max values is returned
-     */
-    max(fieldPath = "value", filter) {
-        return this._collection.max(fieldPath, filter);
-    }
-    /**
-     * Aggregates the events down to their minimum value
-     */
-    min(fieldPath = "value", filter) {
-        return this._collection.min(fieldPath, filter);
-    }
-    /**
-     * Aggregates the `Event`'s in this `TimeSeries` down
-     * to their average(s).
-     *
-     * The `fieldSpec` passed into the avg function is either
-     * a field name or a list of fields.
-     *
-     * The `filter` is one of the Pond filter functions that can be used to remove
-     * bad values in different ways before filtering.
-     *
-     * Example:
-     * ```
-     * const series = timeSeries({
-     *     name: "data",
-     *     columns: ["time", "temperature"],
-     *     points: [
-     *         [1509725624100, 5],
-     *         [1509725624200, 8],
-     *         [1509725624300, 2]
-     *     ]
-     * });
-     * const avg = series.avg("temperature"); // 5
-     * ```
-     */
-    avg(fieldPath = "value", filter) {
-        return this._collection.avg(fieldPath, filter);
-    }
-    /**
-     * Aggregates the events down to their medium value
-     */
-    median(fieldPath = "value", filter) {
-        return this._collection.median(fieldPath, filter);
-    }
-    /**
-     * Aggregates the events down to their stdev
-     */
-    stdev(fieldPath = "value", filter) {
-        return this._collection.stdev(fieldPath, filter);
-    }
-    /**
-     * Gets percentile q within the `TimeSeries`. This works the same way as numpy.
-     *
-     * The percentile function has several parameters that can be supplied:
-     * * `q` - The percentile (should be between 0 and 100)
-     * * `fieldSpec` - Field or fields to find the percentile of
-     * * `interp` - Specifies the interpolation method to use when the desired, see below
-     * * `filter` - Optional filter function used to clean data before aggregating
-     *
-     * For `interp` a `InterpolationType` should be supplied if the default ("linear") is
-     * not used. This enum is defined like so:
-     * ```
-     * enum InterpolationType {
-     *     linear = 1,  // i + (j - i) * fraction
-     *     lower,       // i
-     *     higher,      // j
-     *     nearest,     // i or j, whichever is nearest
-     *     midpoint     // (i + j) / 2
-     * }
-     * ```
-     */
-    percentile(q, fieldPath = "value", interp = functions_1.InterpolationType.linear, filter) {
-        return this._collection.percentile(q, fieldPath, interp, filter);
-    }
-    /**
-     * Aggregates the `TimeSeries` `Event`s down to a single value per field.
-     *
-     * This makes use of a user defined function suppled as the `func` to do
-     * the reduction of values to a single value. The `ReducerFunction` is defined
-     * like so:
-     *
-     * ```
-     * (values: number[]) => number
-     * ```
-     *
-     * Fields to be aggregated are specified using a `fieldSpec` argument, which
-     * can be a field name or array of field names.
-     *
-     * If the `fieldSpec` matches multiple fields then an object is returned
-     * with keys being the fields and the values being the aggregated value for
-     * those fields. If the `fieldSpec` is for a single field then just the
-     * aggregated value is returned.
-     *
-     * Note: The `TimeSeries` class itself contains most of the common aggregation functions
-     * built in (e.g. `series.avg("value")`), but this is here to help when what
-     * you need isn't supplied out of the box.
-     */
-    aggregate(func, fieldPath = "value") {
-        return this._collection.aggregate(func, fieldPath);
-    }
-    /**
-     * Gets n quantiles within the `TimeSeries`. This works the same way as numpy's percentile().
-     * For example `timeseries.quantile(4)` would be the same as using percentile
-     * with q = 0.25, 0.5 and 0.75.
-     */
-    quantile(quantity, fieldPath = "value", interp = functions_1.InterpolationType.linear) {
-        return this._collection.quantile(quantity, fieldPath, interp);
-    }
-    /**
-     * Iterate over the events in this `TimeSeries`.
-     *
-     * `Event`s are in the chronological. The `sideEffect` is a user supplied
-     * function which is passed the `Event<T>` and the index:
-     * ```
-     * (e: Event<T>, index: number) => { //... }
-     * ```
-     *
-     * Returns the number of items iterated.
-     *
-     * Example:
-     * ```
-     * series.forEach((e, i) => {
-     *     console.log(`Event[${i}] is ${e.toString()}`);
-     * })
-     * ```
-     */
-    forEach(sideEffect) {
-        return this._collection.forEach(sideEffect);
-    }
-    /**
-     * Map the `Event`s in this `TimeSeries` to new `Event`s.
-     *
-     * For each `Event` passed to your `mapper` function you return a new Event:
-     * ```
-     * (event: Event<T>, index: number) => Event<M>
-     * ```
-     *
-     * Example:
-     * ```
-     * const mapped = sorted.map(e => {
-     *     return new Event(e.key(), { a: e.get("x") * 2 });
-     * });
-     * ```
-     */
-    map(mapper) {
-        const remapped = this._collection.map(mapper);
-        return this.setCollection(remapped);
-    }
-    /**
-     * Flat map over the events in this `TimeSeries`.
-     *
-     * For each `Event` passed to your callback function you should map that to
-     * zero, one or many `Event`s, returned as an `Immutable.List<Event>`.
-     *
-     * Example:
-     * ```
-     * const series = timeSeries({
-     *     name: "Map Traffic",
-     *     columns: ["time", "NASA_north", "NASA_south"],
-     *     points: [
-     *         [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
-     *         [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
-     *         [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
-     *         [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 42 }]
-     *     ]
-     * });
-     * const split = series.flatMap(e =>
-     *     Immutable.List([
-     *         e.setData(e.get("NASA_north")),
-     *         e.setData(e.get("NASA_south"))
-     *     ])
-     * );
-     * split.toString();
-     *
-     * // {
-     * //     "name": "Map Traffic",
-     * //     "tz": "Etc/UTC",
-     * //     "columns": ["time","in","out","other"],
-     * //     "points":[
-     * //         [1400425951000, 100, 200, null],
-     * //         [1400425951000, 145, 135, null],
-     * //         [1400425952000, 200, 400, null],
-     * //         [1400425952000, 146, 142, null],
-     * //         [1400425953000, 300, 600, null],
-     * //         [1400425953000, 147, 158, null],
-     * //         [1400425954000, 400, 800, null],
-     * //         [1400425954000, 155, 175, 42]
-     * //     ]
-     * // }
-     * ```
-     */
-    flatMap(mapper) {
-        const remapped = this._collection.flatMap(mapper);
-        return this.setCollection(remapped);
-    }
-    /**
-     * Remap the keys of the underlying Events, but keep the data the same.
-     *
-     * For example you can use this if you have a `TimeSeries<Index>` and want to
-     * convert to events of `TimeSeries<Time>`s.
-     *
-     * The mapper function supplied to `mapKeys` should return key of type
-     * `U` given a key of type `T`.
-     *
-     * Example:
-     *
-     * In this example we remap `Time` keys to `TimeRange` keys using the `Time.toTimeRange()`
-     * method, centering the new `TimeRange`s around each `Time` with duration given
-     * by the `Duration` object supplied, in this case representing one hour.
-     *
-     * ```
-     * const hourlyRanges = series.mapKeys<TimeRange>(t =>
-     *     t.toTimeRange(duration("1h"), TimeAlignment.Middle)
-     * );
-     * ```
-     *
-     */
-    mapKeys(mapper) {
-        const collection = new sortedcollection_1.SortedCollection(this._collection.mapKeys(mapper));
-        return this.setCollection(collection);
-    }
-    /**
-     * Filter the `TimeSeries`'s `Event`'s with the supplied function.
-     *
-     * The function `predicate` is passed each `Event` and should return
-     * true to keep the `Event` or false to discard.
-     *
-     * Example:
-     * ```
-     * const filtered = series.filter(e => e.get("a") < 8)
-     * ```
-     */
-    filter(predicate) {
-        const filtered = this._collection.filter(predicate);
-        return this.setCollection(filtered);
-    }
-    /**
-     * Select out specified columns from the `Event`s within this `TimeSeries`.
-     *
-     * The `select()` method needs to be supplied with a `SelectOptions`
-     * object, which takes the following form:
-     *
-     * ```
-     * {
-     *     fields: string[];
-     * }
-     * ```
-     * Options:
-     *  * `fields` - array of columns to keep within each `Event`.
-     *
-     * Example:
-     * ```
-     * const series = timeSeries({
-     *     name: "data",
-     *     columns: ["time", "a", "b", "c"],
-     *     points: [
-     *         [1509725624100, 5, 3, 4],
-     *         [1509725624200, 8, 1, 3],
-     *         [1509725624300, 2, 9, 1]
-     *     ]
-     * });
-     * const newSeries = series.select({
-     *     fields: ["b", "c"]
-     * });
-     *
-     * // returns a series with columns ["b", "c"] only, "a" is discarded.
-     * ```
-     */
-    select(options) {
-        const collection = new sortedcollection_1.SortedCollection(this._collection.select(options));
-        return this.setCollection(collection);
-    }
-    /**
-     * Collapse multiple columns of a `Collection` into a new column.
-     *
-     * The `collapse()` method needs to be supplied with a `CollapseOptions`
-     * object. You use this to specify the columns to collapse, the column name
-     * of the column to collapse to and the reducer function. In addition you
-     * can choose to append this new column or use it in place of the columns
-     * collapsed.
-     *
-     * ```
-     * {
-     *    fieldSpecList: string[];
-     *    fieldName: string;
-     *    reducer: any;
-     *    append: boolean;
-     * }
-     * ```
-     * Options:
-     *  * `fieldSpecList` - the list of fields to collapse
-     *  * `fieldName` - the new field's name
-     *  * `reducer()` - a function to collapse using e.g. `avg()`
-     *  * `append` - to include only the new field, or include it in addition
-     *     to the previous fields.
-     *
-     * Example:
-     * ```
-     * const series = timeSeries({
-     *     name: "data",
-     *     columns: ["time", "a", "b"],
-     *     points: [
-     *         [1509725624100, 5, 6],
-     *         [1509725624200, 4, 2],
-     *         [1509725624300, 6, 3]
-     *     ]
-     * });
-     *
-     * // Sum columns "a" and "b" into a new column "v"
-     * const sums = series.collapse({
-     *     fieldSpecList: ["a", "b"],
-     *     fieldName: "v",
-     *     reducer: sum(),
-     *     append: false
-     * });
-     *
-     * sums.at(0).get("v")  // 11
-     * sums.at(1).get("v")  // 6
-     * sums.at(2).get("v")  // 9
-     * ```
-     */
-    collapse(options) {
-        const collection = new sortedcollection_1.SortedCollection(this._collection.collapse(options));
-        return this.setCollection(collection);
-    }
-    /**
-     * Rename columns in the underlying events.
-     *
-     * Takes a object of columns to rename. Returns a new `TimeSeries` containing
-     * new events. Columns not in the dict will be retained and not renamed.
-     *
-     * Example:
-     * ```
-     * new_ts = ts.renameColumns({
-     *     renameMap: {in: "new_in", out: "new_out"}
-     * });
-     * ```
-     *
-     * As the name implies, this will only rename the main
-     * "top level" (ie: non-deep) columns. If you need more
-     * extravagant renaming, roll your own using `TimeSeries.map()`.
-     */
-    renameColumns(options) {
-        const { renameMap } = options;
-        return this.map(e => {
-            const eventType = e.keyType();
-            const d = e.getData().mapKeys(key => renameMap[key] || key);
-            switch (eventType) {
-                case "time":
-                    return new event_1.Event(time_1.time(e.toPoint(this.columns())[0]), d);
-                case "index":
-                    return new event_1.Event(index_1.index(e.toPoint(this.columns())[0]), d);
-                case "timerange":
-                    const timeArray = e.toPoint(this.columns())[0];
-                    return new event_1.Event(timerange_1.timerange(timeArray[0], timeArray[1]), d);
-            }
+  }
+  /**
+   * Set new meta data for the `TimeSeries` using a `key` and `value`.
+   * The result will be a new `TimeSeries`.
+   */
+  setMeta(key, value) {
+    const newTimeSeries = new TimeSeries(this);
+    const d = newTimeSeries._data;
+    const dd = d.set(key, value);
+    newTimeSeries._data = dd;
+    return newTimeSeries;
+  }
+  /**
+   * Returns the number of events in this `TimeSeries`
+   */
+  size() {
+    return this._collection ? this._collection.size() : 0;
+  }
+  /**
+   * Returns the number of valid items in this `TimeSeries`.
+   *
+   * Uses the `fieldSpec` to look up values in all events.
+   * It then counts the number that are considered valid, which
+   * specifically are not NaN, undefined or null.
+   */
+  sizeValid(fieldSpec) {
+    return this._collection.sizeValid(fieldSpec);
+  }
+  /**
+   * Returns the number of events in this `TimeSeries`. Alias
+   * for size().
+   */
+  count() {
+    return this.size();
+  }
+  /**
+   * Returns the sum of the `Event`'s in this `Collection`
+   * for the `fieldspec`. Optionally pass in a filter function.
+   */
+  sum(fieldPath = "value", filter) {
+    return this._collection.sum(fieldPath, filter);
+  }
+  /**
+   * Aggregates the `Event`'s in this `TimeSeries` down to
+   * their maximum value(s).
+   *
+   * The `fieldSpec` passed into the avg function is either a field name or
+   * a list of fields.
+   *
+   * The `filter` is one of the Pond filter functions that can be used to remove
+   * bad values in different ways before filtering.
+   *
+   * The result is the maximum value if the fieldSpec is for one field. If
+   * multiple fields then a map of fieldName -> max values is returned
+   */
+  max(fieldPath = "value", filter) {
+    return this._collection.max(fieldPath, filter);
+  }
+  /**
+   * Aggregates the events down to their minimum value
+   */
+  min(fieldPath = "value", filter) {
+    return this._collection.min(fieldPath, filter);
+  }
+  /**
+   * Aggregates the `Event`'s in this `TimeSeries` down
+   * to their average(s).
+   *
+   * The `fieldSpec` passed into the avg function is either
+   * a field name or a list of fields.
+   *
+   * The `filter` is one of the Pond filter functions that can be used to remove
+   * bad values in different ways before filtering.
+   *
+   * Example:
+   * ```
+   * const series = timeSeries({
+   *     name: "data",
+   *     columns: ["time", "temperature"],
+   *     points: [
+   *         [1509725624100, 5],
+   *         [1509725624200, 8],
+   *         [1509725624300, 2]
+   *     ]
+   * });
+   * const avg = series.avg("temperature"); // 5
+   * ```
+   */
+  avg(fieldPath = "value", filter) {
+    return this._collection.avg(fieldPath, filter);
+  }
+  /**
+   * Aggregates the events down to their medium value
+   */
+  median(fieldPath = "value", filter) {
+    return this._collection.median(fieldPath, filter);
+  }
+  /**
+   * Aggregates the events down to their stdev
+   */
+  stdev(fieldPath = "value", filter) {
+    return this._collection.stdev(fieldPath, filter);
+  }
+  /**
+   * Gets percentile q within the `TimeSeries`. This works the same way as numpy.
+   *
+   * The percentile function has several parameters that can be supplied:
+   * * `q` - The percentile (should be between 0 and 100)
+   * * `fieldSpec` - Field or fields to find the percentile of
+   * * `interp` - Specifies the interpolation method to use when the desired, see below
+   * * `filter` - Optional filter function used to clean data before aggregating
+   *
+   * For `interp` a `InterpolationType` should be supplied if the default ("linear") is
+   * not used. This enum is defined like so:
+   * ```
+   * enum InterpolationType {
+   *     linear = 1,  // i + (j - i) * fraction
+   *     lower,       // i
+   *     higher,      // j
+   *     nearest,     // i or j, whichever is nearest
+   *     midpoint     // (i + j) / 2
+   * }
+   * ```
+   */
+  percentile(
+    q,
+    fieldPath = "value",
+    interp = functions_1.InterpolationType.linear,
+    filter
+  ) {
+    return this._collection.percentile(q, fieldPath, interp, filter);
+  }
+  /**
+   * Aggregates the `TimeSeries` `Event`s down to a single value per field.
+   *
+   * This makes use of a user defined function suppled as the `func` to do
+   * the reduction of values to a single value. The `ReducerFunction` is defined
+   * like so:
+   *
+   * ```
+   * (values: number[]) => number
+   * ```
+   *
+   * Fields to be aggregated are specified using a `fieldSpec` argument, which
+   * can be a field name or array of field names.
+   *
+   * If the `fieldSpec` matches multiple fields then an object is returned
+   * with keys being the fields and the values being the aggregated value for
+   * those fields. If the `fieldSpec` is for a single field then just the
+   * aggregated value is returned.
+   *
+   * Note: The `TimeSeries` class itself contains most of the common aggregation functions
+   * built in (e.g. `series.avg("value")`), but this is here to help when what
+   * you need isn't supplied out of the box.
+   */
+  aggregate(func, fieldPath = "value") {
+    return this._collection.aggregate(func, fieldPath);
+  }
+  /**
+   * Gets n quantiles within the `TimeSeries`. This works the same way as numpy's percentile().
+   * For example `timeseries.quantile(4)` would be the same as using percentile
+   * with q = 0.25, 0.5 and 0.75.
+   */
+  quantile(
+    quantity,
+    fieldPath = "value",
+    interp = functions_1.InterpolationType.linear
+  ) {
+    return this._collection.quantile(quantity, fieldPath, interp);
+  }
+  /**
+   * Iterate over the events in this `TimeSeries`.
+   *
+   * `Event`s are in the chronological. The `sideEffect` is a user supplied
+   * function which is passed the `Event<T>` and the index:
+   * ```
+   * (e: Event<T>, index: number) => { //... }
+   * ```
+   *
+   * Returns the number of items iterated.
+   *
+   * Example:
+   * ```
+   * series.forEach((e, i) => {
+   *     console.log(`Event[${i}] is ${e.toString()}`);
+   * })
+   * ```
+   */
+  forEach(sideEffect) {
+    return this._collection.forEach(sideEffect);
+  }
+  /**
+   * Map the `Event`s in this `TimeSeries` to new `Event`s.
+   *
+   * For each `Event` passed to your `mapper` function you return a new Event:
+   * ```
+   * (event: Event<T>, index: number) => Event<M>
+   * ```
+   *
+   * Example:
+   * ```
+   * const mapped = sorted.map(e => {
+   *     return new Event(e.key(), { a: e.get("x") * 2 });
+   * });
+   * ```
+   */
+  map(mapper) {
+    const remapped = this._collection.map(mapper);
+    return this.setCollection(remapped);
+  }
+  /**
+   * Flat map over the events in this `TimeSeries`.
+   *
+   * For each `Event` passed to your callback function you should map that to
+   * zero, one or many `Event`s, returned as an `Immutable.List<Event>`.
+   *
+   * Example:
+   * ```
+   * const series = timeSeries({
+   *     name: "Map Traffic",
+   *     columns: ["time", "NASA_north", "NASA_south"],
+   *     points: [
+   *         [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
+   *         [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
+   *         [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
+   *         [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 42 }]
+   *     ]
+   * });
+   * const split = series.flatMap(e =>
+   *     Immutable.List([
+   *         e.setData(e.get("NASA_north")),
+   *         e.setData(e.get("NASA_south"))
+   *     ])
+   * );
+   * split.toString();
+   *
+   * // {
+   * //     "name": "Map Traffic",
+   * //     "tz": "Etc/UTC",
+   * //     "columns": ["time","in","out","other"],
+   * //     "points":[
+   * //         [1400425951000, 100, 200, null],
+   * //         [1400425951000, 145, 135, null],
+   * //         [1400425952000, 200, 400, null],
+   * //         [1400425952000, 146, 142, null],
+   * //         [1400425953000, 300, 600, null],
+   * //         [1400425953000, 147, 158, null],
+   * //         [1400425954000, 400, 800, null],
+   * //         [1400425954000, 155, 175, 42]
+   * //     ]
+   * // }
+   * ```
+   */
+  flatMap(mapper) {
+    const remapped = this._collection.flatMap(mapper);
+    return this.setCollection(remapped);
+  }
+  /**
+   * Remap the keys of the underlying Events, but keep the data the same.
+   *
+   * For example you can use this if you have a `TimeSeries<Index>` and want to
+   * convert to events of `TimeSeries<Time>`s.
+   *
+   * The mapper function supplied to `mapKeys` should return key of type
+   * `U` given a key of type `T`.
+   *
+   * Example:
+   *
+   * In this example we remap `Time` keys to `TimeRange` keys using the `Time.toTimeRange()`
+   * method, centering the new `TimeRange`s around each `Time` with duration given
+   * by the `Duration` object supplied, in this case representing one hour.
+   *
+   * ```
+   * const hourlyRanges = series.mapKeys<TimeRange>(t =>
+   *     t.toTimeRange(duration("1h"), TimeAlignment.Middle)
+   * );
+   * ```
+   *
+   */
+  mapKeys(mapper) {
+    const collection = new sortedcollection_1.SortedCollection(
+      this._collection.mapKeys(mapper)
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Filter the `TimeSeries`'s `Event`'s with the supplied function.
+   *
+   * The function `predicate` is passed each `Event` and should return
+   * true to keep the `Event` or false to discard.
+   *
+   * Example:
+   * ```
+   * const filtered = series.filter(e => e.get("a") < 8)
+   * ```
+   */
+  filter(predicate) {
+    const filtered = this._collection.filter(predicate);
+    return this.setCollection(filtered);
+  }
+  /**
+   * Select out specified columns from the `Event`s within this `TimeSeries`.
+   *
+   * The `select()` method needs to be supplied with a `SelectOptions`
+   * object, which takes the following form:
+   *
+   * ```
+   * {
+   *     fields: string[];
+   * }
+   * ```
+   * Options:
+   *  * `fields` - array of columns to keep within each `Event`.
+   *
+   * Example:
+   * ```
+   * const series = timeSeries({
+   *     name: "data",
+   *     columns: ["time", "a", "b", "c"],
+   *     points: [
+   *         [1509725624100, 5, 3, 4],
+   *         [1509725624200, 8, 1, 3],
+   *         [1509725624300, 2, 9, 1]
+   *     ]
+   * });
+   * const newSeries = series.select({
+   *     fields: ["b", "c"]
+   * });
+   *
+   * // returns a series with columns ["b", "c"] only, "a" is discarded.
+   * ```
+   */
+  select(options) {
+    const collection = new sortedcollection_1.SortedCollection(
+      this._collection.select(options)
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Collapse multiple columns of a `Collection` into a new column.
+   *
+   * The `collapse()` method needs to be supplied with a `CollapseOptions`
+   * object. You use this to specify the columns to collapse, the column name
+   * of the column to collapse to and the reducer function. In addition you
+   * can choose to append this new column or use it in place of the columns
+   * collapsed.
+   *
+   * ```
+   * {
+   *    fieldSpecList: string[];
+   *    fieldName: string;
+   *    reducer: any;
+   *    append: boolean;
+   * }
+   * ```
+   * Options:
+   *  * `fieldSpecList` - the list of fields to collapse
+   *  * `fieldName` - the new field's name
+   *  * `reducer()` - a function to collapse using e.g. `avg()`
+   *  * `append` - to include only the new field, or include it in addition
+   *     to the previous fields.
+   *
+   * Example:
+   * ```
+   * const series = timeSeries({
+   *     name: "data",
+   *     columns: ["time", "a", "b"],
+   *     points: [
+   *         [1509725624100, 5, 6],
+   *         [1509725624200, 4, 2],
+   *         [1509725624300, 6, 3]
+   *     ]
+   * });
+   *
+   * // Sum columns "a" and "b" into a new column "v"
+   * const sums = series.collapse({
+   *     fieldSpecList: ["a", "b"],
+   *     fieldName: "v",
+   *     reducer: sum(),
+   *     append: false
+   * });
+   *
+   * sums.at(0).get("v")  // 11
+   * sums.at(1).get("v")  // 6
+   * sums.at(2).get("v")  // 9
+   * ```
+   */
+  collapse(options) {
+    const collection = new sortedcollection_1.SortedCollection(
+      this._collection.collapse(options)
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Rename columns in the underlying events.
+   *
+   * Takes a object of columns to rename. Returns a new `TimeSeries` containing
+   * new events. Columns not in the dict will be retained and not renamed.
+   *
+   * Example:
+   * ```
+   * new_ts = ts.renameColumns({
+   *     renameMap: {in: "new_in", out: "new_out"}
+   * });
+   * ```
+   *
+   * As the name implies, this will only rename the main
+   * "top level" (ie: non-deep) columns. If you need more
+   * extravagant renaming, roll your own using `TimeSeries.map()`.
+   */
+  renameColumns(options) {
+    const { renameMap } = options;
+    return this.map(e => {
+      const eventType = e.keyType();
+      const d = e.getData().mapKeys(key => renameMap[key] || key);
+      switch (eventType) {
+        case "time":
+          return new event_1.Event(
+            time_1.time(e.toPoint(this.columns())[0]),
+            d
+          );
+        case "index":
+          return new event_1.Event(
+            index_1.index(e.toPoint(this.columns())[0]),
+            d
+          );
+        case "timerange":
+          const timeArray = e.toPoint(this.columns())[0];
+          return new event_1.Event(
+            timerange_1.timerange(timeArray[0], timeArray[1]),
+            d
+          );
+      }
+    });
+  }
+  /**
+   * Take the data in this `TimeSeries` and "fill" any missing or invalid
+   * values. This could be setting `null` values to zero so mathematical
+   * operations will succeed, interpolate a new value, or pad with the
+   * previously given value.
+   *
+   * The fill is controlled by the `FillOptions`. This is an object of the form:
+   * ```
+   * {
+   *     fieldSpec: string | string[];
+   *     method?: FillMethod;
+   *     limit?: number;
+   * }
+   * ```
+   * Options:
+   *  * `fieldSpec` - the field to fill
+   *  * `method` - the interpolation method, one of `FillMethod.Zero`, `FillMethod.Pad`
+   *               or `FillMethod.Linear`
+   *  * `limit` - the number of missing values to fill before giving up
+   *
+   * Example:
+   * ```
+   * const filled = timeseries.fill({
+   *     fieldSpec: ["direction.in", "direction.out"],
+   *     method: "zero",
+   *     limit: 3
+   * });
+   * ```
+   */
+  fill(options) {
+    const {
+      fieldSpec = null,
+      method = types_1.FillMethod.Zero,
+      limit = null
+    } = options;
+    let filledCollection;
+    if (
+      method === types_1.FillMethod.Zero ||
+      method === types_1.FillMethod.Pad
+    ) {
+      filledCollection = this._collection.fill({ fieldSpec, method, limit });
+    } else if (method === types_1.FillMethod.Linear) {
+      if (_.isArray(fieldSpec)) {
+        filledCollection = this._collection;
+        fieldSpec.forEach(fieldPath => {
+          const args = { fieldSpec: fieldPath, method, limit };
+          filledCollection = filledCollection.fill(args);
         });
-    }
-    /**
-     * Take the data in this `TimeSeries` and "fill" any missing or invalid
-     * values. This could be setting `null` values to zero so mathematical
-     * operations will succeed, interpolate a new value, or pad with the
-     * previously given value.
-     *
-     * The fill is controlled by the `FillOptions`. This is an object of the form:
-     * ```
-     * {
-     *     fieldSpec: string | string[];
-     *     method?: FillMethod;
-     *     limit?: number;
-     * }
-     * ```
-     * Options:
-     *  * `fieldSpec` - the field to fill
-     *  * `method` - the interpolation method, one of `FillMethod.Zero`, `FillMethod.Pad`
-     *               or `FillMethod.Linear`
-     *  * `limit` - the number of missing values to fill before giving up
-     *
-     * Example:
-     * ```
-     * const filled = timeseries.fill({
-     *     fieldSpec: ["direction.in", "direction.out"],
-     *     method: "zero",
-     *     limit: 3
-     * });
-     * ```
-     */
-    fill(options) {
-        const { fieldSpec = null, method = types_1.FillMethod.Zero, limit = null } = options;
-        let filledCollection;
-        if (method === types_1.FillMethod.Zero || method === types_1.FillMethod.Pad) {
-            filledCollection = this._collection.fill({ fieldSpec, method, limit });
-        }
-        else if (method === types_1.FillMethod.Linear) {
-            if (_.isArray(fieldSpec)) {
-                filledCollection = this._collection;
-                fieldSpec.forEach(fieldPath => {
-                    const args = { fieldSpec: fieldPath, method, limit };
-                    filledCollection = filledCollection.fill(args);
-                });
-            }
-            else {
-                filledCollection = this._collection.fill({
-                    fieldSpec,
-                    method,
-                    limit
-                });
-            }
-        }
-        else {
-            throw new Error(`Invalid fill method: ${method}`);
-        }
-        const collection = new sortedcollection_1.SortedCollection(filledCollection);
-        return this.setCollection(collection);
-    }
-    /**
-     * Align event values to regular time boundaries. The value at
-     * the boundary is interpolated. Only the new interpolated
-     * points are returned. If limit is reached nulls will be
-     * returned at each boundary position.
-     *
-     * One use case for this is to modify irregular data (i.e. data
-     * that falls at slightly irregular times) so that it falls into a
-     * sequence of evenly spaced values. We use this to take data we
-     * get from the network which is approximately every 30 second
-     * (:32, 1:02, 1:34, ...) and output data on exact 30 second
-     * boundaries (:30, 1:00, 1:30, ...).
-     *
-     * Another use case is data that might be already aligned to
-     * some regular interval, but that contains missing points.
-     * While `fill()` can be used to replace `null` values, `align()`
-     * can be used to add in missing points completely. Those points
-     * can have an interpolated value, or by setting limit to 0,
-     * can be filled with nulls. This is really useful when downstream
-     * processing depends on complete sequences.
-     *
-     * Example:
-     * ```
-     *  const alignOptions: AlignmentOptions = {
-     *       fieldSpec: ["value"],
-     *       period: period(duration("30s")),
-     *       method: AlignmentMethod.Linear,
-     *       limit: 3
-     *   };
-     *
-     *   const aligned = series.align(alignOptions);
-     *
-     * ```
-     */
-    align(options) {
-        const collection = new sortedcollection_1.SortedCollection(this._collection.align(options));
-        return this.setCollection(collection);
-    }
-    /**
-     * Returns the derivative of the `TimeSeries` for the given columns. The result will
-     * be per second. Optionally you can substitute in `null` values if the rate
-     * is negative. This is useful when a negative rate would be considered invalid.
-     */
-    rate(options) {
-        const collection = new sortedcollection_1.SortedCollection(this._collection.rate(options));
-        return this.setCollection(collection);
-    }
-    /**
-     * Builds a new `TimeSeries` by dividing events within the `TimeSeries`
-     * across multiple fixed windows of size `windowSize`.
-     *
-     * Note that these are windows defined relative to Jan 1st, 1970,
-     * and are UTC, so this is best suited to smaller window sizes
-     * (hourly, 5m, 30s, 1s etc), or in situations where you don't care
-     * about the specific window, just that the data is smaller.
-     *
-     * Each window then has an aggregation specification applied as
-     * `aggregation`. This specification describes a mapping of output
-     * fieldNames to aggregation functions and their fieldPath. For example:
-     * ```
-     * { in_avg: { in: avg() }, out_avg: { out: avg() } }
-     * ```
-     * will aggregate both "in" and "out" using the average aggregation
-     * function and return the result as in_avg and out_avg.
-     *
-     * Note that each aggregation function, such as `avg()` also can take a
-     * filter function to apply before the aggregation. A set of filter functions
-     * exists to do common data cleanup such as removing bad values. For example:
-     * ```
-     * { value_avg: { value: avg(filter.ignoreMissing) } }
-     * ```
-     *
-     * Example:
-     * ```
-     *     const timeseries = new TimeSeries(data);
-     *     const dailyAvg = timeseries.fixedWindowRollup({
-     *         windowSize: "1d",
-     *         aggregation: {value:["value", avg()]}
-     *     });
-     * ```
-     *
-     * Note that to output the result as `TimeEvent`'s instead of `IndexedEvent`'s,
-     * you can do the following :
-     * ```
-     * timeseries.fixedWindowRollup(options).mapKeys(index => time(index.toTimeRange().mid()))
-     * ```
-     *
-     */
-    fixedWindowRollup(options) {
-        if (!options.window) {
-            throw new Error("window must be supplied");
-        }
-        if (!options.aggregation || !_.isObject(options.aggregation)) {
-            throw new Error("aggregation object must be supplied, for example: {value: {value: avg()}}");
-        }
-        const aggregatorPipeline = this._collection
-            .window({ window: options.window, trigger: types_1.Trigger.onDiscardedWindow })
-            .aggregate(options.aggregation)
-            .flatten();
-        const collections = new sortedcollection_1.SortedCollection(aggregatorPipeline);
-        return this.setCollection(collections);
-    }
-    /**
-     * Builds a new `TimeSeries` by dividing events into hours.
-     *
-     * Each window then has an aggregation specification `aggregation`
-     * applied. This specification describes a mapping of output
-     * fieldNames to aggregation functions and their fieldPath. For example:
-     * ```
-     * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
-     * ```
-     *
-     */
-    hourlyRollup(options) {
-        const { aggregation } = options;
-        if (!aggregation || !_.isObject(aggregation)) {
-            throw new Error("aggregation object must be supplied, for example: {value: {value: avg()}}");
-        }
-        return this.fixedWindowRollup({
-            window: window_1.window(duration_1.duration("1h")),
-            aggregation
+      } else {
+        filledCollection = this._collection.fill({
+          fieldSpec,
+          method,
+          limit
         });
+      }
+    } else {
+      throw new Error(`Invalid fill method: ${method}`);
     }
-    /**
-     * Builds a new `TimeSeries` by dividing events into days.
-     *
-     * Each window then has an aggregation specification `aggregation`
-     * applied. This specification describes a mapping of output
-     * fieldNames to aggregation functions and their fieldPath. For example:
-     * ```
-     * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
-     * ```
-     *
-     */
-    dailyRollup(options) {
-        const { aggregation, timezone = "Etc/UTC" } = options;
-        if (!aggregation || !_.isObject(aggregation)) {
-            throw new Error("aggregation object must be supplied, for example: {avg_value: {value: avg()}}");
-        }
-        return this._rollup({ window: window_1.daily(timezone), aggregation });
+    const collection = new sortedcollection_1.SortedCollection(
+      filledCollection
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Align event values to regular time boundaries. The value at
+   * the boundary is interpolated. Only the new interpolated
+   * points are returned. If limit is reached nulls will be
+   * returned at each boundary position.
+   *
+   * One use case for this is to modify irregular data (i.e. data
+   * that falls at slightly irregular times) so that it falls into a
+   * sequence of evenly spaced values. We use this to take data we
+   * get from the network which is approximately every 30 second
+   * (:32, 1:02, 1:34, ...) and output data on exact 30 second
+   * boundaries (:30, 1:00, 1:30, ...).
+   *
+   * Another use case is data that might be already aligned to
+   * some regular interval, but that contains missing points.
+   * While `fill()` can be used to replace `null` values, `align()`
+   * can be used to add in missing points completely. Those points
+   * can have an interpolated value, or by setting limit to 0,
+   * can be filled with nulls. This is really useful when downstream
+   * processing depends on complete sequences.
+   *
+   * Example:
+   * ```
+   *  const alignOptions: AlignmentOptions = {
+   *       fieldSpec: ["value"],
+   *       period: period(duration("30s")),
+   *       method: AlignmentMethod.Linear,
+   *       limit: 3
+   *   };
+   *
+   *   const aligned = series.align(alignOptions);
+   *
+   * ```
+   */
+  align(options) {
+    const collection = new sortedcollection_1.SortedCollection(
+      this._collection.align(options)
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Returns the derivative of the `TimeSeries` for the given columns. The result will
+   * be per second. Optionally you can substitute in `null` values if the rate
+   * is negative. This is useful when a negative rate would be considered invalid.
+   */
+  rate(options) {
+    const collection = new sortedcollection_1.SortedCollection(
+      this._collection.rate(options)
+    );
+    return this.setCollection(collection);
+  }
+  /**
+   * Builds a new `TimeSeries` by dividing events within the `TimeSeries`
+   * across multiple fixed windows of size `windowSize`.
+   *
+   * Note that these are windows defined relative to Jan 1st, 1970,
+   * and are UTC, so this is best suited to smaller window sizes
+   * (hourly, 5m, 30s, 1s etc), or in situations where you don't care
+   * about the specific window, just that the data is smaller.
+   *
+   * Each window then has an aggregation specification applied as
+   * `aggregation`. This specification describes a mapping of output
+   * fieldNames to aggregation functions and their fieldPath. For example:
+   * ```
+   * { in_avg: { in: avg() }, out_avg: { out: avg() } }
+   * ```
+   * will aggregate both "in" and "out" using the average aggregation
+   * function and return the result as in_avg and out_avg.
+   *
+   * Note that each aggregation function, such as `avg()` also can take a
+   * filter function to apply before the aggregation. A set of filter functions
+   * exists to do common data cleanup such as removing bad values. For example:
+   * ```
+   * { value_avg: { value: avg(filter.ignoreMissing) } }
+   * ```
+   *
+   * Example:
+   * ```
+   *     const timeseries = new TimeSeries(data);
+   *     const dailyAvg = timeseries.fixedWindowRollup({
+   *         windowSize: "1d",
+   *         aggregation: {value:["value", avg()]}
+   *     });
+   * ```
+   *
+   * Note that to output the result as `TimeEvent`'s instead of `IndexedEvent`'s,
+   * you can do the following :
+   * ```
+   * timeseries.fixedWindowRollup(options).mapKeys(index => time(index.toTimeRange().mid()))
+   * ```
+   *
+   */
+  fixedWindowRollup(options) {
+    if (!options.window) {
+      throw new Error("window must be supplied");
     }
-    /**
-     * Builds a new `TimeSeries` by dividing events into months.
-     *
-     * Each window then has an aggregation specification `aggregation`
-     * applied. This specification describes a mapping of output
-     * fieldNames to aggregation functions and their fieldPath. For example:
-     * ```
-     * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
-     * ```
-     *
-     */
-    /*
+    if (!options.aggregation || !_.isObject(options.aggregation)) {
+      throw new Error(
+        "aggregation object must be supplied, for example: {value: {value: avg()}}"
+      );
+    }
+    const aggregatorPipeline = this._collection
+      .window({
+        window: options.window,
+        trigger: types_1.Trigger.onDiscardedWindow
+      })
+      .aggregate(options.aggregation)
+      .flatten();
+    const collections = new sortedcollection_1.SortedCollection(
+      aggregatorPipeline
+    );
+    return this.setCollection(collections);
+  }
+  /**
+   * Builds a new `TimeSeries` by dividing events into hours.
+   *
+   * Each window then has an aggregation specification `aggregation`
+   * applied. This specification describes a mapping of output
+   * fieldNames to aggregation functions and their fieldPath. For example:
+   * ```
+   * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
+   * ```
+   *
+   */
+  hourlyRollup(options) {
+    const { aggregation } = options;
+    if (!aggregation || !_.isObject(aggregation)) {
+      throw new Error(
+        "aggregation object must be supplied, for example: {value: {value: avg()}}"
+      );
+    }
+    return this.fixedWindowRollup({
+      window: window_1.window(duration_1.duration("1h")),
+      aggregation
+    });
+  }
+  /**
+   * Builds a new `TimeSeries` by dividing events into days.
+   *
+   * Each window then has an aggregation specification `aggregation`
+   * applied. This specification describes a mapping of output
+   * fieldNames to aggregation functions and their fieldPath. For example:
+   * ```
+   * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
+   * ```
+   *
+   */
+  dailyRollup(options) {
+    const { aggregation, timezone = "Etc/UTC" } = options;
+    if (!aggregation || !_.isObject(aggregation)) {
+      throw new Error(
+        "aggregation object must be supplied, for example: {avg_value: {value: avg()}}"
+      );
+    }
+    return this._rollup({ window: window_1.daily(timezone), aggregation });
+  }
+  /**
+   * Builds a new `TimeSeries` by dividing events into months.
+   *
+   * Each window then has an aggregation specification `aggregation`
+   * applied. This specification describes a mapping of output
+   * fieldNames to aggregation functions and their fieldPath. For example:
+   * ```
+   * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
+   * ```
+   *
+   */
+  /*
     monthlyRollup(options: RollupOptions<T>): TimeSeries<Index> {
         const { aggregation } = options;
 
@@ -1138,19 +1199,19 @@ class TimeSeries {
         return this._rollup({ windowSize: period("monthly"), aggregation });
     }
     */
-    /**
-     * Builds a new `TimeSeries` by dividing events into years.
-     *
-     * Each window then has an aggregation specification `aggregation`
-     * applied. This specification describes a mapping of output
-     * fieldNames to aggregation functions and their fieldPath. For example:
-     *
-     * ```
-     * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
-     * ```
-     *
-     */
-    /*
+  /**
+   * Builds a new `TimeSeries` by dividing events into years.
+   *
+   * Each window then has an aggregation specification `aggregation`
+   * applied. This specification describes a mapping of output
+   * fieldNames to aggregation functions and their fieldPath. For example:
+   *
+   * ```
+   * {in_avg: ["in", avg()], out_avg: ["out", avg()]}
+   * ```
+   *
+   */
+  /*
     yearlyRollup(options: RollupOptions<T>): TimeSeries<Index> {
         const { aggregation } = options;
 
@@ -1163,141 +1224,159 @@ class TimeSeries {
         return this._rollup({ windowSize: period("yearly"), aggregation });
     }
     */
-    /**
-     * @private
-     *
-     * Internal function to build the `TimeSeries` rollup functions using
-     * an aggregator Pipeline.
-     */
-    _rollup(options) {
-        const aggregatorPipeline = this._collection
-            .window({ window: options.window, trigger: types_1.Trigger.onDiscardedWindow })
-            .aggregate(options.aggregation)
-            .flatten();
-        const collections = new sortedcollection_1.SortedCollection(aggregatorPipeline);
-        return this.setCollection(collections);
+  /**
+   * @private
+   *
+   * Internal function to build the `TimeSeries` rollup functions using
+   * an aggregator Pipeline.
+   */
+  _rollup(options) {
+    const aggregatorPipeline = this._collection
+      .window({
+        window: options.window,
+        trigger: types_1.Trigger.onDiscardedWindow
+      })
+      .aggregate(options.aggregation)
+      .flatten();
+    const collections = new sortedcollection_1.SortedCollection(
+      aggregatorPipeline
+    );
+    return this.setCollection(collections);
+  }
+  /**
+   * Builds multiple `Collection`s, each collects together
+   * events within a window of size `windowSize`. Note that these
+   * are windows defined relative to Jan 1st, 1970, and are UTC.
+   *
+   * Example:
+   * ```
+   * const timeseries = new TimeSeries(data);
+   * const collections = timeseries.collectByFixedWindow({windowSize: "1d"});
+   * console.log(collections); // {1d-16314: Collection, 1d-16315: Collection, ...}
+   * ```
+   *
+   */
+  collectByWindow(options) {
+    return this._collection.window({ window: options.window }).ungroup();
+  }
+  /*
+   * STATIC
+   */
+  /**
+   * Static function to compare two `TimeSeries` to each other. If the `TimeSeries`
+   * are of the same instance as each other then equals will return true.
+   */
+  // tslint:disable:member-ordering
+  static equal(series1, series2) {
+    return (
+      series1._data === series2._data &&
+      series1._collection === series2._collection
+    );
+  }
+  /**
+   * Static function to compare two `TimeSeries` to each other. If the `TimeSeries`
+   * are of the same value as each other then equals will return true.
+   */
+  static is(series1, series2) {
+    return (
+      Immutable.is(series1._data, series2._data) &&
+      sortedcollection_1.SortedCollection.is(
+        series1._collection,
+        series2._collection
+      )
+    );
+  }
+  /**
+   * Reduces a list of `TimeSeries` objects using a reducer function. This works
+   * by taking each event in each `TimeSeries` and collecting them together
+   * based on timestamp. All events for a given time are then merged together
+   * using the reducer function to produce a new event. The reducer function is
+   * applied to all columns in the `fieldSpec`. Those new events are then
+   * collected together to form a new `TimeSeries`.
+   *
+   * Example:
+   *
+   * For example you might have two TimeSeries with columns "in" and "out" which
+   * corresponds to two measurements per timestamp. You could use this function to
+   * obtain a new TimeSeries which was the sum of the the three measurements using
+   * the `sum()` reducer function and an ["in", "out"] fieldSpec.
+   *
+   * ```
+   * const totalSeries = TimeSeries.timeSeriesListReduce({
+   *     name: "totals",
+   *     seriesList: [inTraffic, outTraffic],
+   *     reducer: sum(),
+   *     fieldSpec: [ "in", "out" ]
+   * });
+   * ```
+   */
+  static timeSeriesListReduce(options) {
+    const { seriesList, fieldSpec, reducer } = options,
+      data = __rest(options, ["seriesList", "fieldSpec", "reducer"]);
+    const combiner = event_1.Event.combiner(fieldSpec, reducer);
+    return TimeSeries.timeSeriesListEventReduce(
+      Object.assign({ seriesList, fieldSpec, reducer: combiner }, data)
+    );
+  }
+  /**
+   * Takes a list of `TimeSeries` and merges them together to form a new
+   * `TimeSeries`.
+   *
+   * Merging will produce a new `Event` only when events are conflict free, so
+   * it is useful in the following cases:
+   *  * to combine multiple `TimeSeries` which have different time ranges, essentially
+   *  concatenating them together
+   *  * combine `TimeSeries` which have different columns, for example inTraffic has
+   *  a column "in" and outTraffic has a column "out" and you want to produce a merged
+   *  trafficSeries with columns "in" and "out".
+   *
+   * Example:
+   * ```
+   * const inTraffic = new TimeSeries(trafficDataIn);
+   * const outTraffic = new TimeSeries(trafficDataOut);
+   * const trafficSeries = TimeSeries.timeSeriesListMerge({
+   *     name: "traffic",
+   *     seriesList: [inTraffic, outTraffic]
+   * });
+   * ```
+   */
+  static timeSeriesListMerge(options) {
+    const { seriesList, fieldSpec, reducer, deep = false } = options,
+      data = __rest(options, ["seriesList", "fieldSpec", "reducer", "deep"]);
+    const merger = event_1.Event.merger(deep);
+    return TimeSeries.timeSeriesListEventReduce(
+      Object.assign({ seriesList, fieldSpec, reducer: merger }, data)
+    );
+  }
+  /**
+   * @private
+   */
+  static timeSeriesListEventReduce(options) {
+    const { seriesList, fieldSpec, reducer } = options,
+      data = __rest(options, ["seriesList", "fieldSpec", "reducer"]);
+    if (!seriesList || !_.isArray(seriesList)) {
+      throw new Error("A list of TimeSeries must be supplied to reduce");
     }
-    /**
-     * Builds multiple `Collection`s, each collects together
-     * events within a window of size `windowSize`. Note that these
-     * are windows defined relative to Jan 1st, 1970, and are UTC.
-     *
-     * Example:
-     * ```
-     * const timeseries = new TimeSeries(data);
-     * const collections = timeseries.collectByFixedWindow({windowSize: "1d"});
-     * console.log(collections); // {1d-16314: Collection, 1d-16315: Collection, ...}
-     * ```
-     *
-     */
-    collectByWindow(options) {
-        return this._collection.window({ window: options.window }).ungroup();
+    if (!reducer || !_.isFunction(reducer)) {
+      throw new Error("reducer function must be supplied, for example avg()");
     }
-    /*
-     * STATIC
-     */
-    /**
-     * Static function to compare two `TimeSeries` to each other. If the `TimeSeries`
-     * are of the same instance as each other then equals will return true.
-     */
-    // tslint:disable:member-ordering
-    static equal(series1, series2) {
-        return series1._data === series2._data && series1._collection === series2._collection;
-    }
-    /**
-     * Static function to compare two `TimeSeries` to each other. If the `TimeSeries`
-     * are of the same value as each other then equals will return true.
-     */
-    static is(series1, series2) {
-        return (Immutable.is(series1._data, series2._data) &&
-            sortedcollection_1.SortedCollection.is(series1._collection, series2._collection));
-    }
-    /**
-     * Reduces a list of `TimeSeries` objects using a reducer function. This works
-     * by taking each event in each `TimeSeries` and collecting them together
-     * based on timestamp. All events for a given time are then merged together
-     * using the reducer function to produce a new event. The reducer function is
-     * applied to all columns in the `fieldSpec`. Those new events are then
-     * collected together to form a new `TimeSeries`.
-     *
-     * Example:
-     *
-     * For example you might have two TimeSeries with columns "in" and "out" which
-     * corresponds to two measurements per timestamp. You could use this function to
-     * obtain a new TimeSeries which was the sum of the the three measurements using
-     * the `sum()` reducer function and an ["in", "out"] fieldSpec.
-     *
-     * ```
-     * const totalSeries = TimeSeries.timeSeriesListReduce({
-     *     name: "totals",
-     *     seriesList: [inTraffic, outTraffic],
-     *     reducer: sum(),
-     *     fieldSpec: [ "in", "out" ]
-     * });
-     * ```
-     */
-    static timeSeriesListReduce(options) {
-        const { seriesList, fieldSpec, reducer } = options, data = __rest(options, ["seriesList", "fieldSpec", "reducer"]);
-        const combiner = event_1.Event.combiner(fieldSpec, reducer);
-        return TimeSeries.timeSeriesListEventReduce(Object.assign({ seriesList,
-            fieldSpec, reducer: combiner }, data));
-    }
-    /**
-     * Takes a list of `TimeSeries` and merges them together to form a new
-     * `TimeSeries`.
-     *
-     * Merging will produce a new `Event` only when events are conflict free, so
-     * it is useful in the following cases:
-     *  * to combine multiple `TimeSeries` which have different time ranges, essentially
-     *  concatenating them together
-     *  * combine `TimeSeries` which have different columns, for example inTraffic has
-     *  a column "in" and outTraffic has a column "out" and you want to produce a merged
-     *  trafficSeries with columns "in" and "out".
-     *
-     * Example:
-     * ```
-     * const inTraffic = new TimeSeries(trafficDataIn);
-     * const outTraffic = new TimeSeries(trafficDataOut);
-     * const trafficSeries = TimeSeries.timeSeriesListMerge({
-     *     name: "traffic",
-     *     seriesList: [inTraffic, outTraffic]
-     * });
-     * ```
-     */
-    static timeSeriesListMerge(options) {
-        const { seriesList, fieldSpec, reducer, deep = false } = options, data = __rest(options, ["seriesList", "fieldSpec", "reducer", "deep"]);
-        const merger = event_1.Event.merger(deep);
-        return TimeSeries.timeSeriesListEventReduce(Object.assign({ seriesList,
-            fieldSpec, reducer: merger }, data));
-    }
-    /**
-     * @private
-     */
-    static timeSeriesListEventReduce(options) {
-        const { seriesList, fieldSpec, reducer } = options, data = __rest(options, ["seriesList", "fieldSpec", "reducer"]);
-        if (!seriesList || !_.isArray(seriesList)) {
-            throw new Error("A list of TimeSeries must be supplied to reduce");
-        }
-        if (!reducer || !_.isFunction(reducer)) {
-            throw new Error("reducer function must be supplied, for example avg()");
-        }
-        // for each series, make a map from timestamp to the
-        // list of events with that timestamp
-        const eventList = [];
-        seriesList.forEach(series => {
-            for (const e of series._collection.eventList()) {
-                eventList.push(e);
-            }
-        });
-        const events = reducer(Immutable.List(eventList));
-        // Make a collection. If the events are out of order, sort them.
-        // It's always possible that events are out of order here, depending
-        // on the start times of the series, along with it the series
-        // have missing data, so I think we don't have a choice here.
-        const collection = new sortedcollection_1.SortedCollection(events);
-        const timeseries = new TimeSeries(Object.assign({}, data, { collection }));
-        return timeseries;
-    }
+    // for each series, make a map from timestamp to the
+    // list of events with that timestamp
+    const eventList = [];
+    seriesList.forEach(series => {
+      for (const e of series._collection.eventList()) {
+        eventList.push(e);
+      }
+    });
+    const events = reducer(Immutable.List(eventList));
+    // Make a collection. If the events are out of order, sort them.
+    // It's always possible that events are out of order here, depending
+    // on the start times of the series, along with it the series
+    // have missing data, so I think we don't have a choice here.
+    const collection = new sortedcollection_1.SortedCollection(events);
+    const timeseries = new TimeSeries(Object.assign({}, data, { collection }));
+    return timeseries;
+  }
 }
 exports.TimeSeries = TimeSeries;
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGltZXNlcmllcy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy90aW1lc2VyaWVzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQTs7Ozs7Ozs7R0FRRzs7Ozs7Ozs7Ozs7QUFFSCx1Q0FBdUM7QUFDdkMsNEJBQTRCO0FBSTVCLHlDQUFzQztBQUN0QyxtQ0FBZ0Y7QUFDaEYsbUNBQXVDO0FBSXZDLHlEQUFzRDtBQUN0RCxpQ0FBb0M7QUFDcEMsMkNBQW1EO0FBQ25ELHFDQUF5QztBQUV6QywyQ0FXcUI7QUFFckIsbUNBZWlCO0FBRWpCLFNBQVMsYUFBYSxDQUFDLElBQUk7SUFDdkIsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUUzQixPQUFPO0lBQ1AsQ0FBQyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFFcEMsUUFBUTtJQUNSLElBQUksSUFBSSxDQUFDLEtBQUssRUFBRTtRQUNaLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEVBQUU7WUFDeEIsQ0FBQyxDQUFDLEtBQUssR0FBRyxJQUFJLGFBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsUUFBUSxFQUFFLENBQUM7U0FDOUM7YUFBTSxJQUFJLElBQUksQ0FBQyxLQUFLLFlBQVksYUFBSyxFQUFFO1lBQ3BDLENBQUMsQ0FBQyxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsQ0FBQztTQUNuQztLQUNKO0lBRUQsV0FBVztJQUNYLENBQUMsQ0FBQyxFQUFFLEdBQUcsU0FBUyxDQUFDO0lBQ2pCLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLEVBQUU7UUFDckIsQ0FBQyxDQUFDLEVBQUUsR0FBRyxJQUFJLENBQUMsRUFBRSxDQUFDO0tBQ2xCO0lBQ0QsT0FBTyxTQUFTLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQzVCLENBQUM7QUE2Q0Q7Ozs7Ozs7Ozs7Ozs7R0FhRztBQUNILFNBQVMsVUFBVSxDQUFDLEdBQXlCO0lBQ3pDLE1BQU0sVUFBVSxHQUFHLEdBQTJCLENBQUM7SUFDL0MsTUFBTSxFQUFFLE9BQU8sRUFBRSxNQUFNLEVBQUUsRUFBRSxHQUFHLFNBQVMsS0FBZSxVQUFVLEVBQXZCLHVEQUF1QixDQUFDO0lBQ2pFLE1BQU0sQ0FBQyxRQUFRLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxPQUFPLENBQUM7SUFDM0MsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsRUFBRTtRQUM5QixNQUFNLENBQUMsR0FBRyxFQUFFLEdBQUcsV0FBVyxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ3BDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxTQUFTLENBQUMsV0FBVyxFQUFFLFdBQVcsQ0FBQyxDQUFDO1FBQ2hELE9BQU8sSUFBSSxhQUFLLENBQU8sV0FBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLFNBQVMsQ0FBQyxNQUFNLENBQUMsQ0FBMEIsQ0FBQyxDQUFDLENBQUM7SUFDcEYsQ0FBQyxDQUFDLENBQUM7SUFDSCxPQUFPLElBQUksVUFBVSxpQkFBRyxNQUFNLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsSUFBSyxLQUFLLEVBQUcsQ0FBQztBQUN4RSxDQUFDO0FBeURRLGdDQUFVO0FBdkRuQjs7Ozs7Ozs7Ozs7OztHQWFHO0FBQ0gsU0FBUyxhQUFhLENBQUMsR0FBeUI7SUFDNUMsTUFBTSxVQUFVLEdBQUcsR0FBMkIsQ0FBQztJQUMvQyxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sRUFBRSxFQUFFLEdBQUcsU0FBUyxLQUFlLFVBQVUsRUFBdkIsdURBQXVCLENBQUM7SUFDakUsTUFBTSxDQUFDLFFBQVEsRUFBRSxHQUFHLFdBQVcsQ0FBQyxHQUFHLE9BQU8sQ0FBQztJQUMzQyxNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFO1FBQzlCLE1BQU0sQ0FBQyxHQUFHLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDcEMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxXQUFXLEVBQUUsV0FBVyxDQUFDLENBQUM7UUFDaEQsT0FBTyxJQUFJLGFBQUssQ0FBUSxhQUFLLENBQUMsR0FBRyxDQUFDLEVBQUUsU0FBUyxDQUFDLE1BQU0sQ0FBQyxDQUEwQixDQUFDLENBQUMsQ0FBQztJQUN0RixDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxVQUFVLGlCQUFHLE1BQU0sRUFBRSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLEtBQUssRUFBRyxDQUFDO0FBQ3hFLENBQUM7QUErQm9CLHNDQUFhO0FBN0JsQzs7Ozs7Ozs7Ozs7OztHQWFHO0FBQ0gsU0FBUyxlQUFlLENBQUMsR0FBeUI7SUFDOUMsTUFBTSxVQUFVLEdBQUcsR0FBMkIsQ0FBQztJQUMvQyxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sRUFBRSxFQUFFLEdBQUcsU0FBUyxLQUFlLFVBQVUsRUFBdkIsdURBQXVCLENBQUM7SUFDakUsTUFBTSxDQUFDLFFBQVEsRUFBRSxHQUFHLFdBQVcsQ0FBQyxHQUFHLE9BQU8sQ0FBQztJQUMzQyxNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFO1FBQzlCLE1BQU0sQ0FBQyxHQUFHLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDcEMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxXQUFXLEVBQUUsV0FBVyxDQUFDLENBQUM7UUFDaEQsT0FBTyxJQUFJLGFBQUssQ0FDWixxQkFBUyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFDekIsU0FBUyxDQUFDLE1BQU0sQ0FBQyxDQUEwQixDQUFDLENBQy9DLENBQUM7SUFDTixDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxVQUFVLGlCQUFHLE1BQU0sRUFBRSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLEtBQUssRUFBRyxDQUFDO0FBQ3hFLENBQUM7QUFFbUMsMENBQWU7QUFFbkQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FzRUc7QUFDSCxNQUFhLFVBQVU7SUFJbkI7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0F5RUc7SUFDSCxZQUFZLEdBQXdDO1FBN0U1QyxnQkFBVyxHQUF3QixJQUFJLENBQUM7UUFDeEMsVUFBSyxHQUFHLElBQUksQ0FBQztRQTZFakIsSUFBSSxHQUFHLFlBQVksVUFBVSxFQUFFO1lBQzNCLEVBQUU7WUFDRiwwQkFBMEI7WUFDMUIsRUFBRTtZQUNGLE1BQU0sS0FBSyxHQUFHLEdBQW9CLENBQUM7WUFDbkMsSUFBSSxDQUFDLEtBQUssR0FBRyxLQUFLLENBQUMsS0FBSyxDQUFDO1lBQ3pCLElBQUksQ0FBQyxXQUFXLEdBQUcsS0FBSyxDQUFDLFdBQVcsQ0FBQztTQUN4QzthQUFNLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxHQUFHLENBQUMsRUFBRTtZQUN4QixJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxFQUFFLFlBQVksQ0FBQyxFQUFFO2dCQUMxQixFQUFFO2dCQUNGLGdDQUFnQztnQkFDaEMsRUFBRTtnQkFDRixNQUFNLEVBQUUsVUFBVSxLQUFlLEdBQUcsRUFBaEIsbUNBQWdCLENBQUM7Z0JBQ3JDLElBQUksQ0FBQyxXQUFXLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBSSxVQUFVLENBQUMsQ0FBQztnQkFDdkQsSUFBSSxDQUFDLEtBQUssR0FBRyxhQUFhLENBQUMsS0FBSyxDQUFDLENBQUM7YUFDckM7aUJBQU0sSUFBSSxDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsRUFBRSxRQUFRLENBQUMsRUFBRTtnQkFDN0IsRUFBRTtnQkFDRix1QkFBdUI7Z0JBQ3ZCLEVBQUU7Z0JBQ0YsTUFBTSxFQUFFLE1BQU0sS0FBZSxHQUFHLEVBQWhCLCtCQUFnQixDQUFDO2dCQUNqQyxJQUFJLENBQUMsV0FBVyxHQUFHLElBQUksbUNBQWdCLENBQUMsTUFBTSxDQUFDLENBQUM7Z0JBQ2hELElBQUksQ0FBQyxLQUFLLEdBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQyxDQUFDO2FBQ3JDO1NBQ0o7SUFDTCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxNQUFNO1FBQ0YsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDO1FBQ3pCLElBQUksQ0FBQyxDQUFDLEVBQUU7WUFDSixPQUFPO1NBQ1Y7UUFDRCxNQUFNLE9BQU8sR0FBRyxDQUFDLENBQUMsQ0FBQyxPQUFPLEVBQUUsRUFBRSxHQUFHLElBQUksQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDO1FBRWpELE1BQU0sTUFBTSxHQUFHLEVBQUUsQ0FBQztRQUNsQixLQUFLLE1BQU0sR0FBRyxJQUFJLElBQUksQ0FBQyxXQUFXLENBQUMsU0FBUyxFQUFFLEVBQUU7WUFDNUMsTUFBTSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUM7U0FDNUM7UUFFRCxPQUFPLENBQUMsQ0FBQyxNQUFNLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUUsRUFBRSxFQUFFLE9BQU8sRUFBRSxNQUFNLEVBQUUsQ0FBQyxDQUFDO0lBQzlELENBQUM7SUFFRDs7O09BR0c7SUFDSCxRQUFRO1FBQ0osT0FBTyxJQUFJLENBQUMsU0FBUyxDQUFDLElBQUksQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDO0lBQ3pDLENBQUM7SUFFRDs7T0FFRztJQUNILFNBQVM7UUFDTCxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsU0FBUyxFQUFFLENBQUM7SUFDeEMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsS0FBSztRQUNELE9BQU8sSUFBSSxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQzVCLENBQUM7SUFFRDs7T0FFRztJQUNILEtBQUs7UUFDRCxPQUFPLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxLQUFLLEVBQUUsQ0FBQztJQUNoQyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxHQUFHO1FBQ0MsT0FBTyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsR0FBRyxFQUFFLENBQUM7SUFDOUIsQ0FBQztJQUVEOztPQUVHO0lBQ0gsRUFBRSxDQUFDLEdBQVc7UUFDVixPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDO0lBQ3BDLENBQUM7SUFFRDs7O09BR0c7SUFDSCxNQUFNLENBQUMsQ0FBTztRQUNWLE1BQU0sR0FBRyxHQUFHLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUM7UUFDM0IsSUFBSSxHQUFHLElBQUksQ0FBQyxJQUFJLEdBQUcsR0FBRyxJQUFJLENBQUMsSUFBSSxFQUFFLEVBQUU7WUFDL0IsT0FBTyxJQUFJLENBQUMsRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDO1NBQ3ZCO0lBQ0wsQ0FBQztJQUVEOztPQUVHO0lBQ0gsT0FBTztRQUNILE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxVQUFVLEVBQUUsQ0FBQztJQUN6QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxNQUFNO1FBQ0YsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQ3hDLENBQUM7SUFFRDs7O09BR0c7SUFDSCxhQUFhLENBQWdCLFVBQStCO1FBQ3hELE1BQU0sTUFBTSxHQUFHLElBQUksVUFBVSxDQUFJLElBQUksQ0FBQyxDQUFDO1FBQ3ZDLElBQUksVUFBVSxFQUFFO1lBQ1osTUFBTSxDQUFDLFdBQVcsR0FBRyxVQUFVLENBQUM7U0FDbkM7YUFBTTtZQUNILE1BQU0sQ0FBQyxXQUFXLEdBQUcsSUFBSSxtQ0FBZ0IsRUFBSyxDQUFDO1NBQ2xEO1FBQ0QsT0FBTyxNQUFNLENBQUM7SUFDbEIsQ0FBQztJQUVEOztPQUVHO0lBQ0gsTUFBTSxDQUFDLENBQU8sRUFBRSxDQUFVO1FBQ3RCLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxNQUFNLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO0lBQ3pDLENBQUM7SUFFRDs7OztPQUlHO0lBQ0gsS0FBSyxDQUFDLEtBQWMsRUFBRSxHQUFZO1FBQzlCLE1BQU0sTUFBTSxHQUFHLElBQUksbUNBQWdCLENBQUMsSUFBSSxDQUFDLFdBQVcsQ0FBQyxLQUFLLENBQUMsS0FBSyxFQUFFLEdBQUcsQ0FBQyxDQUFDLENBQUM7UUFDeEUsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQ3RDLENBQUM7SUFFRDs7T0FFRztJQUNILElBQUksQ0FBQyxFQUFhO1FBQ2QsTUFBTSxjQUFjLEdBQUcsRUFBRSxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ2xDLElBQUksUUFBUSxHQUFHLElBQUksQ0FBQyxNQUFNLENBQUMsY0FBYyxDQUFDLENBQUM7UUFDM0MsTUFBTSx5QkFBeUIsR0FBRyxJQUFJLENBQUMsRUFBRSxDQUFDLFFBQVEsQ0FBQyxDQUFDLFNBQVMsRUFBRSxHQUFHLGNBQWMsQ0FBQztRQUNqRixRQUFRLEdBQUcseUJBQXlCLENBQUMsQ0FBQyxDQUFDLFFBQVEsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQztRQUMvRCxNQUFNLE1BQU0sR0FBRyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxHQUFHLEVBQUUsRUFBRSxRQUFRLENBQUMsQ0FBQztRQUMvQyxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsUUFBUSxFQUFFLE1BQU0sR0FBRyxDQUFDLENBQUMsQ0FBQztJQUM1QyxDQUFDO0lBRUQsRUFBRTtJQUNGLG9DQUFvQztJQUNwQyxFQUFFO0lBQ0Y7O09BRUc7SUFDSCxJQUFJO1FBQ0EsT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUNsQyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxPQUFPLENBQUMsSUFBWTtRQUNoQixPQUFPLElBQUksQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFLElBQUksQ0FBQyxDQUFDO0lBQ3RDLENBQUM7SUFFRDs7OztPQUlHO0lBQ0gsS0FBSztRQUNELE9BQU8sYUFBSyxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsYUFBYTtRQUNULE9BQU8sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsUUFBUSxFQUFFLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQztJQUM5RCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxZQUFZO1FBQ1IsT0FBTyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxXQUFXLEVBQUUsQ0FBQyxDQUFDLENBQUMsU0FBUyxDQUFDO0lBQ2pFLENBQUM7SUFFRDs7T0FFRztJQUNILEtBQUs7UUFDRCxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLElBQUksQ0FBQyxLQUFLLFNBQVMsQ0FBQztJQUM5QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxRQUFRO1FBQ0osT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsQ0FBQztJQUNoQyxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILE9BQU87UUFDSCxNQUFNLENBQUMsR0FBRyxFQUFFLENBQUM7UUFDYixLQUFLLE1BQU0sQ0FBQyxJQUFJLElBQUksQ0FBQyxXQUFXLENBQUMsU0FBUyxFQUFFLEVBQUU7WUFDMUMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDO1lBQ3RCLENBQUMsQ0FBQyxPQUFPLENBQUMsQ0FBQyxHQUFHLEVBQUUsR0FBRyxFQUFFLEVBQUU7Z0JBQ25CLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxJQUFJLENBQUM7WUFDbEIsQ0FBQyxDQUFDLENBQUM7U0FDTjtRQUNELE9BQU8sQ0FBQyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUNyQixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsU0FBUztRQUNMLE9BQU8sSUFBSSxDQUFDLFVBQVUsRUFBRSxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQ3pDLENBQUM7SUFFRDs7T0FFRztJQUNILFVBQVU7UUFDTixPQUFPLElBQUksQ0FBQyxXQUFXLENBQUM7SUFDNUIsQ0FBQztJQUVEOzs7OztPQUtHO0lBQ0gsSUFBSSxDQUFDLEdBQVc7UUFDWixJQUFJLENBQUMsR0FBRyxFQUFFO1lBQ04sT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLE1BQU0sRUFBRSxDQUFDO1NBQzlCO2FBQU07WUFDSCxPQUFPLElBQUksQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDO1NBQzlCO0lBQ0wsQ0FBQztJQUVEOzs7T0FHRztJQUNILE9BQU8sQ0FBQyxHQUFRLEVBQUUsS0FBVTtRQUN4QixNQUFNLGFBQWEsR0FBRyxJQUFJLFVBQVUsQ0FBQyxJQUFJLENBQUMsQ0FBQztRQUMzQyxNQUFNLENBQUMsR0FBRyxhQUFhLENBQUMsS0FBSyxDQUFDO1FBQzlCLE1BQU0sRUFBRSxHQUFHLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxFQUFFLEtBQUssQ0FBQyxDQUFDO1FBQzdCLGFBQWEsQ0FBQyxLQUFLLEdBQUcsRUFBRSxDQUFDO1FBQ3pCLE9BQU8sYUFBYSxDQUFDO0lBQ3pCLENBQUM7SUFFRDs7T0FFRztJQUNILElBQUk7UUFDQSxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsQ0FBQyxDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsSUFBSSxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztJQUMxRCxDQUFDO0lBRUQ7Ozs7OztPQU1HO0lBQ0gsU0FBUyxDQUFDLFNBQWlCO1FBQ3ZCLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxTQUFTLENBQUMsU0FBUyxDQUFDLENBQUM7SUFDakQsQ0FBQztJQUVEOzs7T0FHRztJQUNILEtBQUs7UUFDRCxPQUFPLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQztJQUN2QixDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsR0FBRyxDQUFDLFlBQW9CLE9BQU8sRUFBRSxNQUFPO1FBQ3BDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ25ELENBQUM7SUFFRDs7Ozs7Ozs7Ozs7O09BWUc7SUFDSCxHQUFHLENBQUMsWUFBb0IsT0FBTyxFQUFFLE1BQU87UUFDcEMsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7SUFDbkQsQ0FBQztJQUVEOztPQUVHO0lBQ0gsR0FBRyxDQUFDLFlBQW9CLE9BQU8sRUFBRSxNQUFPO1FBQ3BDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ25ELENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0F1Qkc7SUFDSCxHQUFHLENBQUMsWUFBb0IsT0FBTyxFQUFFLE1BQU87UUFDcEMsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7SUFDbkQsQ0FBQztJQUVEOztPQUVHO0lBQ0gsTUFBTSxDQUFDLFlBQW9CLE9BQU8sRUFBRSxNQUFPO1FBQ3ZDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxNQUFNLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ3RELENBQUM7SUFFRDs7T0FFRztJQUNILEtBQUssQ0FBQyxZQUFvQixPQUFPLEVBQUUsTUFBTztRQUN0QyxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsS0FBSyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUNyRCxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09Bb0JHO0lBQ0gsVUFBVSxDQUNOLENBQVMsRUFDVCxZQUFvQixPQUFPLEVBQzNCLFNBQTRCLDZCQUFpQixDQUFDLE1BQU0sRUFDcEQsTUFBTztRQUVQLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxVQUFVLENBQUMsQ0FBQyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsTUFBTSxDQUFDLENBQUM7SUFDckUsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09Bc0JHO0lBQ0gsU0FBUyxDQUFDLElBQXFCLEVBQUUsWUFBb0IsT0FBTztRQUN4RCxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsU0FBUyxDQUFDLElBQUksRUFBRSxTQUFTLENBQUMsQ0FBQztJQUN2RCxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILFFBQVEsQ0FDSixRQUFnQixFQUNoQixZQUFvQixPQUFPLEVBQzNCLFNBQTRCLDZCQUFpQixDQUFDLE1BQU07UUFFcEQsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLFFBQVEsQ0FBQyxRQUFRLEVBQUUsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ2xFLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7T0FpQkc7SUFDSCxPQUFPLENBQWdCLFVBQXFEO1FBQ3hFLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDaEQsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7OztPQWNHO0lBQ0gsR0FBRyxDQUFnQixNQUFzRDtRQUNyRSxNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUM5QyxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsUUFBUSxDQUFDLENBQUM7SUFDeEMsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0EwQ0c7SUFDSCxPQUFPLENBQ0gsTUFBc0U7UUFFdEUsTUFBTSxRQUFRLEdBQUcsSUFBSSxDQUFDLFdBQVcsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDbEQsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ3hDLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09BcUJHO0lBQ0gsT0FBTyxDQUFnQixNQUFxQjtRQUN4QyxNQUFNLFVBQVUsR0FBRyxJQUFJLG1DQUFnQixDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDLENBQUM7UUFDMUUsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRDs7Ozs7Ozs7OztPQVVHO0lBQ0ksTUFBTSxDQUFDLFNBQXNEO1FBQ2hFLE1BQU0sUUFBUSxHQUFHLElBQUksQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLFNBQVMsQ0FBQyxDQUFDO1FBQ3BELE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUN4QyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0ErQkc7SUFDSCxNQUFNLENBQUMsT0FBc0I7UUFDekIsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDLE1BQU0sQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBQzFFLE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQWdERztJQUNILFFBQVEsQ0FBQyxPQUF3QjtRQUM3QixNQUFNLFVBQVUsR0FBRyxJQUFJLG1DQUFnQixDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDNUUsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7OztPQWdCRztJQUNILGFBQWEsQ0FBQyxPQUE0QjtRQUN0QyxNQUFNLEVBQUUsU0FBUyxFQUFFLEdBQUcsT0FBTyxDQUFDO1FBQzlCLE9BQU8sSUFBSSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRTtZQUNoQixNQUFNLFNBQVMsR0FBRyxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUM7WUFDOUIsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLFNBQVMsQ0FBQyxHQUFHLENBQUMsSUFBSSxHQUFHLENBQUMsQ0FBQztZQUM1RCxRQUFRLFNBQVMsRUFBRTtnQkFDZixLQUFLLE1BQU07b0JBQ1AsT0FBTyxJQUFJLGFBQUssQ0FBQyxXQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO2dCQUM1RCxLQUFLLE9BQU87b0JBQ1IsT0FBTyxJQUFJLGFBQUssQ0FBQyxhQUFLLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO2dCQUM3RCxLQUFLLFdBQVc7b0JBQ1osTUFBTSxTQUFTLEdBQUcsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztvQkFDL0MsT0FBTyxJQUFJLGFBQUssQ0FBQyxxQkFBUyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsRUFBRSxTQUFTLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQzthQUNsRTtRQUNMLENBQUMsQ0FBQyxDQUFDO0lBQ1AsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09BNEJHO0lBQ0gsSUFBSSxDQUFDLE9BQW9CO1FBQ3JCLE1BQU0sRUFBRSxTQUFTLEdBQUcsSUFBSSxFQUFFLE1BQU0sR0FBRyxrQkFBVSxDQUFDLElBQUksRUFBRSxLQUFLLEdBQUcsSUFBSSxFQUFFLEdBQUcsT0FBTyxDQUFDO1FBRTdFLElBQUksZ0JBQXFDLENBQUM7UUFDMUMsSUFBSSxNQUFNLEtBQUssa0JBQVUsQ0FBQyxJQUFJLElBQUksTUFBTSxLQUFLLGtCQUFVLENBQUMsR0FBRyxFQUFFO1lBQ3pELGdCQUFnQixHQUFHLElBQUksQ0FBQyxXQUFXLENBQUMsSUFBSSxDQUFDLEVBQUUsU0FBUyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQyxDQUFDO1NBQzFFO2FBQU0sSUFBSSxNQUFNLEtBQUssa0JBQVUsQ0FBQyxNQUFNLEVBQUU7WUFDckMsSUFBSSxDQUFDLENBQUMsT0FBTyxDQUFDLFNBQVMsQ0FBQyxFQUFFO2dCQUN0QixnQkFBZ0IsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDO2dCQUNwQyxTQUFTLENBQUMsT0FBTyxDQUFDLFNBQVMsQ0FBQyxFQUFFO29CQUMxQixNQUFNLElBQUksR0FBZ0IsRUFBRSxTQUFTLEVBQUUsU0FBUyxFQUFFLE1BQU0sRUFBRSxLQUFLLEVBQUUsQ0FBQztvQkFDbEUsZ0JBQWdCLEdBQUcsZ0JBQWdCLENBQUMsSUFBSSxDQUFDLElBQUksQ0FBQyxDQUFDO2dCQUNuRCxDQUFDLENBQUMsQ0FBQzthQUNOO2lCQUFNO2dCQUNILGdCQUFnQixHQUFHLElBQUksQ0FBQyxXQUFXLENBQUMsSUFBSSxDQUFDO29CQUNyQyxTQUFTO29CQUNULE1BQU07b0JBQ04sS0FBSztpQkFDUixDQUFDLENBQUM7YUFDTjtTQUNKO2FBQU07WUFDSCxNQUFNLElBQUksS0FBSyxDQUFDLHdCQUF3QixNQUFNLEVBQUUsQ0FBQyxDQUFDO1NBQ3JEO1FBRUQsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxnQkFBZ0IsQ0FBQyxDQUFDO1FBQzFELE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQWlDRztJQUNILEtBQUssQ0FBQyxPQUF5QjtRQUMzQixNQUFNLFVBQVUsR0FBRyxJQUFJLG1DQUFnQixDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsS0FBSyxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDekUsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRDs7OztPQUlHO0lBQ0gsSUFBSSxDQUFDLE9BQW9CO1FBQ3JCLE1BQU0sVUFBVSxHQUFHLElBQUksbUNBQWdCLENBQUMsSUFBSSxDQUFDLFdBQVcsQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQztRQUN4RSxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09Bd0NHO0lBQ0gsaUJBQWlCLENBQUMsT0FBeUI7UUFDdkMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxNQUFNLEVBQUU7WUFDakIsTUFBTSxJQUFJLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO1NBQzlDO1FBRUQsSUFBSSxDQUFDLE9BQU8sQ0FBQyxXQUFXLElBQUksQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLE9BQU8sQ0FBQyxXQUFXLENBQUMsRUFBRTtZQUMxRCxNQUFNLElBQUksS0FBSyxDQUNYLDJFQUEyRSxDQUM5RSxDQUFDO1NBQ0w7UUFFRCxNQUFNLGtCQUFrQixHQUFHLElBQUksQ0FBQyxXQUFXO2FBQ3RDLE1BQU0sQ0FBQyxFQUFFLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTSxFQUFFLE9BQU8sRUFBRSxlQUFPLENBQUMsaUJBQWlCLEVBQUUsQ0FBQzthQUN0RSxTQUFTLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQzthQUM5QixPQUFPLEVBQUUsQ0FBQztRQUVmLE1BQU0sV0FBVyxHQUFHLElBQUksbUNBQWdCLENBQUMsa0JBQWtCLENBQUMsQ0FBQztRQUU3RCxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsV0FBVyxDQUFDLENBQUM7SUFDM0MsQ0FBQztJQUVEOzs7Ozs7Ozs7O09BVUc7SUFDSCxZQUFZLENBQUMsT0FBeUI7UUFDbEMsTUFBTSxFQUFFLFdBQVcsRUFBRSxHQUFHLE9BQU8sQ0FBQztRQUVoQyxJQUFJLENBQUMsV0FBVyxJQUFJLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxXQUFXLENBQUMsRUFBRTtZQUMxQyxNQUFNLElBQUksS0FBSyxDQUNYLDJFQUEyRSxDQUM5RSxDQUFDO1NBQ0w7UUFFRCxPQUFPLElBQUksQ0FBQyxpQkFBaUIsQ0FBQztZQUMxQixNQUFNLEVBQUUsZUFBTSxDQUFDLG1CQUFRLENBQUMsSUFBSSxDQUFDLENBQUM7WUFDOUIsV0FBVztTQUNkLENBQUMsQ0FBQztJQUNQLENBQUM7SUFFRDs7Ozs7Ozs7OztPQVVHO0lBQ0gsV0FBVyxDQUFDLE9BQXlCO1FBQ2pDLE1BQU0sRUFBRSxXQUFXLEVBQUUsUUFBUSxHQUFHLFNBQVMsRUFBRSxHQUFHLE9BQU8sQ0FBQztRQUN0RCxJQUFJLENBQUMsV0FBVyxJQUFJLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxXQUFXLENBQUMsRUFBRTtZQUMxQyxNQUFNLElBQUksS0FBSyxDQUNYLCtFQUErRSxDQUNsRixDQUFDO1NBQ0w7UUFDRCxPQUFPLElBQUksQ0FBQyxPQUFPLENBQUMsRUFBRSxNQUFNLEVBQUUsY0FBSyxDQUFDLFFBQVEsQ0FBQyxFQUFFLFdBQVcsRUFBRSxDQUFDLENBQUM7SUFDbEUsQ0FBQztJQUVEOzs7Ozs7Ozs7O09BVUc7SUFDSDs7Ozs7Ozs7Ozs7O01BWUU7SUFFRjs7Ozs7Ozs7Ozs7T0FXRztJQUNIOzs7Ozs7Ozs7Ozs7TUFZRTtJQUVGOzs7OztPQUtHO0lBQ0gsT0FBTyxDQUFDLE9BQXlCO1FBQzdCLE1BQU0sa0JBQWtCLEdBQUcsSUFBSSxDQUFDLFdBQVc7YUFDdEMsTUFBTSxDQUFDLEVBQUUsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNLEVBQUUsT0FBTyxFQUFFLGVBQU8sQ0FBQyxpQkFBaUIsRUFBRSxDQUFDO2FBQ3RFLFNBQVMsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDO2FBQzlCLE9BQU8sRUFBRSxDQUFDO1FBRWYsTUFBTSxXQUFXLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO1FBQzdELE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxXQUFXLENBQUMsQ0FBQztJQUMzQyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7OztPQVlHO0lBQ0gsZUFBZSxDQUFDLE9BQXlCO1FBQ3JDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxNQUFNLENBQUMsRUFBRSxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU0sRUFBRSxDQUFDLENBQUMsT0FBTyxFQUFFLENBQUM7SUFDekUsQ0FBQztJQUVEOztPQUVHO0lBQ0g7OztPQUdHO0lBQ0gsaUNBQWlDO0lBQ2pDLE1BQU0sQ0FBQyxLQUFLLENBQUMsT0FBd0IsRUFBRSxPQUF3QjtRQUMzRCxPQUFPLE9BQU8sQ0FBQyxLQUFLLEtBQUssT0FBTyxDQUFDLEtBQUssSUFBSSxPQUFPLENBQUMsV0FBVyxLQUFLLE9BQU8sQ0FBQyxXQUFXLENBQUM7SUFDMUYsQ0FBQztJQUVEOzs7T0FHRztJQUNILE1BQU0sQ0FBQyxFQUFFLENBQUMsT0FBd0IsRUFBRSxPQUF3QjtRQUN4RCxPQUFPLENBQ0gsU0FBUyxDQUFDLEVBQUUsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLE9BQU8sQ0FBQyxLQUFLLENBQUM7WUFDMUMsbUNBQWdCLENBQUMsRUFBRSxDQUFDLE9BQU8sQ0FBQyxXQUFXLEVBQUUsT0FBTyxDQUFDLFdBQVcsQ0FBQyxDQUNoRSxDQUFDO0lBQ04sQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQXVCRztJQUNILE1BQU0sQ0FBQyxvQkFBb0IsQ0FBZ0IsT0FBMEI7UUFDakUsTUFBTSxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsT0FBTyxLQUFjLE9BQU8sRUFBbkIsOERBQW1CLENBQUM7UUFDNUQsTUFBTSxRQUFRLEdBQUcsYUFBSyxDQUFDLFFBQVEsQ0FBQyxTQUFTLEVBQUUsT0FBTyxDQUFDLENBQUM7UUFDcEQsT0FBTyxVQUFVLENBQUMseUJBQXlCLGlCQUN2QyxVQUFVO1lBQ1YsU0FBUyxFQUNULE9BQU8sRUFBRSxRQUFRLElBQ2QsSUFBSSxFQUNULENBQUM7SUFDUCxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQXFCRztJQUNILE1BQU0sQ0FBQyxtQkFBbUIsQ0FBZ0IsT0FBMEI7UUFDaEUsTUFBTSxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsT0FBTyxFQUFFLElBQUksR0FBRyxLQUFLLEtBQWMsT0FBTyxFQUFuQixzRUFBbUIsQ0FBQztRQUMxRSxNQUFNLE1BQU0sR0FBRyxhQUFLLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxDQUFDO1FBQ2xDLE9BQU8sVUFBVSxDQUFDLHlCQUF5QixpQkFDdkMsVUFBVTtZQUNWLFNBQVMsRUFDVCxPQUFPLEVBQUUsTUFBTSxJQUNaLElBQUksRUFDVCxDQUFDO0lBQ1AsQ0FBQztJQUVEOztPQUVHO0lBQ0gsTUFBTSxDQUFDLHlCQUF5QixDQUM1QixPQUFxQztRQUVyQyxNQUFNLEVBQUUsVUFBVSxFQUFFLFNBQVMsRUFBRSxPQUFPLEtBQWMsT0FBTyxFQUFuQiw4REFBbUIsQ0FBQztRQUM1RCxJQUFJLENBQUMsVUFBVSxJQUFJLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsRUFBRTtZQUN2QyxNQUFNLElBQUksS0FBSyxDQUFDLGlEQUFpRCxDQUFDLENBQUM7U0FDdEU7UUFFRCxJQUFJLENBQUMsT0FBTyxJQUFJLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxPQUFPLENBQUMsRUFBRTtZQUNwQyxNQUFNLElBQUksS0FBSyxDQUFDLHNEQUFzRCxDQUFDLENBQUM7U0FDM0U7UUFFRCxvREFBb0Q7UUFDcEQscUNBQXFDO1FBQ3JDLE1BQU0sU0FBUyxHQUFHLEVBQUUsQ0FBQztRQUNyQixVQUFVLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxFQUFFO1lBQ3hCLEtBQUssTUFBTSxDQUFDLElBQUksTUFBTSxDQUFDLFdBQVcsQ0FBQyxTQUFTLEVBQUUsRUFBRTtnQkFDNUMsU0FBUyxDQUFDLElBQUksQ0FBQyxDQUFDLENBQUMsQ0FBQzthQUNyQjtRQUNMLENBQUMsQ0FBQyxDQUFDO1FBRUgsTUFBTSxNQUFNLEdBQUcsT0FBTyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQztRQUVsRCxnRUFBZ0U7UUFDaEUsb0VBQW9FO1FBQ3BFLDZEQUE2RDtRQUM3RCw2REFBNkQ7UUFDN0QsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxNQUFNLENBQUMsQ0FBQztRQUNoRCxNQUFNLFVBQVUsR0FBRyxJQUFJLFVBQVUsbUJBQVMsSUFBSSxJQUFFLFVBQVUsSUFBRyxDQUFDO1FBRTlELE9BQU8sVUFBVSxDQUFDO0lBQ3RCLENBQUM7Q0FDSjtBQWhyQ0QsZ0NBZ3JDQyJ9
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGltZXNlcmllcy5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uL3NyYy90aW1lc2VyaWVzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QUFBQTs7Ozs7Ozs7R0FRRzs7Ozs7Ozs7Ozs7QUFFSCx1Q0FBdUM7QUFDdkMsNEJBQTRCO0FBSTVCLHlDQUFzQztBQUN0QyxtQ0FBZ0Y7QUFDaEYsbUNBQXVDO0FBSXZDLHlEQUFzRDtBQUN0RCxpQ0FBb0M7QUFDcEMsMkNBQW1EO0FBQ25ELHFDQUF5QztBQUV6QywyQ0FXcUI7QUFFckIsbUNBZWlCO0FBRWpCLFNBQVMsYUFBYSxDQUFDLElBQUk7SUFDdkIsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQztJQUUzQixPQUFPO0lBQ1AsQ0FBQyxDQUFDLElBQUksR0FBRyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsSUFBSSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFFcEMsUUFBUTtJQUNSLElBQUksSUFBSSxDQUFDLEtBQUssRUFBRTtRQUNaLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEVBQUU7WUFDeEIsQ0FBQyxDQUFDLEtBQUssR0FBRyxJQUFJLGFBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLENBQUMsUUFBUSxFQUFFLENBQUM7U0FDOUM7YUFBTSxJQUFJLElBQUksQ0FBQyxLQUFLLFlBQVksYUFBSyxFQUFFO1lBQ3BDLENBQUMsQ0FBQyxLQUFLLEdBQUcsSUFBSSxDQUFDLEtBQUssQ0FBQyxRQUFRLEVBQUUsQ0FBQztTQUNuQztLQUNKO0lBRUQsV0FBVztJQUNYLENBQUMsQ0FBQyxFQUFFLEdBQUcsU0FBUyxDQUFDO0lBQ2pCLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDLEVBQUU7UUFDckIsQ0FBQyxDQUFDLEVBQUUsR0FBRyxJQUFJLENBQUMsRUFBRSxDQUFDO0tBQ2xCO0lBQ0QsT0FBTyxTQUFTLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQzVCLENBQUM7QUE2Q0Q7Ozs7Ozs7Ozs7Ozs7R0FhRztBQUNILFNBQVMsVUFBVSxDQUFDLEdBQXlCO0lBQ3pDLE1BQU0sVUFBVSxHQUFHLEdBQTJCLENBQUM7SUFDL0MsTUFBTSxFQUFFLE9BQU8sRUFBRSxNQUFNLEVBQUUsRUFBRSxHQUFHLFNBQVMsS0FBZSxVQUFVLEVBQXZCLHVEQUF1QixDQUFDO0lBQ2pFLE1BQU0sQ0FBQyxRQUFRLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxPQUFPLENBQUM7SUFDM0MsTUFBTSxNQUFNLEdBQUcsTUFBTSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsRUFBRTtRQUM5QixNQUFNLENBQUMsR0FBRyxFQUFFLEdBQUcsV0FBVyxDQUFDLEdBQUcsS0FBSyxDQUFDO1FBQ3BDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxTQUFTLENBQUMsV0FBVyxFQUFFLFdBQVcsQ0FBQyxDQUFDO1FBQ2hELE9BQU8sSUFBSSxhQUFLLENBQU8sV0FBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFLFNBQVMsQ0FBQyxNQUFNLENBQUMsQ0FBMEIsQ0FBQyxDQUFDLENBQUM7SUFDcEYsQ0FBQyxDQUFDLENBQUM7SUFDSCxPQUFPLElBQUksVUFBVSxpQkFBRyxNQUFNLEVBQUUsU0FBUyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsSUFBSyxLQUFLLEVBQUcsQ0FBQztBQUN4RSxDQUFDO0FBeURRLGdDQUFVO0FBdkRuQjs7Ozs7Ozs7Ozs7OztHQWFHO0FBQ0gsU0FBUyxhQUFhLENBQUMsR0FBeUI7SUFDNUMsTUFBTSxVQUFVLEdBQUcsR0FBMkIsQ0FBQztJQUMvQyxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sRUFBRSxFQUFFLEdBQUcsU0FBUyxLQUFlLFVBQVUsRUFBdkIsdURBQXVCLENBQUM7SUFDakUsTUFBTSxDQUFDLFFBQVEsRUFBRSxHQUFHLFdBQVcsQ0FBQyxHQUFHLE9BQU8sQ0FBQztJQUMzQyxNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFO1FBQzlCLE1BQU0sQ0FBQyxHQUFHLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDcEMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxXQUFXLEVBQUUsV0FBVyxDQUFDLENBQUM7UUFDaEQsT0FBTyxJQUFJLGFBQUssQ0FBUSxhQUFLLENBQUMsR0FBRyxDQUFDLEVBQUUsU0FBUyxDQUFDLE1BQU0sQ0FBQyxDQUEwQixDQUFDLENBQUMsQ0FBQztJQUN0RixDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxVQUFVLGlCQUFHLE1BQU0sRUFBRSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLEtBQUssRUFBRyxDQUFDO0FBQ3hFLENBQUM7QUErQm9CLHNDQUFhO0FBN0JsQzs7Ozs7Ozs7Ozs7OztHQWFHO0FBQ0gsU0FBUyxlQUFlLENBQUMsR0FBeUI7SUFDOUMsTUFBTSxVQUFVLEdBQUcsR0FBMkIsQ0FBQztJQUMvQyxNQUFNLEVBQUUsT0FBTyxFQUFFLE1BQU0sRUFBRSxFQUFFLEdBQUcsU0FBUyxLQUFlLFVBQVUsRUFBdkIsdURBQXVCLENBQUM7SUFDakUsTUFBTSxDQUFDLFFBQVEsRUFBRSxHQUFHLFdBQVcsQ0FBQyxHQUFHLE9BQU8sQ0FBQztJQUMzQyxNQUFNLE1BQU0sR0FBRyxNQUFNLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFO1FBQzlCLE1BQU0sQ0FBQyxHQUFHLEVBQUUsR0FBRyxXQUFXLENBQUMsR0FBRyxLQUFLLENBQUM7UUFDcEMsTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLFNBQVMsQ0FBQyxXQUFXLEVBQUUsV0FBVyxDQUFDLENBQUM7UUFDaEQsT0FBTyxJQUFJLGFBQUssQ0FDWixxQkFBUyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsRUFBRSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFDekIsU0FBUyxDQUFDLE1BQU0sQ0FBQyxDQUEwQixDQUFDLENBQy9DLENBQUM7SUFDTixDQUFDLENBQUMsQ0FBQztJQUNILE9BQU8sSUFBSSxVQUFVLGlCQUFHLE1BQU0sRUFBRSxTQUFTLENBQUMsSUFBSSxDQUFDLE1BQU0sQ0FBQyxJQUFLLEtBQUssRUFBRyxDQUFDO0FBQ3hFLENBQUM7QUFFbUMsMENBQWU7QUFFbkQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7R0FzRUc7QUFDSCxNQUFhLFVBQVU7SUFJbkI7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0F5RUc7SUFDSCxZQUFZLEdBQXdDO1FBN0U1QyxnQkFBVyxHQUF3QixJQUFJLENBQUM7UUFDeEMsVUFBSyxHQUFHLElBQUksQ0FBQztRQTZFakIsSUFBSSxHQUFHLFlBQVksVUFBVSxFQUFFO1lBQzNCLEVBQUU7WUFDRiwwQkFBMEI7WUFDMUIsRUFBRTtZQUNGLE1BQU0sS0FBSyxHQUFHLEdBQW9CLENBQUM7WUFDbkMsSUFBSSxDQUFDLEtBQUssR0FBRyxLQUFLLENBQUMsS0FBSyxDQUFDO1lBQ3pCLElBQUksQ0FBQyxXQUFXLEdBQUcsS0FBSyxDQUFDLFdBQVcsQ0FBQztTQUN4QzthQUFNLElBQUksQ0FBQyxDQUFDLFFBQVEsQ0FBQyxHQUFHLENBQUMsRUFBRTtZQUN4QixJQUFJLENBQUMsQ0FBQyxHQUFHLENBQUMsR0FBRyxFQUFFLFlBQVksQ0FBQyxFQUFFO2dCQUMxQixFQUFFO2dCQUNGLGdDQUFnQztnQkFDaEMsRUFBRTtnQkFDRixNQUFNLEVBQUUsVUFBVSxLQUFlLEdBQUcsRUFBaEIsbUNBQWdCLENBQUM7Z0JBQ3JDLElBQUksQ0FBQyxXQUFXLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBSSxVQUFVLENBQUMsQ0FBQztnQkFDdkQsSUFBSSxDQUFDLEtBQUssR0FBRyxhQUFhLENBQUMsS0FBSyxDQUFDLENBQUM7YUFDckM7aUJBQU0sSUFBSSxDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsRUFBRSxRQUFRLENBQUMsRUFBRTtnQkFDN0IsRUFBRTtnQkFDRix1QkFBdUI7Z0JBQ3ZCLEVBQUU7Z0JBQ0YsTUFBTSxFQUFFLE1BQU0sS0FBZSxHQUFHLEVBQWhCLCtCQUFnQixDQUFDO2dCQUNqQyxJQUFJLENBQUMsV0FBVyxHQUFHLElBQUksbUNBQWdCLENBQUMsTUFBTSxDQUFDLENBQUM7Z0JBQ2hELElBQUksQ0FBQyxLQUFLLEdBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQyxDQUFDO2FBQ3JDO1NBQ0o7SUFDTCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxNQUFNO1FBQ0YsTUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDO1FBQ3pCLElBQUksQ0FBQyxDQUFDLEVBQUU7WUFDSixPQUFPO1NBQ1Y7UUFFRCxNQUFNLFVBQVUsR0FBRyxJQUFJLENBQUMsT0FBTyxFQUFFLENBQUM7UUFDbEMsTUFBTSxPQUFPLEdBQUcsQ0FBQyxDQUFDLENBQUMsT0FBTyxFQUFFLEVBQUUsR0FBRyxVQUFVLENBQUMsQ0FBQztRQUM3QyxNQUFNLE1BQU0sR0FBRyxFQUFFLENBQUM7UUFDbEIsS0FBSyxNQUFNLEdBQUcsSUFBSSxJQUFJLENBQUMsV0FBVyxDQUFDLFNBQVMsRUFBRSxFQUFFO1lBQzVDLE1BQU0sQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLE9BQU8sQ0FBQyxVQUFVLENBQUMsQ0FBQyxDQUFDO1NBQ3hDO1FBRUQsT0FBTyxDQUFDLENBQUMsTUFBTSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsTUFBTSxFQUFFLEVBQUUsRUFBRSxPQUFPLEVBQUUsTUFBTSxFQUFFLENBQUMsQ0FBQztJQUM5RCxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsUUFBUTtRQUNKLE9BQU8sSUFBSSxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQUMsTUFBTSxFQUFFLENBQUMsQ0FBQztJQUN6QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxTQUFTO1FBQ0wsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLFNBQVMsRUFBRSxDQUFDO0lBQ3hDLENBQUM7SUFFRDs7T0FFRztJQUNILEtBQUs7UUFDRCxPQUFPLElBQUksQ0FBQyxTQUFTLEVBQUUsQ0FBQztJQUM1QixDQUFDO0lBRUQ7O09BRUc7SUFDSCxLQUFLO1FBQ0QsT0FBTyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsS0FBSyxFQUFFLENBQUM7SUFDaEMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsR0FBRztRQUNDLE9BQU8sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLEdBQUcsRUFBRSxDQUFDO0lBQzlCLENBQUM7SUFFRDs7T0FFRztJQUNILEVBQUUsQ0FBQyxHQUFXO1FBQ1YsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLEVBQUUsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUNwQyxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsTUFBTSxDQUFDLENBQU87UUFDVixNQUFNLEdBQUcsR0FBRyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO1FBQzNCLElBQUksR0FBRyxJQUFJLENBQUMsSUFBSSxHQUFHLEdBQUcsSUFBSSxDQUFDLElBQUksRUFBRSxFQUFFO1lBQy9CLE9BQU8sSUFBSSxDQUFDLEVBQUUsQ0FBQyxHQUFHLENBQUMsQ0FBQztTQUN2QjtJQUNMLENBQUM7SUFFRDs7T0FFRztJQUNILE9BQU87UUFDSCxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsVUFBVSxFQUFFLENBQUM7SUFDekMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsTUFBTTtRQUNGLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxTQUFTLEVBQUUsQ0FBQztJQUN4QyxDQUFDO0lBRUQ7OztPQUdHO0lBQ0gsYUFBYSxDQUFnQixVQUErQjtRQUN4RCxNQUFNLE1BQU0sR0FBRyxJQUFJLFVBQVUsQ0FBSSxJQUFJLENBQUMsQ0FBQztRQUN2QyxJQUFJLFVBQVUsRUFBRTtZQUNaLE1BQU0sQ0FBQyxXQUFXLEdBQUcsVUFBVSxDQUFDO1NBQ25DO2FBQU07WUFDSCxNQUFNLENBQUMsV0FBVyxHQUFHLElBQUksbUNBQWdCLEVBQUssQ0FBQztTQUNsRDtRQUNELE9BQU8sTUFBTSxDQUFDO0lBQ2xCLENBQUM7SUFFRDs7T0FFRztJQUNILE1BQU0sQ0FBQyxDQUFPLEVBQUUsQ0FBVTtRQUN0QixPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUN6QyxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILEtBQUssQ0FBQyxLQUFjLEVBQUUsR0FBWTtRQUM5QixNQUFNLE1BQU0sR0FBRyxJQUFJLG1DQUFnQixDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsS0FBSyxDQUFDLEtBQUssRUFBRSxHQUFHLENBQUMsQ0FBQyxDQUFDO1FBQ3hFLE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxNQUFNLENBQUMsQ0FBQztJQUN0QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxJQUFJLENBQUMsRUFBYTtRQUNkLE1BQU0sY0FBYyxHQUFHLEVBQUUsQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUNsQyxJQUFJLFFBQVEsR0FBRyxJQUFJLENBQUMsTUFBTSxDQUFDLGNBQWMsQ0FBQyxDQUFDO1FBQzNDLE1BQU0seUJBQXlCLEdBQUcsSUFBSSxDQUFDLEVBQUUsQ0FBQyxRQUFRLENBQUMsQ0FBQyxTQUFTLEVBQUUsR0FBRyxjQUFjLENBQUM7UUFDakYsUUFBUSxHQUFHLHlCQUF5QixDQUFDLENBQUMsQ0FBQyxRQUFRLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUM7UUFDL0QsTUFBTSxNQUFNLEdBQUcsSUFBSSxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUMsR0FBRyxFQUFFLEVBQUUsUUFBUSxDQUFDLENBQUM7UUFDL0MsT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLFFBQVEsRUFBRSxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUM7SUFDNUMsQ0FBQztJQUVELEVBQUU7SUFDRixvQ0FBb0M7SUFDcEMsRUFBRTtJQUNGOztPQUVHO0lBQ0gsSUFBSTtRQUNBLE9BQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDbEMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsT0FBTyxDQUFDLElBQVk7UUFDaEIsT0FBTyxJQUFJLENBQUMsT0FBTyxDQUFDLE1BQU0sRUFBRSxJQUFJLENBQUMsQ0FBQztJQUN0QyxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILEtBQUs7UUFDRCxPQUFPLGFBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRDs7T0FFRztJQUNILGFBQWE7UUFDVCxPQUFPLElBQUksQ0FBQyxLQUFLLEVBQUUsQ0FBQyxDQUFDLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLFFBQVEsRUFBRSxDQUFDLENBQUMsQ0FBQyxTQUFTLENBQUM7SUFDOUQsQ0FBQztJQUVEOztPQUVHO0lBQ0gsWUFBWTtRQUNSLE9BQU8sSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsV0FBVyxFQUFFLENBQUMsQ0FBQyxDQUFDLFNBQVMsQ0FBQztJQUNqRSxDQUFDO0lBRUQ7O09BRUc7SUFDSCxLQUFLO1FBQ0QsT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxJQUFJLENBQUMsS0FBSyxTQUFTLENBQUM7SUFDOUMsQ0FBQztJQUVEOztPQUVHO0lBQ0gsUUFBUTtRQUNKLE9BQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLENBQUM7SUFDaEMsQ0FBQztJQUVEOzs7O09BSUc7SUFDSCxPQUFPO1FBQ0gsTUFBTSxDQUFDLEdBQUcsRUFBRSxDQUFDO1FBQ2IsS0FBSyxNQUFNLENBQUMsSUFBSSxJQUFJLENBQUMsV0FBVyxDQUFDLFNBQVMsRUFBRSxFQUFFO1lBQzFDLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQztZQUN0QixDQUFDLENBQUMsT0FBTyxDQUFDLENBQUMsR0FBRyxFQUFFLEdBQUcsRUFBRSxFQUFFO2dCQUNuQixDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsSUFBSSxDQUFDO1lBQ2xCLENBQUMsQ0FBQyxDQUFDO1NBQ047UUFDRCxPQUFPLENBQUMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDckIsQ0FBQztJQUVEOzs7T0FHRztJQUNILFNBQVM7UUFDTCxPQUFPLElBQUksQ0FBQyxVQUFVLEVBQUUsQ0FBQyxTQUFTLEVBQUUsQ0FBQztJQUN6QyxDQUFDO0lBRUQ7O09BRUc7SUFDSCxVQUFVO1FBQ04sT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDO0lBQzVCLENBQUM7SUFFRDs7Ozs7T0FLRztJQUNILElBQUksQ0FBQyxHQUFXO1FBQ1osSUFBSSxDQUFDLEdBQUcsRUFBRTtZQUNOLE9BQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxNQUFNLEVBQUUsQ0FBQztTQUM5QjthQUFNO1lBQ0gsT0FBTyxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxHQUFHLENBQUMsQ0FBQztTQUM5QjtJQUNMLENBQUM7SUFFRDs7O09BR0c7SUFDSCxPQUFPLENBQUMsR0FBUSxFQUFFLEtBQVU7UUFDeEIsTUFBTSxhQUFhLEdBQUcsSUFBSSxVQUFVLENBQUMsSUFBSSxDQUFDLENBQUM7UUFDM0MsTUFBTSxDQUFDLEdBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQztRQUM5QixNQUFNLEVBQUUsR0FBRyxDQUFDLENBQUMsR0FBRyxDQUFDLEdBQUcsRUFBRSxLQUFLLENBQUMsQ0FBQztRQUM3QixhQUFhLENBQUMsS0FBSyxHQUFHLEVBQUUsQ0FBQztRQUN6QixPQUFPLGFBQWEsQ0FBQztJQUN6QixDQUFDO0lBRUQ7O09BRUc7SUFDSCxJQUFJO1FBQ0EsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLENBQUMsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDLElBQUksRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7SUFDMUQsQ0FBQztJQUVEOzs7Ozs7T0FNRztJQUNILFNBQVMsQ0FBQyxTQUFpQjtRQUN2QixPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsU0FBUyxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQ2pELENBQUM7SUFFRDs7O09BR0c7SUFDSCxLQUFLO1FBQ0QsT0FBTyxJQUFJLENBQUMsSUFBSSxFQUFFLENBQUM7SUFDdkIsQ0FBQztJQUVEOzs7T0FHRztJQUNILEdBQUcsQ0FBQyxZQUFvQixPQUFPLEVBQUUsTUFBTztRQUNwQyxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsR0FBRyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUNuRCxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7OztPQVlHO0lBQ0gsR0FBRyxDQUFDLFlBQW9CLE9BQU8sRUFBRSxNQUFPO1FBQ3BDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ25ELENBQUM7SUFFRDs7T0FFRztJQUNILEdBQUcsQ0FBQyxZQUFvQixPQUFPLEVBQUUsTUFBTztRQUNwQyxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsR0FBRyxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUNuRCxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09BdUJHO0lBQ0gsR0FBRyxDQUFDLFlBQW9CLE9BQU8sRUFBRSxNQUFPO1FBQ3BDLE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsU0FBUyxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ25ELENBQUM7SUFFRDs7T0FFRztJQUNILE1BQU0sQ0FBQyxZQUFvQixPQUFPLEVBQUUsTUFBTztRQUN2QyxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUN0RCxDQUFDO0lBRUQ7O09BRUc7SUFDSCxLQUFLLENBQUMsWUFBb0IsT0FBTyxFQUFFLE1BQU87UUFDdEMsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLEtBQUssQ0FBQyxTQUFTLEVBQUUsTUFBTSxDQUFDLENBQUM7SUFDckQsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQW9CRztJQUNILFVBQVUsQ0FDTixDQUFTLEVBQ1QsWUFBb0IsT0FBTyxFQUMzQixTQUE0Qiw2QkFBaUIsQ0FBQyxNQUFNLEVBQ3BELE1BQU87UUFFUCxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsVUFBVSxDQUFDLENBQUMsRUFBRSxTQUFTLEVBQUUsTUFBTSxFQUFFLE1BQU0sQ0FBQyxDQUFDO0lBQ3JFLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQXNCRztJQUNILFNBQVMsQ0FBQyxJQUFxQixFQUFFLFlBQW9CLE9BQU87UUFDeEQsT0FBTyxJQUFJLENBQUMsV0FBVyxDQUFDLFNBQVMsQ0FBQyxJQUFJLEVBQUUsU0FBUyxDQUFDLENBQUM7SUFDdkQsQ0FBQztJQUVEOzs7O09BSUc7SUFDSCxRQUFRLENBQ0osUUFBZ0IsRUFDaEIsWUFBb0IsT0FBTyxFQUMzQixTQUE0Qiw2QkFBaUIsQ0FBQyxNQUFNO1FBRXBELE9BQU8sSUFBSSxDQUFDLFdBQVcsQ0FBQyxRQUFRLENBQUMsUUFBUSxFQUFFLFNBQVMsRUFBRSxNQUFNLENBQUMsQ0FBQztJQUNsRSxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7O09BaUJHO0lBQ0gsT0FBTyxDQUFnQixVQUFxRDtRQUN4RSxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsT0FBTyxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQ2hELENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7T0FjRztJQUNILEdBQUcsQ0FBZ0IsTUFBc0Q7UUFDckUsTUFBTSxRQUFRLEdBQUcsSUFBSSxDQUFDLFdBQVcsQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDOUMsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQ3hDLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09BMENHO0lBQ0gsT0FBTyxDQUNILE1BQXNFO1FBRXRFLE1BQU0sUUFBUSxHQUFHLElBQUksQ0FBQyxXQUFXLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDO1FBQ2xELE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxRQUFRLENBQUMsQ0FBQztJQUN4QyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQXFCRztJQUNILE9BQU8sQ0FBZ0IsTUFBcUI7UUFDeEMsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDO1FBQzFFLE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7T0FVRztJQUNJLE1BQU0sQ0FBQyxTQUFzRDtRQUNoRSxNQUFNLFFBQVEsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDLE1BQU0sQ0FBQyxTQUFTLENBQUMsQ0FBQztRQUNwRCxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsUUFBUSxDQUFDLENBQUM7SUFDeEMsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O09BK0JHO0lBQ0gsTUFBTSxDQUFDLE9BQXNCO1FBQ3pCLE1BQU0sVUFBVSxHQUFHLElBQUksbUNBQWdCLENBQUMsSUFBSSxDQUFDLFdBQVcsQ0FBQyxNQUFNLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQztRQUMxRSxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0FnREc7SUFDSCxRQUFRLENBQUMsT0FBd0I7UUFDN0IsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBQzVFLE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7Ozs7Ozs7T0FnQkc7SUFDSCxhQUFhLENBQUMsT0FBNEI7UUFDdEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxHQUFHLE9BQU8sQ0FBQztRQUM5QixPQUFPLElBQUksQ0FBQyxHQUFHLENBQUMsQ0FBQyxDQUFDLEVBQUU7WUFDaEIsTUFBTSxTQUFTLEdBQUcsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDO1lBQzlCLE1BQU0sQ0FBQyxHQUFHLENBQUMsQ0FBQyxPQUFPLEVBQUUsQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxTQUFTLENBQUMsR0FBRyxDQUFDLElBQUksR0FBRyxDQUFDLENBQUM7WUFDNUQsUUFBUSxTQUFTLEVBQUU7Z0JBQ2YsS0FBSyxNQUFNO29CQUNQLE9BQU8sSUFBSSxhQUFLLENBQUMsV0FBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztnQkFDNUQsS0FBSyxPQUFPO29CQUNSLE9BQU8sSUFBSSxhQUFLLENBQUMsYUFBSyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQztnQkFDN0QsS0FBSyxXQUFXO29CQUNaLE1BQU0sU0FBUyxHQUFHLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLE9BQU8sRUFBRSxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUM7b0JBQy9DLE9BQU8sSUFBSSxhQUFLLENBQUMscUJBQVMsQ0FBQyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQUUsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7YUFDbEU7UUFDTCxDQUFDLENBQUMsQ0FBQztJQUNQLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQTRCRztJQUNILElBQUksQ0FBQyxPQUFvQjtRQUNyQixNQUFNLEVBQUUsU0FBUyxHQUFHLElBQUksRUFBRSxNQUFNLEdBQUcsa0JBQVUsQ0FBQyxJQUFJLEVBQUUsS0FBSyxHQUFHLElBQUksRUFBRSxHQUFHLE9BQU8sQ0FBQztRQUU3RSxJQUFJLGdCQUFxQyxDQUFDO1FBQzFDLElBQUksTUFBTSxLQUFLLGtCQUFVLENBQUMsSUFBSSxJQUFJLE1BQU0sS0FBSyxrQkFBVSxDQUFDLEdBQUcsRUFBRTtZQUN6RCxnQkFBZ0IsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUMsQ0FBQztTQUMxRTthQUFNLElBQUksTUFBTSxLQUFLLGtCQUFVLENBQUMsTUFBTSxFQUFFO1lBQ3JDLElBQUksQ0FBQyxDQUFDLE9BQU8sQ0FBQyxTQUFTLENBQUMsRUFBRTtnQkFDdEIsZ0JBQWdCLEdBQUcsSUFBSSxDQUFDLFdBQVcsQ0FBQztnQkFDcEMsU0FBUyxDQUFDLE9BQU8sQ0FBQyxTQUFTLENBQUMsRUFBRTtvQkFDMUIsTUFBTSxJQUFJLEdBQWdCLEVBQUUsU0FBUyxFQUFFLFNBQVMsRUFBRSxNQUFNLEVBQUUsS0FBSyxFQUFFLENBQUM7b0JBQ2xFLGdCQUFnQixHQUFHLGdCQUFnQixDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQztnQkFDbkQsQ0FBQyxDQUFDLENBQUM7YUFDTjtpQkFBTTtnQkFDSCxnQkFBZ0IsR0FBRyxJQUFJLENBQUMsV0FBVyxDQUFDLElBQUksQ0FBQztvQkFDckMsU0FBUztvQkFDVCxNQUFNO29CQUNOLEtBQUs7aUJBQ1IsQ0FBQyxDQUFDO2FBQ047U0FDSjthQUFNO1lBQ0gsTUFBTSxJQUFJLEtBQUssQ0FBQyx3QkFBd0IsTUFBTSxFQUFFLENBQUMsQ0FBQztTQUNyRDtRQUVELE1BQU0sVUFBVSxHQUFHLElBQUksbUNBQWdCLENBQUMsZ0JBQWdCLENBQUMsQ0FBQztRQUMxRCxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsVUFBVSxDQUFDLENBQUM7SUFDMUMsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0FpQ0c7SUFDSCxLQUFLLENBQUMsT0FBeUI7UUFDM0IsTUFBTSxVQUFVLEdBQUcsSUFBSSxtQ0FBZ0IsQ0FBQyxJQUFJLENBQUMsV0FBVyxDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDO1FBQ3pFLE9BQU8sSUFBSSxDQUFDLGFBQWEsQ0FBQyxVQUFVLENBQUMsQ0FBQztJQUMxQyxDQUFDO0lBRUQ7Ozs7T0FJRztJQUNILElBQUksQ0FBQyxPQUFvQjtRQUNyQixNQUFNLFVBQVUsR0FBRyxJQUFJLG1DQUFnQixDQUFDLElBQUksQ0FBQyxXQUFXLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUM7UUFDeEUsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFVBQVUsQ0FBQyxDQUFDO0lBQzFDLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztPQXdDRztJQUNILGlCQUFpQixDQUFDLE9BQXlCO1FBQ3ZDLElBQUksQ0FBQyxPQUFPLENBQUMsTUFBTSxFQUFFO1lBQ2pCLE1BQU0sSUFBSSxLQUFLLENBQUMseUJBQXlCLENBQUMsQ0FBQztTQUM5QztRQUVELElBQUksQ0FBQyxPQUFPLENBQUMsV0FBVyxJQUFJLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLEVBQUU7WUFDMUQsTUFBTSxJQUFJLEtBQUssQ0FDWCwyRUFBMkUsQ0FDOUUsQ0FBQztTQUNMO1FBRUQsTUFBTSxrQkFBa0IsR0FBRyxJQUFJLENBQUMsV0FBVzthQUN0QyxNQUFNLENBQUMsRUFBRSxNQUFNLEVBQUUsT0FBTyxDQUFDLE1BQU0sRUFBRSxPQUFPLEVBQUUsZUFBTyxDQUFDLGlCQUFpQixFQUFFLENBQUM7YUFDdEUsU0FBUyxDQUFDLE9BQU8sQ0FBQyxXQUFXLENBQUM7YUFDOUIsT0FBTyxFQUFFLENBQUM7UUFFZixNQUFNLFdBQVcsR0FBRyxJQUFJLG1DQUFnQixDQUFDLGtCQUFrQixDQUFDLENBQUM7UUFFN0QsT0FBTyxJQUFJLENBQUMsYUFBYSxDQUFDLFdBQVcsQ0FBQyxDQUFDO0lBQzNDLENBQUM7SUFFRDs7Ozs7Ozs7OztPQVVHO0lBQ0gsWUFBWSxDQUFDLE9BQXlCO1FBQ2xDLE1BQU0sRUFBRSxXQUFXLEVBQUUsR0FBRyxPQUFPLENBQUM7UUFFaEMsSUFBSSxDQUFDLFdBQVcsSUFBSSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsV0FBVyxDQUFDLEVBQUU7WUFDMUMsTUFBTSxJQUFJLEtBQUssQ0FDWCwyRUFBMkUsQ0FDOUUsQ0FBQztTQUNMO1FBRUQsT0FBTyxJQUFJLENBQUMsaUJBQWlCLENBQUM7WUFDMUIsTUFBTSxFQUFFLGVBQU0sQ0FBQyxtQkFBUSxDQUFDLElBQUksQ0FBQyxDQUFDO1lBQzlCLFdBQVc7U0FDZCxDQUFDLENBQUM7SUFDUCxDQUFDO0lBRUQ7Ozs7Ozs7Ozs7T0FVRztJQUNILFdBQVcsQ0FBQyxPQUF5QjtRQUNqQyxNQUFNLEVBQUUsV0FBVyxFQUFFLFFBQVEsR0FBRyxTQUFTLEVBQUUsR0FBRyxPQUFPLENBQUM7UUFDdEQsSUFBSSxDQUFDLFdBQVcsSUFBSSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsV0FBVyxDQUFDLEVBQUU7WUFDMUMsTUFBTSxJQUFJLEtBQUssQ0FDWCwrRUFBK0UsQ0FDbEYsQ0FBQztTQUNMO1FBQ0QsT0FBTyxJQUFJLENBQUMsT0FBTyxDQUFDLEVBQUUsTUFBTSxFQUFFLGNBQUssQ0FBQyxRQUFRLENBQUMsRUFBRSxXQUFXLEVBQUUsQ0FBQyxDQUFDO0lBQ2xFLENBQUM7SUFFRDs7Ozs7Ozs7OztPQVVHO0lBQ0g7Ozs7Ozs7Ozs7OztNQVlFO0lBRUY7Ozs7Ozs7Ozs7O09BV0c7SUFDSDs7Ozs7Ozs7Ozs7O01BWUU7SUFFRjs7Ozs7T0FLRztJQUNILE9BQU8sQ0FBQyxPQUF5QjtRQUM3QixNQUFNLGtCQUFrQixHQUFHLElBQUksQ0FBQyxXQUFXO2FBQ3RDLE1BQU0sQ0FBQyxFQUFFLE1BQU0sRUFBRSxPQUFPLENBQUMsTUFBTSxFQUFFLE9BQU8sRUFBRSxlQUFPLENBQUMsaUJBQWlCLEVBQUUsQ0FBQzthQUN0RSxTQUFTLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQzthQUM5QixPQUFPLEVBQUUsQ0FBQztRQUVmLE1BQU0sV0FBVyxHQUFHLElBQUksbUNBQWdCLENBQUMsa0JBQWtCLENBQUMsQ0FBQztRQUM3RCxPQUFPLElBQUksQ0FBQyxhQUFhLENBQUMsV0FBVyxDQUFDLENBQUM7SUFDM0MsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7T0FZRztJQUNILGVBQWUsQ0FBQyxPQUF5QjtRQUNyQyxPQUFPLElBQUksQ0FBQyxXQUFXLENBQUMsTUFBTSxDQUFDLEVBQUUsTUFBTSxFQUFFLE9BQU8sQ0FBQyxNQUFNLEVBQUUsQ0FBQyxDQUFDLE9BQU8sRUFBRSxDQUFDO0lBQ3pFLENBQUM7SUFFRDs7T0FFRztJQUNIOzs7T0FHRztJQUNILGlDQUFpQztJQUNqQyxNQUFNLENBQUMsS0FBSyxDQUFDLE9BQXdCLEVBQUUsT0FBd0I7UUFDM0QsT0FBTyxPQUFPLENBQUMsS0FBSyxLQUFLLE9BQU8sQ0FBQyxLQUFLLElBQUksT0FBTyxDQUFDLFdBQVcsS0FBSyxPQUFPLENBQUMsV0FBVyxDQUFDO0lBQzFGLENBQUM7SUFFRDs7O09BR0c7SUFDSCxNQUFNLENBQUMsRUFBRSxDQUFDLE9BQXdCLEVBQUUsT0FBd0I7UUFDeEQsT0FBTyxDQUNILFNBQVMsQ0FBQyxFQUFFLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxPQUFPLENBQUMsS0FBSyxDQUFDO1lBQzFDLG1DQUFnQixDQUFDLEVBQUUsQ0FBQyxPQUFPLENBQUMsV0FBVyxFQUFFLE9BQU8sQ0FBQyxXQUFXLENBQUMsQ0FDaEUsQ0FBQztJQUNOLENBQUM7SUFFRDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0F1Qkc7SUFDSCxNQUFNLENBQUMsb0JBQW9CLENBQWdCLE9BQTBCO1FBQ2pFLE1BQU0sRUFBRSxVQUFVLEVBQUUsU0FBUyxFQUFFLE9BQU8sS0FBYyxPQUFPLEVBQW5CLDhEQUFtQixDQUFDO1FBQzVELE1BQU0sUUFBUSxHQUFHLGFBQUssQ0FBQyxRQUFRLENBQUMsU0FBUyxFQUFFLE9BQU8sQ0FBQyxDQUFDO1FBQ3BELE9BQU8sVUFBVSxDQUFDLHlCQUF5QixpQkFDdkMsVUFBVTtZQUNWLFNBQVMsRUFDVCxPQUFPLEVBQUUsUUFBUSxJQUNkLElBQUksRUFDVCxDQUFDO0lBQ1AsQ0FBQztJQUVEOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7T0FxQkc7SUFDSCxNQUFNLENBQUMsbUJBQW1CLENBQWdCLE9BQTBCO1FBQ2hFLE1BQU0sRUFBRSxVQUFVLEVBQUUsU0FBUyxFQUFFLE9BQU8sRUFBRSxJQUFJLEdBQUcsS0FBSyxLQUFjLE9BQU8sRUFBbkIsc0VBQW1CLENBQUM7UUFDMUUsTUFBTSxNQUFNLEdBQUcsYUFBSyxDQUFDLE1BQU0sQ0FBQyxJQUFJLENBQUMsQ0FBQztRQUNsQyxPQUFPLFVBQVUsQ0FBQyx5QkFBeUIsaUJBQ3ZDLFVBQVU7WUFDVixTQUFTLEVBQ1QsT0FBTyxFQUFFLE1BQU0sSUFDWixJQUFJLEVBQ1QsQ0FBQztJQUNQLENBQUM7SUFFRDs7T0FFRztJQUNILE1BQU0sQ0FBQyx5QkFBeUIsQ0FDNUIsT0FBcUM7UUFFckMsTUFBTSxFQUFFLFVBQVUsRUFBRSxTQUFTLEVBQUUsT0FBTyxLQUFjLE9BQU8sRUFBbkIsOERBQW1CLENBQUM7UUFDNUQsSUFBSSxDQUFDLFVBQVUsSUFBSSxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsVUFBVSxDQUFDLEVBQUU7WUFDdkMsTUFBTSxJQUFJLEtBQUssQ0FBQyxpREFBaUQsQ0FBQyxDQUFDO1NBQ3RFO1FBRUQsSUFBSSxDQUFDLE9BQU8sSUFBSSxDQUFDLENBQUMsQ0FBQyxVQUFVLENBQUMsT0FBTyxDQUFDLEVBQUU7WUFDcEMsTUFBTSxJQUFJLEtBQUssQ0FBQyxzREFBc0QsQ0FBQyxDQUFDO1NBQzNFO1FBRUQsb0RBQW9EO1FBQ3BELHFDQUFxQztRQUNyQyxNQUFNLFNBQVMsR0FBRyxFQUFFLENBQUM7UUFDckIsVUFBVSxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUMsRUFBRTtZQUN4QixLQUFLLE1BQU0sQ0FBQyxJQUFJLE1BQU0sQ0FBQyxXQUFXLENBQUMsU0FBUyxFQUFFLEVBQUU7Z0JBQzVDLFNBQVMsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDLENBQUM7YUFDckI7UUFDTCxDQUFDLENBQUMsQ0FBQztRQUVILE1BQU0sTUFBTSxHQUFHLE9BQU8sQ0FBQyxTQUFTLENBQUMsSUFBSSxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUM7UUFFbEQsZ0VBQWdFO1FBQ2hFLG9FQUFvRTtRQUNwRSw2REFBNkQ7UUFDN0QsNkRBQTZEO1FBQzdELE1BQU0sVUFBVSxHQUFHLElBQUksbUNBQWdCLENBQUMsTUFBTSxDQUFDLENBQUM7UUFDaEQsTUFBTSxVQUFVLEdBQUcsSUFBSSxVQUFVLG1CQUFTLElBQUksSUFBRSxVQUFVLElBQUcsQ0FBQztRQUU5RCxPQUFPLFVBQVUsQ0FBQztJQUN0QixDQUFDO0NBQ0o7QUFqckNELGdDQWlyQ0MifQ==

--- a/packages/pond/package-lock.json
+++ b/packages/pond/package-lock.json
@@ -787,11 +787,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
       "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
     },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -801,12 +796,9 @@
       }
     },
     "commander": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.10.0.tgz",
-      "integrity": "sha512-q/r9trjmuikWDRJNTBHAVnWhuU6w+z80KgBq7j9YDclik5E7X4xi0KnlZBNFA1zOQ+SH/vHMWd2mC9QTOz7GpA==",
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -2144,11 +2136,6 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growly": {
       "version": "1.3.0",
@@ -5138,35 +5125,74 @@
       }
     },
     "tslib": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.7.0.tgz",
-      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
       "requires": {
         "babel-code-frame": "^6.22.0",
-        "colors": "^1.1.2",
-        "commander": "^2.9.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.7.1",
-        "tsutils": "^2.8.1"
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
       },
       "dependencies": {
-        "tsutils": {
-          "version": "2.8.2",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.2.tgz",
-          "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "tslib": "^1.7.1"
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg=="
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "requires": {
+        "tslib": "^1.8.1"
       }
     },
     "tunnel-agent": {
@@ -5228,9 +5254,9 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/packages/pond/package.json
+++ b/packages/pond/package.json
@@ -1,43 +1,44 @@
 {
-    "name": "pondjs",
-    "version": "1.0.0-alpha.8",
-    "description": "A TimeSeries library built on Immutable.js with Typescript",
-    "main": "lib/exports.js",
-    "types": "lib/exports.d.ts",
-    "author": "Software Engineering Group at ESnet",
-    "license": "BSD-style",
-    "dependencies": {
-        "immutable": "^4.0.0-rc.12",
-        "lodash": "^4.17.4",
-        "moment": "^2.18.1",
-        "moment-timezone": "^0.5.13"
+  "name": "pondjs",
+  "version": "1.0.0-alpha.8",
+  "description": "A TimeSeries library built on Immutable.js with Typescript",
+  "main": "lib/exports.js",
+  "types": "lib/exports.d.ts",
+  "author": "Software Engineering Group at ESnet",
+  "license": "BSD-style",
+  "dependencies": {
+    "immutable": "^4.0.0-rc.12",
+    "lodash": "^4.17.11",
+    "moment": "^2.24.0",
+    "moment-timezone": "^0.5.25"
+  },
+  "devDependencies": {
+    "@types/lodash": "^4.14.123",
+    "jest": "^24.7.1",
+    "jest-cli": "^24.7.1",
+    "prettier": "^1.17.0",
+    "ts-jest": "^24.0.2",
+    "tslint": "^5.16.0",
+    "tslint-config-prettier": "^1.18.0",
+    "typedoc": "^0.14.2",
+    "typescript": "^3.4.5"
+  },
+  "scripts": {
+    "build": "tsc --version && tsc",
+    "watch": "tsc --watch",
+    "docs": "typedoc --json ../website/src/doc.json --mode modules ./src/*.ts --ignoreCompilerErrors",
+    "test": "jest --watch",
+    "lint": "tslint ./src/*.ts"
+  },
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "devDependencies": {
-        "@types/lodash": "^4.14.71",
-        "jest": "^21.2.1 ",
-        "jest-cli": "^21.2.1",
-        "prettier": "^1.9.1",
-        "ts-jest": "^21.2.4",
-        "tslint": "^5.5.0",
-        "typedoc": "^0.9.0",
-        "typescript": "^2.5.3"
-    },
-    "scripts": {
-        "build": "tsc --version && tsc",
-        "watch": "tsc --watch",
-        "docs": "typedoc --json ../website/src/doc.json --mode modules ./src/*.ts --ignoreCompilerErrors",
-        "test": "jest --watch",
-        "lint": "tslint ./src/*.ts"
-    },
-    "jest": {
-        "transform": {
-            ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
-        },
-        "testRegex": "(/tests/.*)\\.(ts|tsx|js)$",
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ]
-    }
+    "testRegex": "(/tests/.*)\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ]
+  }
 }

--- a/packages/pond/src/rate.ts
+++ b/packages/pond/src/rate.ts
@@ -41,81 +41,87 @@ import { RateOptions } from "./types";
  *  * `allowNegative` - allow emit of negative rates
  */
 export class Rate<T extends Key> extends Processor<T, TimeRange> {
-    // Internal state
-    private _fieldSpec: string[];
-    private _allowNegative: boolean;
+  // Internal state
+  private fieldSpec: string[];
+  private allowNegative: boolean;
 
-    private _previous: Event<T>;
+  private previous: Event<T>;
 
-    constructor(options: RateOptions) {
-        super();
-        const { fieldSpec, allowNegative = false } = options;
+  constructor(options: RateOptions) {
+    super();
+    const { fieldSpec, allowNegative = false } = options;
 
-        // Options
-        this._fieldSpec = _.isString(fieldSpec) ? [fieldSpec] : fieldSpec;
-        this._allowNegative = allowNegative;
+    // Options
+    this.fieldSpec = _.isString(fieldSpec) ? [fieldSpec] : fieldSpec;
+    this.allowNegative = allowNegative;
 
-        // Previous event
-        this._previous = null;
+    // Previous event
+    this.previous = null;
+  }
+
+  /**
+   * Perform the rate operation on the `Event` and the the `_previous`
+   * `Event` and emit the result.
+   */
+  public addEvent(event: Event<T>): Immutable.List<Event<TimeRange>> {
+    const eventList = new Array<Event<TimeRange>>();
+
+    if (!this.previous) {
+      this.previous = event;
+      return Immutable.List<Event<TimeRange>>();
     }
 
-    /**
-     * Generate a new `TimeRangeEvent` containing the rate per second
-     * between two events.
-     */
-    getRate(event): Event<TimeRange> {
-        let d = Immutable.Map<string, any>();
-
-        const previousTime = this._previous.timestamp().getTime();
-        const currentTime = event.timestamp().getTime();
-        const deltaTime = (currentTime - previousTime) / 1000;
-
-        this._fieldSpec.forEach(path => {
-            const fieldPath = util.fieldAsArray(path);
-            const ratePath = fieldPath.slice();
-            ratePath[ratePath.length - 1] += "_rate";
-
-            const previousVal = this._previous.get(fieldPath);
-            const currentVal = event.get(fieldPath);
-
-            let rate = null;
-            if (!_.isNumber(previousVal) || !_.isNumber(currentVal)) {
-                // tslint:disable-next-line
-                console.warn(`Path ${fieldPath} contains a non-numeric value or does not exist`);
-            } else {
-                rate = (currentVal - previousVal) / deltaTime;
-            }
-
-            if (this._allowNegative === false && rate < 0) {
-                // don't allow negative differentials in certain cases
-                d = d.setIn(ratePath, null);
-            } else {
-                d = d.setIn(ratePath, rate);
-            }
-        });
-
-        return new Event(timerange(previousTime, currentTime), d);
+    const rate = this.getRate(event);
+    if (rate) {
+      eventList.push(rate);
     }
 
-    /**
-     * Perform the rate operation on the `Event` and the the `_previous`
-     * `Event` and emit the result.
-     */
-    addEvent(event: Event<T>): Immutable.List<Event<TimeRange>> {
-        const eventList = new Array<Event<TimeRange>>();
+    this.previous = event;
 
-        if (!this._previous) {
-            this._previous = event;
-            return Immutable.List<Event<TimeRange>>();
-        }
+    return Immutable.List(eventList);
+  }
 
-        const rate = this.getRate(event);
-        if (rate) {
-            eventList.push(rate);
-        }
+  /**
+   * Generate a new `TimeRangeEvent` containing the rate per second
+   * between two events.
+   */
+  private getRate(event: Event<T>): Event<TimeRange> {
+    let d = Immutable.Map<string, any>();
 
-        this._previous = event;
+    const previousTime = this.previous.timestamp().getTime();
+    const currentTime = event.timestamp().getTime();
+    const deltaTime = (currentTime - previousTime) / 1000;
 
-        return Immutable.List(eventList);
-    }
+    this.fieldSpec.forEach(path => {
+      const fieldPath = util.fieldAsArray(path);
+      const ratePath = fieldPath.slice();
+      ratePath[ratePath.length - 1] += "_rate";
+
+      const previousVal = this.previous.get(fieldPath);
+      const currentVal = event.get(fieldPath);
+
+      let rate = null;
+
+      if (_.isNumber(currentVal) && _.isNumber(previousVal)) {
+        // Calculate the rate
+        rate = (currentVal - previousVal) / deltaTime;
+      } else if (
+        (previousVal !== null && !_.isNumber(previousVal)) ||
+        (currentVal !== null && !_.isNumber(currentVal))
+      ) {
+        // Only issue warning if the current or previous values are bad
+        // i.e. not a number or not null (null values result in null output)
+        console.warn(
+          `Event field "${fieldPath}" is a non-numeric or non-null value`
+        );
+      }
+
+      d =
+        this.allowNegative === false && rate < 0
+          ? (d = d.setIn(ratePath, null)) // don't allow negative differentials in certain cases
+          : (d = d.setIn(ratePath, rate));
+    });
+
+    return new Event(timerange(previousTime, currentTime), d);
+  }
 }

--- a/packages/pond/tests/rate.test.ts
+++ b/packages/pond/tests/rate.test.ts
@@ -14,94 +14,117 @@ import { time } from "../src/time";
 import { AlignmentMethod } from "../src/types";
 
 const DATA2 = [
-    [0, 1],
-    [30000, 3],
-    [60000, 10],
-    [90000, 40],
-    [120000, 70],
-    [150000, 130],
-    [180000, 190],
-    [210000, 220],
-    [240000, 300],
-    [270000, 390],
-    [300000, 510]
+  [0, 1],
+  [30000, 3],
+  [60000, 10],
+  [90000, 40],
+  [120000, 70],
+  [150000, 130],
+  [180000, 190],
+  [210000, 220],
+  [240000, 300],
+  [270000, 390],
+  [300000, 510]
 ];
 
 it("can calculate the rate using Collection.rate()", () => {
-    const list = DATA2.map(e => {
-        return event(time(e[0]), Immutable.Map({ in: e[1] }));
-    });
+  const list = DATA2.map(e => {
+    return event(time(e[0]), Immutable.Map({ in: e[1] }));
+  });
 
-    const c = sortedCollection(Immutable.List(list));
-    const rates = c.rate({ fieldSpec: "in" });
+  const c = sortedCollection(Immutable.List(list));
+  const rates = c.rate({ fieldSpec: "in" });
 
-    expect(rates.size()).toEqual(list.length - 1);
-    expect(rates.at(2).get("in_rate")).toEqual(1);
-    expect(rates.at(3).get("in_rate")).toEqual(1);
-    expect(rates.at(4).get("in_rate")).toEqual(2);
-    expect(rates.at(8).get("in_rate")).toEqual(3);
-    expect(rates.at(9).get("in_rate")).toEqual(4);
+  expect(rates.size()).toEqual(list.length - 1);
+  expect(rates.at(2).get("in_rate")).toEqual(1);
+  expect(rates.at(3).get("in_rate")).toEqual(1);
+  expect(rates.at(4).get("in_rate")).toEqual(2);
+  expect(rates.at(8).get("in_rate")).toEqual(3);
+  expect(rates.at(9).get("in_rate")).toEqual(4);
 });
 
 it("can do basic rate using Collection.rate()", () => {
-    const list = [[89000, 100], [181000, 200]].map(e => {
-        return event(time(e[0]), Immutable.Map({ value: e[1] }));
-    });
+  const list = [[89000, 100], [181000, 200]].map(e => {
+    return event(time(e[0]), Immutable.Map({ value: e[1] }));
+  });
 
-    const c = sortedCollection(Immutable.List(list));
-    const rates = c
-        .align({
-            fieldSpec: "value",
-            period: period(duration("30s")),
-            method: AlignmentMethod.Linear
-        })
-        .rate({
-            fieldSpec: "value"
-        })
-        .mapKeys(tr => time(tr.mid()));
+  const c = sortedCollection(Immutable.List(list));
+  const rates = c
+    .align({
+      fieldSpec: "value",
+      period: period(duration("30s")),
+      method: AlignmentMethod.Linear
+    })
+    .rate({
+      fieldSpec: "value"
+    })
+    .mapKeys(tr => time(tr.mid()));
 
-    expect(rates.size()).toEqual(3);
-    expect(rates.at(0).get("value_rate")).toEqual(1.0869565217391313);
-    expect(rates.at(1).get("value_rate")).toEqual(1.0869565217391293);
-    expect(rates.at(2).get("value_rate")).toEqual(1.0869565217391313);
+  expect(rates.size()).toEqual(3);
+  expect(rates.at(0).get("value_rate")).toEqual(1.0869565217391313);
+  expect(rates.at(1).get("value_rate")).toEqual(1.0869565217391293);
+  expect(rates.at(2).get("value_rate")).toEqual(1.0869565217391313);
 });
 
 it("can output nulls for negative values", () => {
-    const list = [[89000, 100], [181000, 50]].map(e => {
-        return event(time(e[0]), Immutable.Map({ value: e[1] }));
+  const list = [[89000, 100], [181000, 50]].map(e => {
+    return event(time(e[0]), Immutable.Map({ value: e[1] }));
+  });
+
+  const c = sortedCollection(Immutable.List(list));
+
+  const rates1 = c
+    .align({
+      fieldSpec: "value",
+      period: period(duration("30s")),
+      method: AlignmentMethod.Linear
+    })
+    .rate({
+      fieldSpec: "value",
+      allowNegative: true
     });
 
-    const c = sortedCollection(Immutable.List(list));
+  expect(rates1.size()).toEqual(3);
+  expect(rates1.at(0).get("value_rate")).toEqual(-0.5434782608695656);
+  expect(rates1.at(1).get("value_rate")).toEqual(-0.5434782608695646);
+  expect(rates1.at(2).get("value_rate")).toEqual(-0.5434782608695653);
 
-    const rates1 = c
-        .align({
-            fieldSpec: "value",
-            period: period(duration("30s")),
-            method: AlignmentMethod.Linear
-        })
-        .rate({
-            fieldSpec: "value",
-            allowNegative: true
-        });
+  const rates2 = c
+    .align({
+      fieldSpec: "value",
+      period: period(duration("30s")),
+      method: AlignmentMethod.Linear
+    })
+    .rate({
+      fieldSpec: "value",
+      allowNegative: false
+    });
 
-    expect(rates1.size()).toEqual(3);
-    expect(rates1.at(0).get("value_rate")).toEqual(-0.5434782608695656);
-    expect(rates1.at(1).get("value_rate")).toEqual(-0.5434782608695646);
-    expect(rates1.at(2).get("value_rate")).toEqual(-0.5434782608695653);
+  expect(rates2.size()).toEqual(3);
+  expect(rates2.at(0).get("value_rate")).toBeNull();
+  expect(rates2.at(1).get("value_rate")).toBeNull();
+  expect(rates2.at(2).get("value_rate")).toBeNull();
+});
 
-    const rates2 = c
-        .align({
-            fieldSpec: "value",
-            period: period(duration("30s")),
-            method: AlignmentMethod.Linear
-        })
-        .rate({
-            fieldSpec: "value",
-            allowNegative: false
-        });
+it("can output a null rate when data has nulls", () => {
+  const INPUT = [
+    [0, 10],
+    [30000, 40],
+    [60000, null],
+    [90000, 100],
+    [120000, 130]
+  ];
 
-    expect(rates2.size()).toEqual(3);
-    expect(rates2.at(0).get("value_rate")).toBeNull();
-    expect(rates2.at(1).get("value_rate")).toBeNull();
-    expect(rates2.at(2).get("value_rate")).toBeNull();
+  const list = INPUT.map(e => {
+    return event(time(e[0]), Immutable.Map({ in: e[1] }));
+  });
+
+  const c = sortedCollection(Immutable.List(list));
+  const rates = c.rate({ fieldSpec: "in" });
+
+  expect(rates.size()).toEqual(list.length - 1);
+  expect(rates.at(0).get("in_rate")).toEqual(1);
+  expect(rates.at(1).get("in_rate")).toEqual(null);
+  expect(rates.at(2).get("in_rate")).toEqual(null);
+  expect(rates.at(3).get("in_rate")).toEqual(1);
 });

--- a/packages/pond/tests/rate.test.ts
+++ b/packages/pond/tests/rate.test.ts
@@ -14,117 +14,111 @@ import { time } from "../src/time";
 import { AlignmentMethod } from "../src/types";
 
 const DATA2 = [
-  [0, 1],
-  [30000, 3],
-  [60000, 10],
-  [90000, 40],
-  [120000, 70],
-  [150000, 130],
-  [180000, 190],
-  [210000, 220],
-  [240000, 300],
-  [270000, 390],
-  [300000, 510]
+    [0, 1],
+    [30000, 3],
+    [60000, 10],
+    [90000, 40],
+    [120000, 70],
+    [150000, 130],
+    [180000, 190],
+    [210000, 220],
+    [240000, 300],
+    [270000, 390],
+    [300000, 510]
 ];
 
 it("can calculate the rate using Collection.rate()", () => {
-  const list = DATA2.map(e => {
-    return event(time(e[0]), Immutable.Map({ in: e[1] }));
-  });
+    const list = DATA2.map(e => {
+        return event(time(e[0]), Immutable.Map({ in: e[1] }));
+    });
 
-  const c = sortedCollection(Immutable.List(list));
-  const rates = c.rate({ fieldSpec: "in" });
+    const c = sortedCollection(Immutable.List(list));
+    const rates = c.rate({ fieldSpec: "in" });
 
-  expect(rates.size()).toEqual(list.length - 1);
-  expect(rates.at(2).get("in_rate")).toEqual(1);
-  expect(rates.at(3).get("in_rate")).toEqual(1);
-  expect(rates.at(4).get("in_rate")).toEqual(2);
-  expect(rates.at(8).get("in_rate")).toEqual(3);
-  expect(rates.at(9).get("in_rate")).toEqual(4);
+    expect(rates.size()).toEqual(list.length - 1);
+    expect(rates.at(2).get("in_rate")).toEqual(1);
+    expect(rates.at(3).get("in_rate")).toEqual(1);
+    expect(rates.at(4).get("in_rate")).toEqual(2);
+    expect(rates.at(8).get("in_rate")).toEqual(3);
+    expect(rates.at(9).get("in_rate")).toEqual(4);
 });
 
 it("can do basic rate using Collection.rate()", () => {
-  const list = [[89000, 100], [181000, 200]].map(e => {
-    return event(time(e[0]), Immutable.Map({ value: e[1] }));
-  });
+    const list = [[89000, 100], [181000, 200]].map(e => {
+        return event(time(e[0]), Immutable.Map({ value: e[1] }));
+    });
 
-  const c = sortedCollection(Immutable.List(list));
-  const rates = c
-    .align({
-      fieldSpec: "value",
-      period: period(duration("30s")),
-      method: AlignmentMethod.Linear
-    })
-    .rate({
-      fieldSpec: "value"
-    })
-    .mapKeys(tr => time(tr.mid()));
+    const c = sortedCollection(Immutable.List(list));
+    const rates = c
+        .align({
+            fieldSpec: "value",
+            period: period(duration("30s")),
+            method: AlignmentMethod.Linear
+        })
+        .rate({
+            fieldSpec: "value"
+        })
+        .mapKeys(tr => time(tr.mid()));
 
-  expect(rates.size()).toEqual(3);
-  expect(rates.at(0).get("value_rate")).toEqual(1.0869565217391313);
-  expect(rates.at(1).get("value_rate")).toEqual(1.0869565217391293);
-  expect(rates.at(2).get("value_rate")).toEqual(1.0869565217391313);
+    expect(rates.size()).toEqual(3);
+    expect(rates.at(0).get("value_rate")).toEqual(1.0869565217391313);
+    expect(rates.at(1).get("value_rate")).toEqual(1.0869565217391293);
+    expect(rates.at(2).get("value_rate")).toEqual(1.0869565217391313);
 });
 
 it("can output nulls for negative values", () => {
-  const list = [[89000, 100], [181000, 50]].map(e => {
-    return event(time(e[0]), Immutable.Map({ value: e[1] }));
-  });
-
-  const c = sortedCollection(Immutable.List(list));
-
-  const rates1 = c
-    .align({
-      fieldSpec: "value",
-      period: period(duration("30s")),
-      method: AlignmentMethod.Linear
-    })
-    .rate({
-      fieldSpec: "value",
-      allowNegative: true
+    const list = [[89000, 100], [181000, 50]].map(e => {
+        return event(time(e[0]), Immutable.Map({ value: e[1] }));
     });
 
-  expect(rates1.size()).toEqual(3);
-  expect(rates1.at(0).get("value_rate")).toEqual(-0.5434782608695656);
-  expect(rates1.at(1).get("value_rate")).toEqual(-0.5434782608695646);
-  expect(rates1.at(2).get("value_rate")).toEqual(-0.5434782608695653);
+    const c = sortedCollection(Immutable.List(list));
 
-  const rates2 = c
-    .align({
-      fieldSpec: "value",
-      period: period(duration("30s")),
-      method: AlignmentMethod.Linear
-    })
-    .rate({
-      fieldSpec: "value",
-      allowNegative: false
-    });
+    const rates1 = c
+        .align({
+            fieldSpec: "value",
+            period: period(duration("30s")),
+            method: AlignmentMethod.Linear
+        })
+        .rate({
+            fieldSpec: "value",
+            allowNegative: true
+        });
 
-  expect(rates2.size()).toEqual(3);
-  expect(rates2.at(0).get("value_rate")).toBeNull();
-  expect(rates2.at(1).get("value_rate")).toBeNull();
-  expect(rates2.at(2).get("value_rate")).toBeNull();
+    expect(rates1.size()).toEqual(3);
+    expect(rates1.at(0).get("value_rate")).toEqual(-0.5434782608695656);
+    expect(rates1.at(1).get("value_rate")).toEqual(-0.5434782608695646);
+    expect(rates1.at(2).get("value_rate")).toEqual(-0.5434782608695653);
+
+    const rates2 = c
+        .align({
+            fieldSpec: "value",
+            period: period(duration("30s")),
+            method: AlignmentMethod.Linear
+        })
+        .rate({
+            fieldSpec: "value",
+            allowNegative: false
+        });
+
+    expect(rates2.size()).toEqual(3);
+    expect(rates2.at(0).get("value_rate")).toBeNull();
+    expect(rates2.at(1).get("value_rate")).toBeNull();
+    expect(rates2.at(2).get("value_rate")).toBeNull();
 });
 
 it("can output a null rate when data has nulls", () => {
-  const INPUT = [
-    [0, 10],
-    [30000, 40],
-    [60000, null],
-    [90000, 100],
-    [120000, 130]
-  ];
+    const INPUT = [[0, 10], [30000, 40], [60000, null], [90000, 100], [120000, 130]];
 
-  const list = INPUT.map(e => {
-    return event(time(e[0]), Immutable.Map({ in: e[1] }));
-  });
+    const list = INPUT.map(e => {
+        return event(time(e[0]), Immutable.Map({ in: e[1] }));
+    });
 
-  const c = sortedCollection(Immutable.List(list));
-  const rates = c.rate({ fieldSpec: "in" });
+    const c = sortedCollection(Immutable.List(list));
+    const rates = c.rate({ fieldSpec: "in" });
 
-  expect(rates.size()).toEqual(list.length - 1);
-  expect(rates.at(0).get("in_rate")).toEqual(1);
-  expect(rates.at(1).get("in_rate")).toEqual(null);
-  expect(rates.at(2).get("in_rate")).toEqual(null);
-  expect(rates.at(3).get("in_rate")).toEqual(1);
+    expect(rates.size()).toEqual(list.length - 1);
+    expect(rates.at(0).get("in_rate")).toEqual(1);
+    expect(rates.at(1).get("in_rate")).toEqual(null);
+    expect(rates.at(2).get("in_rate")).toEqual(null);
+    expect(rates.at(3).get("in_rate")).toEqual(1);
 });

--- a/packages/pond/tests/timeseries.test.ts
+++ b/packages/pond/tests/timeseries.test.ts
@@ -18,1145 +18,1208 @@ import Moment = moment.Moment;
 
 import { collection, Collection } from "../src/collection";
 import { duration } from "../src/duration";
-import { event } from "../src/event";
-import { indexedEvent, timeEvent, timeRangeEvent } from "../src/event";
+import { event, indexedEvent, timeEvent, timeRangeEvent } from "../src/event";
 import { avg, max, sum } from "../src/functions";
 import { index, Index } from "../src/index";
 import { time, Time } from "../src/time";
 import { timerange } from "../src/timerange";
-import { TimeSeries, TimeSeriesWireFormat } from "../src/timeseries";
-import { indexedSeries, timeRangeSeries, timeSeries } from "../src/timeseries";
+import {
+  indexedSeries,
+  timeRangeSeries,
+  TimeSeries,
+  timeSeries,
+  TimeSeriesWireFormat
+} from "../src/timeseries";
 import { TimeAlignment } from "../src/types";
 import { window } from "../src/window";
 
 const EVENT_DATA = {
-    name: "avg temps",
-    events: Immutable.List([
-        event(time("2015-04-22T03:30:00Z"), Immutable.Map({ in: 1, out: 2 })),
-        event(time("2015-04-22T03:31:00Z"), Immutable.Map({ in: 3, out: 4 }))
-    ])
+  name: "avg temps",
+  events: Immutable.List([
+    event(time("2015-04-22T03:30:00Z"), Immutable.Map({ in: 1, out: 2 })),
+    event(time("2015-04-22T03:31:00Z"), Immutable.Map({ in: 3, out: 4 }))
+  ])
 };
 
 const COLLECTION_DATA = {
-    name: "avg coll",
-    collection: collection(
-        Immutable.List([
-            event(time("2015-04-22T02:30:00Z"), Immutable.Map({ a: 5, b: 6 })),
-            event(time("2015-04-22T03:30:00Z"), Immutable.Map({ a: 4, b: 2 }))
-        ])
-    )
+  name: "avg coll",
+  collection: collection(
+    Immutable.List([
+      event(time("2015-04-22T02:30:00Z"), Immutable.Map({ a: 5, b: 6 })),
+      event(time("2015-04-22T03:30:00Z"), Immutable.Map({ a: 4, b: 2 }))
+    ])
+  )
 };
 
 const TIMESERIES_TEST_DATA = {
-    name: "traffic",
-    columns: ["time", "value", "status"],
-    points: [
-        [1400425947000, 52, "ok"],
-        [1400425948000, 18, "ok"],
-        [1400425949000, 26, "fail"],
-        [1400425950000, 93, "offline"]
-    ]
+  name: "traffic",
+  columns: ["time", "value", "status"],
+  points: [
+    [1400425947000, 52, "ok"],
+    [1400425948000, 18, "ok"],
+    [1400425949000, 26, "fail"],
+    [1400425950000, 93, "offline"]
+  ]
 };
 
 const AVAILABILITY_DATA = {
-    name: "availability",
-    columns: ["index", "uptime"],
-    points: [
-        ["2014-07", "100%"],
-        ["2014-08", "88%"],
-        ["2014-09", "95%"],
-        ["2014-10", "99%"],
-        ["2014-11", "91%"],
-        ["2014-12", "99%"],
-        ["2015-01", "100%"],
-        ["2015-02", "92%"],
-        ["2015-03", "99%"],
-        ["2015-04", "87%"],
-        ["2015-05", "92%"],
-        ["2015-06", "100%"]
-    ]
+  name: "availability",
+  columns: ["index", "uptime"],
+  points: [
+    ["2014-07", "100%"],
+    ["2014-08", "88%"],
+    ["2014-09", "95%"],
+    ["2014-10", "99%"],
+    ["2014-11", "91%"],
+    ["2014-12", "99%"],
+    ["2015-01", "100%"],
+    ["2015-02", "92%"],
+    ["2015-03", "99%"],
+    ["2015-04", "87%"],
+    ["2015-05", "92%"],
+    ["2015-06", "100%"]
+  ]
 };
 
 const AVAILABILITY_DATA_2 = {
-    name: "availability",
-    columns: ["index", "uptime", "notes", "outages"],
-    points: [
-        ["2014-07", 100, "", 2],
-        ["2014-08", 88, "", 17],
-        ["2014-09", 95, "", 6],
-        ["2014-10", 99, "", 3],
-        ["2014-11", 91, "", 14],
-        ["2014-12", 99, "", 3],
-        ["2015-01", 100, "", 0],
-        ["2015-02", 92, "", 12],
-        ["2015-03", 99, "Minor outage March 2", 4],
-        ["2015-04", 87, "Planned downtime in April", 82],
-        ["2015-05", 92, "Router failure June 12", 26],
-        ["2015-06", 100, "", 0]
-    ]
+  name: "availability",
+  columns: ["index", "uptime", "notes", "outages"],
+  points: [
+    ["2014-07", 100, "", 2],
+    ["2014-08", 88, "", 17],
+    ["2014-09", 95, "", 6],
+    ["2014-10", 99, "", 3],
+    ["2014-11", 91, "", 14],
+    ["2014-12", 99, "", 3],
+    ["2015-01", 100, "", 0],
+    ["2015-02", 92, "", 12],
+    ["2015-03", 99, "Minor outage March 2", 4],
+    ["2015-04", 87, "Planned downtime in April", 82],
+    ["2015-05", 92, "Router failure June 12", 26],
+    ["2015-06", 100, "", 0]
+  ]
 };
 
 const INDEXED_DATA = {
-    index: "1d-625",
-    name: "traffic",
-    columns: ["time", "value", "status"],
-    points: [
-        [1400425947000, 52, "ok"],
-        [1400425948000, 18, "ok"],
-        [1400425949000, 26, "fail"],
-        [1400425950000, 93, "offline"]
-    ]
+  index: "1d-625",
+  name: "traffic",
+  columns: ["time", "value", "status"],
+  points: [
+    [1400425947000, 52, "ok"],
+    [1400425948000, 18, "ok"],
+    [1400425949000, 26, "fail"],
+    [1400425950000, 93, "offline"]
+  ]
 };
 
 const INTERFACE_TEST_DATA = {
-    name: "star-cr5:to_anl_ip-a_v4",
-    description: "star-cr5->anl(as683):100ge:site-ex:show:intercloud",
-    device: "star-cr5",
-    id: 169,
-    interface: "to_anl_ip-a_v4",
-    is_ipv6: false,
-    is_oscars: false,
-    oscars_id: null,
-    resource_uri: "",
-    site: "anl",
-    site_device: "noni",
-    site_interface: "et-1/0/0",
-    stats_type: "Standard",
-    title: null,
-    columns: ["time", "in", "out"],
-    points: [
-        [1400425947000, 52, 34],
-        [1400425948000, 18, 13],
-        [1400425949000, 26, 67],
-        [1400425950000, 93, 91]
-    ]
+  name: "star-cr5:to_anl_ip-a_v4",
+  description: "star-cr5->anl(as683):100ge:site-ex:show:intercloud",
+  device: "star-cr5",
+  id: 169,
+  interface: "to_anl_ip-a_v4",
+  is_ipv6: false,
+  is_oscars: false,
+  oscars_id: null,
+  resource_uri: "",
+  site: "anl",
+  site_device: "noni",
+  site_interface: "et-1/0/0",
+  stats_type: "Standard",
+  title: null,
+  columns: ["time", "in", "out"],
+  points: [
+    [1400425947000, 52, 34],
+    [1400425948000, 18, 13],
+    [1400425949000, 26, 67],
+    [1400425950000, 93, 91]
+  ]
 };
 
 const fmt = "YYYY-MM-DD HH:mm";
 
 const BISECT_TEST_DATA = {
-    name: "test",
-    columns: ["time", "value"],
-    points: [
-        [moment("2012-01-11 01:00", fmt).valueOf(), 22],
-        [moment("2012-01-11 02:00", fmt).valueOf(), 33],
-        [moment("2012-01-11 03:00", fmt).valueOf(), 44],
-        [moment("2012-01-11 04:00", fmt).valueOf(), 55],
-        [moment("2012-01-11 05:00", fmt).valueOf(), 66],
-        [moment("2012-01-11 06:00", fmt).valueOf(), 77],
-        [moment("2012-01-11 07:00", fmt).valueOf(), 88]
-    ]
+  name: "test",
+  columns: ["time", "value"],
+  points: [
+    [moment("2012-01-11 01:00", fmt).valueOf(), 22],
+    [moment("2012-01-11 02:00", fmt).valueOf(), 33],
+    [moment("2012-01-11 03:00", fmt).valueOf(), 44],
+    [moment("2012-01-11 04:00", fmt).valueOf(), 55],
+    [moment("2012-01-11 05:00", fmt).valueOf(), 66],
+    [moment("2012-01-11 06:00", fmt).valueOf(), 77],
+    [moment("2012-01-11 07:00", fmt).valueOf(), 88]
+  ]
 };
 
 const TRAFFIC_DATA_IN = {
-    name: "star-cr5:to_anl_ip-a_v4",
-    columns: ["time", "in"],
-    points: [[1400425947000, 52], [1400425948000, 18], [1400425949000, 26], [1400425950000, 93]]
+  name: "star-cr5:to_anl_ip-a_v4",
+  columns: ["time", "in"],
+  points: [
+    [1400425947000, 52],
+    [1400425948000, 18],
+    [1400425949000, 26],
+    [1400425950000, 93]
+  ]
 };
 
 const TRAFFIC_DATA_OUT = {
-    name: "star-cr5:to_anl_ip-a_v4",
-    columns: ["time", "out"],
-    points: [[1400425947000, 34], [1400425948000, 13], [1400425949000, 67], [1400425950000, 91]]
+  name: "star-cr5:to_anl_ip-a_v4",
+  columns: ["time", "out"],
+  points: [
+    [1400425947000, 34],
+    [1400425948000, 13],
+    [1400425949000, 67],
+    [1400425950000, 91]
+  ]
 };
 
 const PARTIAL_TRAFFIC_PART_A = {
-    name: "star-cr5:to_anl_ip-a_v4",
-    columns: ["time", "value"],
-    points: [[1400425947000, 34], [1400425948000, 13], [1400425949000, 67], [1400425950000, 91]]
+  name: "star-cr5:to_anl_ip-a_v4",
+  columns: ["time", "value"],
+  points: [
+    [1400425947000, 34],
+    [1400425948000, 13],
+    [1400425949000, 67],
+    [1400425950000, 91]
+  ]
 };
 
 const PARTIAL_TRAFFIC_PART_B = {
-    name: "star-cr5:to_anl_ip-a_v4",
-    columns: ["time", "value"],
-    points: [[1400425951000, 65], [1400425952000, 86], [1400425953000, 27], [1400425954000, 72]]
+  name: "star-cr5:to_anl_ip-a_v4",
+  columns: ["time", "value"],
+  points: [
+    [1400425951000, 65],
+    [1400425952000, 86],
+    [1400425953000, 27],
+    [1400425954000, 72]
+  ]
 };
 
 const TRAFFIC_BNL_TO_NEWY = {
-    name: "BNL to NEWY",
-    columns: ["time", "in"],
-    points: [
-        [1441051950000, 2998846524.2666664],
-        [1441051980000, 2682032885.3333335],
-        [1441052010000, 2753537586.9333334]
-    ]
+  name: "BNL to NEWY",
+  columns: ["time", "in"],
+  points: [
+    [1441051950000, 2998846524.2666664],
+    [1441051980000, 2682032885.3333335],
+    [1441052010000, 2753537586.9333334]
+  ]
 };
 
 const TRAFFIC_NEWY_TO_BNL = {
-    name: "NEWY to BNL",
-    columns: ["time", "out"],
-    points: [
-        [1441051950000, 22034579982.4],
-        [1441051980000, 24783871443.2],
-        [1441052010000, 26907368572.800003]
-    ]
+  name: "NEWY to BNL",
+  columns: ["time", "out"],
+  points: [
+    [1441051950000, 22034579982.4],
+    [1441051980000, 24783871443.2],
+    [1441052010000, 26907368572.800003]
+  ]
 };
 
 const sumPart1 = {
-    name: "part1",
-    columns: ["time", "in", "out"],
-    points: [
+  name: "part1",
+  columns: ["time", "in", "out"],
+  points: [
+    [1400425951000, 1, 6],
+    [1400425952000, 2, 7],
+    [1400425953000, 3, 8],
+    [1400425954000, 4, 9]
+  ]
+};
+const sumPart2 = {
+  name: "part2",
+  columns: ["time", "in", "out"],
+  points: [
+    [1400425951000, 9, 1],
+    [1400425952000, 7, 2],
+    [1400425953000, 5, 3],
+    [1400425954000, 3, 4]
+  ]
+};
+
+const sept2014Data = {
+  utc: false,
+  name: "traffic",
+  columns: ["time", "value"],
+  points: [
+    [1409529600000, 80],
+    [1409533200000, 88],
+    [1409536800000, 52],
+    [1409540400000, 80],
+    [1409544000000, 26],
+    [1409547600000, 37],
+    [1409551200000, 6],
+    [1409554800000, 32],
+    [1409558400000, 69],
+    [1409562000000, 21],
+    [1409565600000, 6],
+    [1409569200000, 54],
+    [1409572800000, 88],
+    [1409576400000, 41],
+    [1409580000000, 35],
+    [1409583600000, 43],
+    [1409587200000, 84],
+    [1409590800000, 32],
+    [1409594400000, 41],
+    [1409598000000, 57],
+    [1409601600000, 27],
+    [1409605200000, 50],
+    [1409608800000, 13],
+    [1409612400000, 63],
+    [1409616000000, 58],
+    [1409619600000, 80],
+    [1409623200000, 59],
+    [1409626800000, 96],
+    [1409630400000, 2],
+    [1409634000000, 20],
+    [1409637600000, 64],
+    [1409641200000, 7],
+    [1409644800000, 50],
+    [1409648400000, 88],
+    [1409652000000, 34],
+    [1409655600000, 31],
+    [1409659200000, 16],
+    [1409662800000, 38],
+    [1409666400000, 94],
+    [1409670000000, 78],
+    [1409673600000, 86],
+    [1409677200000, 13],
+    [1409680800000, 34],
+    [1409684400000, 29],
+    [1409688000000, 48],
+    [1409691600000, 80],
+    [1409695200000, 30],
+    [1409698800000, 15],
+    [1409702400000, 62],
+    [1409706000000, 66],
+    [1409709600000, 44],
+    [1409713200000, 94],
+    [1409716800000, 78],
+    [1409720400000, 29],
+    [1409724000000, 21],
+    [1409727600000, 4],
+    [1409731200000, 83],
+    [1409734800000, 15],
+    [1409738400000, 89],
+    [1409742000000, 53],
+    [1409745600000, 70],
+    [1409749200000, 41],
+    [1409752800000, 47],
+    [1409756400000, 30],
+    [1409760000000, 68],
+    [1409763600000, 89],
+    [1409767200000, 29],
+    [1409770800000, 17],
+    [1409774400000, 38],
+    [1409778000000, 67],
+    [1409781600000, 75],
+    [1409785200000, 89],
+    [1409788800000, 47],
+    [1409792400000, 82],
+    [1409796000000, 33],
+    [1409799600000, 67],
+    [1409803200000, 93],
+    [1409806800000, 86],
+    [1409810400000, 97],
+    [1409814000000, 19],
+    [1409817600000, 19],
+    [1409821200000, 31],
+    [1409824800000, 56],
+    [1409828400000, 19],
+    [1409832000000, 43],
+    [1409835600000, 29],
+    [1409839200000, 72],
+    [1409842800000, 27],
+    [1409846400000, 21],
+    [1409850000000, 88],
+    [1409853600000, 18],
+    [1409857200000, 30],
+    [1409860800000, 46],
+    [1409864400000, 34],
+    [1409868000000, 31],
+    [1409871600000, 20],
+    [1409875200000, 45],
+    [1409878800000, 17],
+    [1409882400000, 24],
+    [1409886000000, 84],
+    [1409889600000, 6],
+    [1409893200000, 91],
+    [1409896800000, 82],
+    [1409900400000, 71],
+    [1409904000000, 97],
+    [1409907600000, 43],
+    [1409911200000, 38],
+    [1409914800000, 1],
+    [1409918400000, 71],
+    [1409922000000, 50],
+    [1409925600000, 19],
+    [1409929200000, 19],
+    [1409932800000, 86],
+    [1409936400000, 65],
+    [1409940000000, 93],
+    [1409943600000, 35]
+  ]
+};
+
+const OUTAGE_EVENT_LIST = Immutable.List([
+  {
+    startTime: "2015-03-04T09:00:00Z",
+    endTime: "2015-03-04T14:00:00Z",
+    title: "ANL Scheduled Maintenance",
+    description: "ANL will be switching border routers...",
+    completed: true,
+    external_ticket: "",
+    esnet_ticket: "ESNET-20150302-002",
+    organization: "ANL",
+    type: "Planned"
+  },
+  {
+    startTime: "2015-04-22T03:30:00Z",
+    endTime: "2015-04-22T13:00:00Z",
+    description: "At 13:33 pacific circuit 06519 went down.",
+    title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+    completed: true,
+    external_ticket: "",
+    esnet_ticket: "ESNET-20150421-013",
+    organization: "Internet2 / Level 3",
+    type: "Unplanned"
+  },
+  {
+    startTime: "2015-04-22T03:35:00Z",
+    endTime: "2015-04-22T16:50:00Z",
+    title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+    description: "The listed circuit was unavailable due to bent pins.",
+    completed: true,
+    external_ticket: "3576:144",
+    esnet_ticket: "ESNET-20150421-013",
+    organization: "Internet2 / Level 3",
+    type: "Unplanned"
+  }
+]);
+
+const TIMERANGE_EVENT_LIST = OUTAGE_EVENT_LIST.map(evt => {
+  const { startTime, endTime, ...other } = evt;
+  const b = new Date(startTime);
+  const e = new Date(endTime);
+  return timeRangeEvent(timerange(b, e), Immutable.Map(other as {}));
+});
+
+const weather = Immutable.List([
+  {
+    date: "2014-7-1",
+    actual_mean_temp: 81,
+    actual_min_temp: 72,
+    actual_max_temp: 89,
+    average_min_temp: 68,
+    average_max_temp: 83,
+    record_min_temp: 52,
+    record_max_temp: 100,
+    record_min_temp_year: 1943,
+    record_max_temp_year: 1901,
+    actual_precipitation: 0,
+    average_precipitation: 0.12,
+    record_precipitation: 2.17
+  },
+  {
+    date: "2014-7-2",
+    actual_mean_temp: 82,
+    actual_min_temp: 72,
+    actual_max_temp: 91,
+    average_min_temp: 68,
+    average_max_temp: 83,
+    record_min_temp: 56,
+    record_max_temp: 100,
+    record_min_temp_year: 2001,
+    record_max_temp_year: 1966,
+    actual_precipitation: 0.96,
+    average_precipitation: 0.13,
+    record_precipitation: 1.79
+  },
+  {
+    date: "2014-7-3",
+    actual_mean_temp: 78,
+    actual_min_temp: 69,
+    actual_max_temp: 87,
+    average_min_temp: 68,
+    average_max_temp: 83,
+    record_min_temp: 54,
+    record_max_temp: 103,
+    record_min_temp_year: 1933,
+    record_max_temp_year: 1966,
+    actual_precipitation: 1.78,
+    average_precipitation: 0.12,
+    record_precipitation: 2.8
+  }
+]);
+
+describe("Creation", () => {
+  it("can create a series with a list of events", () => {
+    const series = new TimeSeries(EVENT_DATA);
+    expect(series).toBeDefined();
+  });
+
+  it("can create a series with a collection", () => {
+    const series = new TimeSeries(COLLECTION_DATA);
+    expect(series).toBeDefined();
+  });
+
+  it("can create a timeseries with our wire format", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    expect(series).toBeDefined();
+  });
+
+  it("can create an indexed series with our wire format", () => {
+    const series = indexedSeries(AVAILABILITY_DATA);
+    expect(series).toBeDefined();
+  });
+
+  it("can create an series with a list of Events", () => {
+    const events = [];
+    events.push(
+      timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 }))
+    );
+    events.push(
+      timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 }))
+    );
+    const series = new TimeSeries({
+      name: "events",
+      events: Immutable.List(events)
+    });
+    expect(series.size()).toBe(2);
+  });
+
+  it("can create an series with a list of Indexed Events", () => {
+    const events = weather.map(item => {
+      const {
+        date,
+        actual_min_temp,
+        actual_max_temp,
+        record_min_temp,
+        record_max_temp
+      } = item;
+      return indexedEvent(
+        index(date),
+        Immutable.Map({
+          temp: [
+            +record_min_temp, // tslint-disable-line
+            +actual_min_temp, // tslint-disable-line
+            +actual_max_temp, // tslint-disable-line
+            +record_max_temp // tslint-disable-line
+          ]
+        })
+      );
+    });
+
+    const c = new Collection(events);
+    const series = new TimeSeries({ name, collection: c });
+    expect(series.size()).toBe(3);
+  });
+
+  it("can create an series with no events", () => {
+    const events = [];
+    const series = new TimeSeries({
+      name: "events",
+      events: Immutable.List(events)
+    });
+    expect(series.size()).toBe(0);
+  });
+
+  it("can create a timerange series with the right timerange", () => {
+    const series = new TimeSeries({
+      name: "outages",
+      events: TIMERANGE_EVENT_LIST
+    });
+    expect(series.range().toString()).toBe(
+      '{"timerange":[1425459600000,1429721400000]}'
+    );
+  });
+});
+
+describe("Basic Query API", () => {
+  // tslint:disable:max-line-length
+  it("can return the size of the series", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    expect(series.size()).toBe(4);
+  });
+
+  it("can return an item in the series as an event", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const e = series.at(1);
+    expect(e.keyType()).toBe("time");
+  });
+
+  it("can return an item in the series with the correct data", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const e = series.at(1);
+    expect(JSON.stringify(e.getData())).toBe(`{"value":18,"status":"ok"}`);
+    expect(e.timestamp().getTime()).toBe(1400425948000);
+  });
+
+  it("can serialize to a string", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const expectedString = `{"name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+    expect(series.toString()).toBe(expectedString);
+  });
+
+  it("can return the time range of the series", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const expectedString =
+      "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
+    expect(series.timerange().toUTCString()).toBe(expectedString);
+  });
+});
+
+describe("Meta Data", () => {
+  it("can create a series with meta data and get that data back", () => {
+    const series = timeSeries(INTERFACE_TEST_DATA);
+    const expected = `{"site_interface":"et-1/0/0","tz":"Etc/UTC","site":"anl","name":"star-cr5:to_anl_ip-a_v4","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]]}`;
+    expect(series.toString()).toBe(expected);
+    expect(series.meta("interface")).toBe("to_anl_ip-a_v4");
+  });
+
+  it("can create a series and set a new name", () => {
+    const series = timeSeries(INTERFACE_TEST_DATA);
+    expect(series.name()).toBe("star-cr5:to_anl_ip-a_v4");
+    const newSeries = series.setName("bob");
+    expect(newSeries.name()).toBe("bob");
+  });
+
+  it("can create a series with meta data and get that data back", () => {
+    const series = timeSeries(INTERFACE_TEST_DATA);
+    expect(series.meta("site_interface")).toBe("et-1/0/0");
+    const newSeries = series.setMeta("site_interface", "bob");
+    expect(newSeries.meta("site_interface")).toBe("bob");
+    expect(newSeries.at(0).get("in")).toBe(52);
+    expect(newSeries.meta("site")).toBe("anl");
+  });
+});
+
+describe("Deep Event Data", () => {
+  it("can create a series with a nested object", () => {
+    const series = timeSeries({
+      name: "Map Traffic",
+      columns: ["time", "NASA_north", "NASA_south"],
+      points: [
+        [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
+        [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
+        [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
+        [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175 }]
+      ]
+    });
+    expect(
+      series
+        .at(0)
+        .get("NASA_north")
+        .get("in")
+    ).toBe(100);
+    expect(
+      series
+        .at(0)
+        .get("NASA_north")
+        .get("out")
+    ).toBe(200);
+
+    expect(series.at(0).get("NASA_north.in")).toBe(100);
+    expect(series.at(0).get(["NASA_north", "in"])).toBe(100);
+  });
+
+  it("can create a series with nested events", () => {
+    const events = [];
+    events.push(
+      timeEvent(
+        time(new Date(2015, 6, 1)),
+        Immutable.Map({
+          NASA_north: { in: 100, out: 200 },
+          NASA_south: { in: 145, out: 135 }
+        })
+      )
+    );
+    events.push(
+      timeEvent(
+        time(new Date(2015, 7, 1)),
+        Immutable.Map({
+          NASA_north: { in: 200, out: 400 },
+          NASA_south: { in: 146, out: 142 }
+        })
+      )
+    );
+    events.push(
+      timeEvent(
+        time(new Date(2015, 8, 1)),
+        Immutable.Map({
+          NASA_north: { in: 300, out: 600 },
+          NASA_south: { in: 147, out: 158 }
+        })
+      )
+    );
+    events.push(
+      timeEvent(
+        time(new Date(2015, 9, 1)),
+        Immutable.Map({
+          NASA_north: { in: 400, out: 800 },
+          NASA_south: { in: 155, out: 175 }
+        })
+      )
+    );
+    const series = new TimeSeries({
+      name: "Map traffic",
+      events: Immutable.List(events)
+    });
+    expect(series.at(0).get("NASA_north").in).toBe(100);
+    expect(series.at(3).get("NASA_south").out).toBe(175);
+    expect(series.size()).toBe(4);
+  });
+});
+
+describe("Comparing TimeSeries", () => {
+  it("can compare a series and a reference to a series as being equal", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const refSeries = series;
+    expect(series).toBe(refSeries);
+  });
+
+  it("can use the equals() comparator to compare a series and a copy of the series as true", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const copyOfSeries = new TimeSeries(series);
+    expect(TimeSeries.equal(series, copyOfSeries)).toBeTruthy();
+  });
+
+  it("can use the equals() comparator to compare a series and a value equivalent series as false", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
+    expect(TimeSeries.equal(series, otherSeries)).toBeFalsy();
+  });
+
+  it("can use the is() comparator to compare a series and a value equivalent series as true", () => {
+    const series = timeSeries(TIMESERIES_TEST_DATA);
+    const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
+    expect(TimeSeries.is(series, otherSeries)).toBeTruthy();
+  });
+
+  it("can use the is() comparator to compare a series and a value different series as false", () => {
+    const series = timeSeries(sumPart1);
+    const otherSeries = timeSeries(sumPart2);
+    expect(TimeSeries.is(series, otherSeries)).toBeFalsy();
+  });
+});
+
+describe("Bisect", () => {
+  it("can find the bisect starting from 0", () => {
+    const series = timeSeries(BISECT_TEST_DATA);
+    expect(series.bisect(moment("2012-01-11 00:30", fmt).toDate())).toBe(0);
+    expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate())).toBe(2);
+    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate())).toBe(2);
+    expect(series.bisect(moment("2012-01-11 08:00", fmt).toDate())).toBe(6);
+  });
+
+  it("can find the bisect starting from an begin index", () => {
+    const series = timeSeries(BISECT_TEST_DATA);
+    expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate(), 2)).toBe(2);
+    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 3)).toBe(2);
+    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 4)).toBe(3);
+
+    const first = series.bisect(moment("2012-01-11 03:30", fmt).toDate());
+    const second = series.bisect(
+      moment("2012-01-11 04:30", fmt).toDate(),
+      first
+    );
+    expect(series.at(first).get()).toBe(44);
+    expect(series.at(second).get()).toBe(55);
+  });
+});
+
+describe("Time Range Events", () => {
+  it("can make a timeseries with the right timerange", () => {
+    const series = new TimeSeries({
+      name: "outages",
+      events: TIMERANGE_EVENT_LIST
+    });
+    expect(series.range().toString()).toBe(
+      '{"timerange":[1425459600000,1429721400000]}'
+    );
+  });
+
+  it("can make a timeseries that can be serialized to a string", () => {
+    const series = new TimeSeries({
+      name: "outages",
+      events: TIMERANGE_EVENT_LIST
+    });
+    const expected = `{"name":"outages","tz":"Etc/UTC","columns":["timerange","title","description","completed","external_ticket","esnet_ticket","organization","type"],"points":[[[1425459600000,1425477600000],"ANL Scheduled Maintenance","ANL will be switching border routers...",true,"","ESNET-20150302-002","ANL","Planned"],[[1429673400000,1429707600000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","At 13:33 pacific circuit 06519 went down.",true,"","ESNET-20150421-013","Internet2 / Level 3","Unplanned"],[[1429673700000,1429721400000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","The listed circuit was unavailable due to bent pins.",true,"3576:144","ESNET-20150421-013","Internet2 / Level 3","Unplanned"]]}`;
+    expect(series.toString()).toBe(expected);
+  });
+
+  it("can make a timeseries that can be serialized to JSON and then used to construct a TimeSeries again", () => {
+    const series = new TimeSeries({
+      name: "outages",
+      events: TIMERANGE_EVENT_LIST
+    });
+    const newSeries = timeRangeSeries(series.toJSON() as TimeSeriesWireFormat);
+    expect(series.toString()).toBe(newSeries.toString());
+  });
+});
+
+describe("Indexed Events", () => {
+  it("can serialize to a string", () => {
+    const series = timeSeries(INDEXED_DATA);
+    const expectedString = `{"index":"1d-625","name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+    expect(series.toString()).toBe(expectedString);
+  });
+
+  it("can return the time range of the series", () => {
+    const series = timeSeries(INDEXED_DATA);
+    const expectedString =
+      "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
+    expect(series.indexAsRange().toUTCString()).toBe(expectedString);
+  });
+
+  it("can create an series with indexed data (in UTC time)", () => {
+    const series = indexedSeries(AVAILABILITY_DATA);
+    const e = series.at(2);
+    expect(e.timerangeAsUTCString()).toBe(
+      "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]"
+    );
+    expect(
+      series
+        .range()
+        .begin()
+        .getTime()
+    ).toBe(1404172800000);
+    expect(
+      series
+        .range()
+        .end()
+        .getTime()
+    ).toBe(1435708799999);
+  });
+});
+
+describe("Slicing a timeseries", () => {
+  it("can create a slice of a series", () => {
+    const series = indexedSeries(AVAILABILITY_DATA);
+    const expectedLastTwo = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2015-05","92%"],["2015-06","100%"]]}`;
+    const lastTwo = series.slice(-2);
+    expect(lastTwo.toString()).toBe(expectedLastTwo);
+    const expectedFirstThree = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"]]}`;
+    const firstThree = series.slice(0, 3);
+    expect(firstThree.toString()).toBe(expectedFirstThree);
+    const expectedAll = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"],["2014-10","99%"],["2014-11","91%"],["2014-12","99%"],["2015-01","100%"],["2015-02","92%"],["2015-03","99%"],["2015-04","87%"],["2015-05","92%"],["2015-06","100%"]]}`;
+    const sliceAll = series.slice();
+    expect(sliceAll.toString()).toBe(expectedAll);
+  });
+});
+
+describe("Cropping a timeseries", () => {
+  it("can create crop a series", () => {
+    const series = timeSeries({
+      name: "exact timestamps",
+      columns: ["time", "value"],
+      points: [
+        [1504014065240, 1],
+        [1504014065243, 2],
+        [1504014065244, 3],
+        [1504014065245, 4],
+        [1504014065249, 5]
+      ]
+    });
+    const ts1 = series.crop(timerange(1504014065243, 1504014065245));
+    expect(ts1.size()).toBe(3);
+    const ts2 = series.crop(timerange(1504014065242, 1504014065245));
+    expect(ts2.size()).toBe(3);
+    const ts3 = series.crop(timerange(1504014065243, 1504014065247));
+    expect(ts3.size()).toBe(3);
+    const ts4 = series.crop(timerange(1504014065242, 1504014065247));
+    expect(ts4.size()).toBe(3);
+  });
+});
+
+describe("Merging two timeseries together", () => {
+  it("can merge two timeseries columns together using merge", () => {
+    const inTraffic = timeSeries(TRAFFIC_DATA_IN);
+    const outTraffic = timeSeries(TRAFFIC_DATA_OUT);
+    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+      name: "traffic",
+      seriesList: [inTraffic, outTraffic],
+      fieldSpec: ["in", "out"]
+    });
+
+    expect(trafficSeries.at(2).get("in")).toBe(26);
+    expect(trafficSeries.at(2).get("out")).toBe(67);
+  });
+
+  it("can append two timeseries together using merge", () => {
+    const tile1 = timeSeries(PARTIAL_TRAFFIC_PART_A);
+    const tile2 = timeSeries(PARTIAL_TRAFFIC_PART_B);
+    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+      name: "traffic",
+      source: "router",
+      seriesList: [tile1, tile2],
+      fieldSpec: "value"
+    });
+    expect(trafficSeries.size()).toBe(8);
+    expect(trafficSeries.at(0).get()).toBe(34);
+    expect(trafficSeries.at(1).get()).toBe(13);
+    expect(trafficSeries.at(2).get()).toBe(67);
+    expect(trafficSeries.at(3).get()).toBe(91);
+    expect(trafficSeries.at(4).get()).toBe(65);
+    expect(trafficSeries.at(5).get()).toBe(86);
+    expect(trafficSeries.at(6).get()).toBe(27);
+    expect(trafficSeries.at(7).get()).toBe(72);
+    expect(trafficSeries.name()).toBe("traffic");
+    expect(trafficSeries.meta("source")).toBe("router");
+  });
+
+  it("can merge two series and preserve the correct time format", () => {
+    const inTraffic = timeSeries(TRAFFIC_BNL_TO_NEWY);
+    const outTraffic = timeSeries(TRAFFIC_NEWY_TO_BNL);
+    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+      name: "traffic",
+      seriesList: [inTraffic, outTraffic]
+    });
+    expect(trafficSeries.at(0).timestampAsUTCString()).toBe(
+      "Mon, 31 Aug 2015 20:12:30 GMT"
+    );
+    expect(trafficSeries.at(1).timestampAsUTCString()).toBe(
+      "Mon, 31 Aug 2015 20:13:00 GMT"
+    );
+    expect(trafficSeries.at(2).timestampAsUTCString()).toBe(
+      "Mon, 31 Aug 2015 20:13:30 GMT"
+    );
+  });
+
+  it("can merge two irregular time series together", () => {
+    const A = {
+      name: "a",
+      columns: ["time", "valueA"],
+      points: [
+        [1400425947000, 34],
+        [1400425948000, 13],
+        [1400425949000, 67],
+        [1400425950000, 91]
+      ]
+    };
+
+    const B = {
+      name: "b",
+      columns: ["time", "valueB"],
+      points: [
+        [1400425951000, 65],
+        [1400425952000, 86],
+        [1400425953000, 27],
+        [1400425954000, 72]
+      ]
+    };
+
+    const tile1 = timeSeries(A);
+    const tile2 = timeSeries(B);
+
+    const series = TimeSeries.timeSeriesListMerge({
+      name: "traffic",
+      seriesList: [tile1, tile2]
+    });
+    // console.log("series is ", series);
+    const expected = `{"name":"traffic","tz":"Etc/UTC","columns":["time","valueA","valueB"],"points":[[1400425947000,34,null],[1400425948000,13,null],[1400425949000,67,null],[1400425950000,91,null],[1400425951000,null,65],[1400425952000,null,86],[1400425953000,null,27],[1400425954000,null,72]]}`;
+    expect(series.toString()).toBe(expected);
+  });
+});
+
+describe("Summing two timeseries together", () => {
+  it("can merge two timeseries into a new timeseries that is the sum", () => {
+    const part1 = timeSeries(sumPart1);
+    const part2 = timeSeries(sumPart2);
+
+    const result = TimeSeries.timeSeriesListReduce({
+      name: "sum",
+      seriesList: [part1, part2],
+      reducer: sum(),
+      fieldSpec: ["in", "out"]
+    });
+
+    // 10, 9, 8, 7
+    expect(result.at(0).get("in")).toBe(10);
+    expect(result.at(1).get("in")).toBe(9);
+    expect(result.at(2).get("in")).toBe(8);
+    expect(result.at(3).get("in")).toBe(7);
+
+    // 7, 9, 11, 13
+    expect(result.at(0).get("out")).toBe(7);
+    expect(result.at(1).get("out")).toBe(9);
+    expect(result.at(2).get("out")).toBe(11);
+    expect(result.at(3).get("out")).toBe(13);
+  });
+});
+
+describe("Averaging two timeseries together", () => {
+  it("can merge two timeseries into a new timeseries that is the sum", () => {
+    const part1 = timeSeries({
+      name: "part1",
+      columns: ["time", "in", "out"],
+      points: [
         [1400425951000, 1, 6],
         [1400425952000, 2, 7],
         [1400425953000, 3, 8],
         [1400425954000, 4, 9]
-    ]
-};
-const sumPart2 = {
-    name: "part2",
-    columns: ["time", "in", "out"],
-    points: [
+      ]
+    });
+    const part2 = timeSeries({
+      name: "part2",
+      columns: ["time", "in", "out"],
+      points: [
         [1400425951000, 9, 1],
         [1400425952000, 7, 2],
         [1400425953000, 5, 3],
         [1400425954000, 3, 4]
-    ]
-};
-
-const sept2014Data = {
-    utc: false,
-    name: "traffic",
-    columns: ["time", "value"],
-    points: [
-        [1409529600000, 80],
-        [1409533200000, 88],
-        [1409536800000, 52],
-        [1409540400000, 80],
-        [1409544000000, 26],
-        [1409547600000, 37],
-        [1409551200000, 6],
-        [1409554800000, 32],
-        [1409558400000, 69],
-        [1409562000000, 21],
-        [1409565600000, 6],
-        [1409569200000, 54],
-        [1409572800000, 88],
-        [1409576400000, 41],
-        [1409580000000, 35],
-        [1409583600000, 43],
-        [1409587200000, 84],
-        [1409590800000, 32],
-        [1409594400000, 41],
-        [1409598000000, 57],
-        [1409601600000, 27],
-        [1409605200000, 50],
-        [1409608800000, 13],
-        [1409612400000, 63],
-        [1409616000000, 58],
-        [1409619600000, 80],
-        [1409623200000, 59],
-        [1409626800000, 96],
-        [1409630400000, 2],
-        [1409634000000, 20],
-        [1409637600000, 64],
-        [1409641200000, 7],
-        [1409644800000, 50],
-        [1409648400000, 88],
-        [1409652000000, 34],
-        [1409655600000, 31],
-        [1409659200000, 16],
-        [1409662800000, 38],
-        [1409666400000, 94],
-        [1409670000000, 78],
-        [1409673600000, 86],
-        [1409677200000, 13],
-        [1409680800000, 34],
-        [1409684400000, 29],
-        [1409688000000, 48],
-        [1409691600000, 80],
-        [1409695200000, 30],
-        [1409698800000, 15],
-        [1409702400000, 62],
-        [1409706000000, 66],
-        [1409709600000, 44],
-        [1409713200000, 94],
-        [1409716800000, 78],
-        [1409720400000, 29],
-        [1409724000000, 21],
-        [1409727600000, 4],
-        [1409731200000, 83],
-        [1409734800000, 15],
-        [1409738400000, 89],
-        [1409742000000, 53],
-        [1409745600000, 70],
-        [1409749200000, 41],
-        [1409752800000, 47],
-        [1409756400000, 30],
-        [1409760000000, 68],
-        [1409763600000, 89],
-        [1409767200000, 29],
-        [1409770800000, 17],
-        [1409774400000, 38],
-        [1409778000000, 67],
-        [1409781600000, 75],
-        [1409785200000, 89],
-        [1409788800000, 47],
-        [1409792400000, 82],
-        [1409796000000, 33],
-        [1409799600000, 67],
-        [1409803200000, 93],
-        [1409806800000, 86],
-        [1409810400000, 97],
-        [1409814000000, 19],
-        [1409817600000, 19],
-        [1409821200000, 31],
-        [1409824800000, 56],
-        [1409828400000, 19],
-        [1409832000000, 43],
-        [1409835600000, 29],
-        [1409839200000, 72],
-        [1409842800000, 27],
-        [1409846400000, 21],
-        [1409850000000, 88],
-        [1409853600000, 18],
-        [1409857200000, 30],
-        [1409860800000, 46],
-        [1409864400000, 34],
-        [1409868000000, 31],
-        [1409871600000, 20],
-        [1409875200000, 45],
-        [1409878800000, 17],
-        [1409882400000, 24],
-        [1409886000000, 84],
-        [1409889600000, 6],
-        [1409893200000, 91],
-        [1409896800000, 82],
-        [1409900400000, 71],
-        [1409904000000, 97],
-        [1409907600000, 43],
-        [1409911200000, 38],
-        [1409914800000, 1],
-        [1409918400000, 71],
-        [1409922000000, 50],
-        [1409925600000, 19],
-        [1409929200000, 19],
-        [1409932800000, 86],
-        [1409936400000, 65],
-        [1409940000000, 93],
-        [1409943600000, 35]
-    ]
-};
-
-const OUTAGE_EVENT_LIST = Immutable.List([
-    {
-        startTime: "2015-03-04T09:00:00Z",
-        endTime: "2015-03-04T14:00:00Z",
-        title: "ANL Scheduled Maintenance",
-        description: "ANL will be switching border routers...",
-        completed: true,
-        external_ticket: "",
-        esnet_ticket: "ESNET-20150302-002",
-        organization: "ANL",
-        type: "Planned"
-    },
-    {
-        startTime: "2015-04-22T03:30:00Z",
-        endTime: "2015-04-22T13:00:00Z",
-        description: "At 13:33 pacific circuit 06519 went down.",
-        title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-        completed: true,
-        external_ticket: "",
-        esnet_ticket: "ESNET-20150421-013",
-        organization: "Internet2 / Level 3",
-        type: "Unplanned"
-    },
-    {
-        startTime: "2015-04-22T03:35:00Z",
-        endTime: "2015-04-22T16:50:00Z",
-        title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-        description: "The listed circuit was unavailable due to bent pins.",
-        completed: true,
-        external_ticket: "3576:144",
-        esnet_ticket: "ESNET-20150421-013",
-        organization: "Internet2 / Level 3",
-        type: "Unplanned"
-    }
-]);
-
-const TIMERANGE_EVENT_LIST = OUTAGE_EVENT_LIST.map(evt => {
-    const { startTime, endTime, ...other } = evt;
-    const b = new Date(startTime);
-    const e = new Date(endTime);
-    return timeRangeEvent(timerange(b, e), Immutable.Map(other as {}));
-});
-
-const weather = Immutable.List([
-    {
-        date: "2014-7-1",
-        actual_mean_temp: 81,
-        actual_min_temp: 72,
-        actual_max_temp: 89,
-        average_min_temp: 68,
-        average_max_temp: 83,
-        record_min_temp: 52,
-        record_max_temp: 100,
-        record_min_temp_year: 1943,
-        record_max_temp_year: 1901,
-        actual_precipitation: 0,
-        average_precipitation: 0.12,
-        record_precipitation: 2.17
-    },
-    {
-        date: "2014-7-2",
-        actual_mean_temp: 82,
-        actual_min_temp: 72,
-        actual_max_temp: 91,
-        average_min_temp: 68,
-        average_max_temp: 83,
-        record_min_temp: 56,
-        record_max_temp: 100,
-        record_min_temp_year: 2001,
-        record_max_temp_year: 1966,
-        actual_precipitation: 0.96,
-        average_precipitation: 0.13,
-        record_precipitation: 1.79
-    },
-    {
-        date: "2014-7-3",
-        actual_mean_temp: 78,
-        actual_min_temp: 69,
-        actual_max_temp: 87,
-        average_min_temp: 68,
-        average_max_temp: 83,
-        record_min_temp: 54,
-        record_max_temp: 103,
-        record_min_temp_year: 1933,
-        record_max_temp_year: 1966,
-        actual_precipitation: 1.78,
-        average_precipitation: 0.12,
-        record_precipitation: 2.8
-    }
-]);
-
-describe("Creation", () => {
-    it("can create a series with a list of events", () => {
-        const series = new TimeSeries(EVENT_DATA);
-        expect(series).toBeDefined();
+      ]
     });
 
-    it("can create a series with a collection", () => {
-        const series = new TimeSeries(COLLECTION_DATA);
-        expect(series).toBeDefined();
+    const avgSeries = TimeSeries.timeSeriesListReduce({
+      name: "avg",
+      seriesList: [part1, part2],
+      fieldSpec: ["in", "out"],
+      reducer: avg()
     });
 
-    it("can create a timeseries with our wire format", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        expect(series).toBeDefined();
+    expect(avgSeries.at(0).get("in")).toBe(5);
+    expect(avgSeries.at(1).get("in")).toBe(4.5);
+    expect(avgSeries.at(2).get("in")).toBe(4);
+    expect(avgSeries.at(3).get("in")).toBe(3.5);
+
+    expect(avgSeries.at(0).get("out")).toBe(3.5);
+    expect(avgSeries.at(1).get("out")).toBe(4.5);
+    expect(avgSeries.at(2).get("out")).toBe(5.5);
+    expect(avgSeries.at(3).get("out")).toBe(6.5);
+
+    const avgSeries2 = TimeSeries.timeSeriesListReduce({
+      name: "avg",
+      seriesList: [part1, part2],
+      reducer: avg(),
+      fieldSpec: ["in", "out"]
     });
 
-    it("can create an indexed series with our wire format", () => {
-        const series = indexedSeries(AVAILABILITY_DATA);
-        expect(series).toBeDefined();
-    });
-
-    it("can create an series with a list of Events", () => {
-        const events = [];
-        events.push(timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 })));
-        events.push(timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 })));
-        const series = new TimeSeries({ name: "events", events: Immutable.List(events) });
-        expect(series.size()).toBe(2);
-    });
-
-    it("can create an series with a list of Indexed Events", () => {
-        const events = weather.map(item => {
-            const {
-                date,
-                actual_min_temp,
-                actual_max_temp,
-                record_min_temp,
-                record_max_temp
-            } = item;
-            return indexedEvent(
-                index(date),
-                Immutable.Map({
-                    temp: [
-                        +record_min_temp, // tslint-disable-line
-                        +actual_min_temp, // tslint-disable-line
-                        +actual_max_temp, // tslint-disable-line
-                        +record_max_temp // tslint-disable-line
-                    ]
-                })
-            );
-        });
-
-        const c = new Collection(events);
-        const series = new TimeSeries({ name, collection: c });
-        expect(series.size()).toBe(3);
-    });
-
-    it("can create an series with no events", () => {
-        const events = [];
-        const series = new TimeSeries({ name: "events", events: Immutable.List(events) });
-        expect(series.size()).toBe(0);
-    });
-
-    it("can create a timerange series with the right timerange", () => {
-        const series = new TimeSeries({
-            name: "outages",
-            events: TIMERANGE_EVENT_LIST
-        });
-        expect(series.range().toString()).toBe('{"timerange":[1425459600000,1429721400000]}');
-    });
-});
-
-describe("Basic Query API", () => {
-    // tslint:disable:max-line-length
-    it("can return the size of the series", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        expect(series.size()).toBe(4);
-    });
-
-    it("can return an item in the series as an event", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const e = series.at(1);
-        expect(e.keyType()).toBe("time");
-    });
-
-    it("can return an item in the series with the correct data", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const e = series.at(1);
-        expect(JSON.stringify(e.getData())).toBe(`{"value":18,"status":"ok"}`);
-        expect(e.timestamp().getTime()).toBe(1400425948000);
-    });
-
-    it("can serialize to a string", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const expectedString = `{"name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
-        expect(series.toString()).toBe(expectedString);
-    });
-
-    it("can return the time range of the series", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const expectedString = "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
-        expect(series.timerange().toUTCString()).toBe(expectedString);
-    });
-});
-
-describe("Meta Data", () => {
-    it("can create a series with meta data and get that data back", () => {
-        const series = timeSeries(INTERFACE_TEST_DATA);
-        const expected = `{"site_interface":"et-1/0/0","tz":"Etc/UTC","site":"anl","name":"star-cr5:to_anl_ip-a_v4","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]]}`;
-        expect(series.toString()).toBe(expected);
-        expect(series.meta("interface")).toBe("to_anl_ip-a_v4");
-    });
-
-    it("can create a series and set a new name", () => {
-        const series = timeSeries(INTERFACE_TEST_DATA);
-        expect(series.name()).toBe("star-cr5:to_anl_ip-a_v4");
-        const newSeries = series.setName("bob");
-        expect(newSeries.name()).toBe("bob");
-    });
-
-    it("can create a series with meta data and get that data back", () => {
-        const series = timeSeries(INTERFACE_TEST_DATA);
-        expect(series.meta("site_interface")).toBe("et-1/0/0");
-        const newSeries = series.setMeta("site_interface", "bob");
-        expect(newSeries.meta("site_interface")).toBe("bob");
-        expect(newSeries.at(0).get("in")).toBe(52);
-        expect(newSeries.meta("site")).toBe("anl");
-    });
-});
-
-describe("Deep Event Data", () => {
-    it("can create a series with a nested object", () => {
-        const series = timeSeries({
-            name: "Map Traffic",
-            columns: ["time", "NASA_north", "NASA_south"],
-            points: [
-                [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
-                [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
-                [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
-                [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175 }]
-            ]
-        });
-        expect(
-            series
-                .at(0)
-                .get("NASA_north")
-                .get("in")
-        ).toBe(100);
-        expect(
-            series
-                .at(0)
-                .get("NASA_north")
-                .get("out")
-        ).toBe(200);
-
-        expect(series.at(0).get("NASA_north.in")).toBe(100);
-        expect(series.at(0).get(["NASA_north", "in"])).toBe(100);
-    });
-
-    it("can create a series with nested events", () => {
-        const events = [];
-        events.push(
-            timeEvent(
-                time(new Date(2015, 6, 1)),
-                Immutable.Map({
-                    NASA_north: { in: 100, out: 200 },
-                    NASA_south: { in: 145, out: 135 }
-                })
-            )
-        );
-        events.push(
-            timeEvent(
-                time(new Date(2015, 7, 1)),
-                Immutable.Map({
-                    NASA_north: { in: 200, out: 400 },
-                    NASA_south: { in: 146, out: 142 }
-                })
-            )
-        );
-        events.push(
-            timeEvent(
-                time(new Date(2015, 8, 1)),
-                Immutable.Map({
-                    NASA_north: { in: 300, out: 600 },
-                    NASA_south: { in: 147, out: 158 }
-                })
-            )
-        );
-        events.push(
-            timeEvent(
-                time(new Date(2015, 9, 1)),
-                Immutable.Map({
-                    NASA_north: { in: 400, out: 800 },
-                    NASA_south: { in: 155, out: 175 }
-                })
-            )
-        );
-        const series = new TimeSeries({ name: "Map traffic", events: Immutable.List(events) });
-        expect(series.at(0).get("NASA_north").in).toBe(100);
-        expect(series.at(3).get("NASA_south").out).toBe(175);
-        expect(series.size()).toBe(4);
-    });
-});
-
-describe("Comparing TimeSeries", () => {
-    it("can compare a series and a reference to a series as being equal", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const refSeries = series;
-        expect(series).toBe(refSeries);
-    });
-
-    it("can use the equals() comparator to compare a series and a copy of the series as true", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const copyOfSeries = new TimeSeries(series);
-        expect(TimeSeries.equal(series, copyOfSeries)).toBeTruthy();
-    });
-
-    it("can use the equals() comparator to compare a series and a value equivalent series as false", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
-        expect(TimeSeries.equal(series, otherSeries)).toBeFalsy();
-    });
-
-    it("can use the is() comparator to compare a series and a value equivalent series as true", () => {
-        const series = timeSeries(TIMESERIES_TEST_DATA);
-        const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
-        expect(TimeSeries.is(series, otherSeries)).toBeTruthy();
-    });
-
-    it("can use the is() comparator to compare a series and a value different series as false", () => {
-        const series = timeSeries(sumPart1);
-        const otherSeries = timeSeries(sumPart2);
-        expect(TimeSeries.is(series, otherSeries)).toBeFalsy();
-    });
-});
-
-describe("Bisect", () => {
-    it("can find the bisect starting from 0", () => {
-        const series = timeSeries(BISECT_TEST_DATA);
-        expect(series.bisect(moment("2012-01-11 00:30", fmt).toDate())).toBe(0);
-        expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate())).toBe(2);
-        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate())).toBe(2);
-        expect(series.bisect(moment("2012-01-11 08:00", fmt).toDate())).toBe(6);
-    });
-
-    it("can find the bisect starting from an begin index", () => {
-        const series = timeSeries(BISECT_TEST_DATA);
-        expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate(), 2)).toBe(2);
-        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 3)).toBe(2);
-        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 4)).toBe(3);
-
-        const first = series.bisect(moment("2012-01-11 03:30", fmt).toDate());
-        const second = series.bisect(moment("2012-01-11 04:30", fmt).toDate(), first);
-        expect(series.at(first).get()).toBe(44);
-        expect(series.at(second).get()).toBe(55);
-    });
-});
-
-describe("Time Range Events", () => {
-    it("can make a timeseries with the right timerange", () => {
-        const series = new TimeSeries({
-            name: "outages",
-            events: TIMERANGE_EVENT_LIST
-        });
-        expect(series.range().toString()).toBe('{"timerange":[1425459600000,1429721400000]}');
-    });
-
-    it("can make a timeseries that can be serialized to a string", () => {
-        const series = new TimeSeries({
-            name: "outages",
-            events: TIMERANGE_EVENT_LIST
-        });
-        const expected = `{"name":"outages","tz":"Etc/UTC","columns":["timerange","title","description","completed","external_ticket","esnet_ticket","organization","type"],"points":[[[1425459600000,1425477600000],"ANL Scheduled Maintenance","ANL will be switching border routers...",true,"","ESNET-20150302-002","ANL","Planned"],[[1429673400000,1429707600000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","At 13:33 pacific circuit 06519 went down.",true,"","ESNET-20150421-013","Internet2 / Level 3","Unplanned"],[[1429673700000,1429721400000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","The listed circuit was unavailable due to bent pins.",true,"3576:144","ESNET-20150421-013","Internet2 / Level 3","Unplanned"]]}`;
-        expect(series.toString()).toBe(expected);
-    });
-
-    it("can make a timeseries that can be serialized to JSON and then used to construct a TimeSeries again", () => {
-        const series = new TimeSeries({
-            name: "outages",
-            events: TIMERANGE_EVENT_LIST
-        });
-        const newSeries = timeRangeSeries(series.toJSON() as TimeSeriesWireFormat);
-        expect(series.toString()).toBe(newSeries.toString());
-    });
-});
-
-describe("Indexed Events", () => {
-    it("can serialize to a string", () => {
-        const series = timeSeries(INDEXED_DATA);
-        const expectedString = `{"index":"1d-625","name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
-        expect(series.toString()).toBe(expectedString);
-    });
-
-    it("can return the time range of the series", () => {
-        const series = timeSeries(INDEXED_DATA);
-        const expectedString = "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
-        expect(series.indexAsRange().toUTCString()).toBe(expectedString);
-    });
-
-    it("can create an series with indexed data (in UTC time)", () => {
-        const series = indexedSeries(AVAILABILITY_DATA);
-        const e = series.at(2);
-        expect(e.timerangeAsUTCString()).toBe(
-            "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]"
-        );
-        expect(
-            series
-                .range()
-                .begin()
-                .getTime()
-        ).toBe(1404172800000);
-        expect(
-            series
-                .range()
-                .end()
-                .getTime()
-        ).toBe(1435708799999);
-    });
-});
-
-describe("Slicing a timeseries", () => {
-    it("can create a slice of a series", () => {
-        const series = indexedSeries(AVAILABILITY_DATA);
-        const expectedLastTwo = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2015-05","92%"],["2015-06","100%"]]}`;
-        const lastTwo = series.slice(-2);
-        expect(lastTwo.toString()).toBe(expectedLastTwo);
-        const expectedFirstThree = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"]]}`;
-        const firstThree = series.slice(0, 3);
-        expect(firstThree.toString()).toBe(expectedFirstThree);
-        const expectedAll = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"],["2014-10","99%"],["2014-11","91%"],["2014-12","99%"],["2015-01","100%"],["2015-02","92%"],["2015-03","99%"],["2015-04","87%"],["2015-05","92%"],["2015-06","100%"]]}`;
-        const sliceAll = series.slice();
-        expect(sliceAll.toString()).toBe(expectedAll);
-    });
-});
-
-describe("Cropping a timeseries", () => {
-    it("can create crop a series", () => {
-        const series = timeSeries({
-            name: "exact timestamps",
-            columns: ["time", "value"],
-            points: [
-                [1504014065240, 1],
-                [1504014065243, 2],
-                [1504014065244, 3],
-                [1504014065245, 4],
-                [1504014065249, 5]
-            ]
-        });
-        const ts1 = series.crop(timerange(1504014065243, 1504014065245));
-        expect(ts1.size()).toBe(3);
-        const ts2 = series.crop(timerange(1504014065242, 1504014065245));
-        expect(ts2.size()).toBe(3);
-        const ts3 = series.crop(timerange(1504014065243, 1504014065247));
-        expect(ts3.size()).toBe(3);
-        const ts4 = series.crop(timerange(1504014065242, 1504014065247));
-        expect(ts4.size()).toBe(3);
-    });
-});
-
-describe("Merging two timeseries together", () => {
-    it("can merge two timeseries columns together using merge", () => {
-        const inTraffic = timeSeries(TRAFFIC_DATA_IN);
-        const outTraffic = timeSeries(TRAFFIC_DATA_OUT);
-        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-            name: "traffic",
-            seriesList: [inTraffic, outTraffic],
-            fieldSpec: ["in", "out"]
-        });
-
-        expect(trafficSeries.at(2).get("in")).toBe(26);
-        expect(trafficSeries.at(2).get("out")).toBe(67);
-    });
-
-    it("can append two timeseries together using merge", () => {
-        const tile1 = timeSeries(PARTIAL_TRAFFIC_PART_A);
-        const tile2 = timeSeries(PARTIAL_TRAFFIC_PART_B);
-        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-            name: "traffic",
-            source: "router",
-            seriesList: [tile1, tile2],
-            fieldSpec: "value"
-        });
-        expect(trafficSeries.size()).toBe(8);
-        expect(trafficSeries.at(0).get()).toBe(34);
-        expect(trafficSeries.at(1).get()).toBe(13);
-        expect(trafficSeries.at(2).get()).toBe(67);
-        expect(trafficSeries.at(3).get()).toBe(91);
-        expect(trafficSeries.at(4).get()).toBe(65);
-        expect(trafficSeries.at(5).get()).toBe(86);
-        expect(trafficSeries.at(6).get()).toBe(27);
-        expect(trafficSeries.at(7).get()).toBe(72);
-        expect(trafficSeries.name()).toBe("traffic");
-        expect(trafficSeries.meta("source")).toBe("router");
-    });
-
-    it("can merge two series and preserve the correct time format", () => {
-        const inTraffic = timeSeries(TRAFFIC_BNL_TO_NEWY);
-        const outTraffic = timeSeries(TRAFFIC_NEWY_TO_BNL);
-        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-            name: "traffic",
-            seriesList: [inTraffic, outTraffic]
-        });
-        expect(trafficSeries.at(0).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:12:30 GMT");
-        expect(trafficSeries.at(1).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:13:00 GMT");
-        expect(trafficSeries.at(2).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:13:30 GMT");
-    });
-
-    it("can merge two irregular time series together", () => {
-        const A = {
-            name: "a",
-            columns: ["time", "valueA"],
-            points: [
-                [1400425947000, 34],
-                [1400425948000, 13],
-                [1400425949000, 67],
-                [1400425950000, 91]
-            ]
-        };
-
-        const B = {
-            name: "b",
-            columns: ["time", "valueB"],
-            points: [
-                [1400425951000, 65],
-                [1400425952000, 86],
-                [1400425953000, 27],
-                [1400425954000, 72]
-            ]
-        };
-
-        const tile1 = timeSeries(A);
-        const tile2 = timeSeries(B);
-
-        const series = TimeSeries.timeSeriesListMerge({
-            name: "traffic",
-            seriesList: [tile1, tile2]
-        });
-        // console.log("series is ", series);
-        const expected = `{"name":"traffic","tz":"Etc/UTC","columns":["time","valueA","valueB"],"points":[[1400425947000,34,null],[1400425948000,13,null],[1400425949000,67,null],[1400425950000,91,null],[1400425951000,null,65],[1400425952000,null,86],[1400425953000,null,27],[1400425954000,null,72]]}`;
-        expect(series.toString()).toBe(expected);
-    });
-});
-
-describe("Summing two timeseries together", () => {
-    it("can merge two timeseries into a new timeseries that is the sum", () => {
-        const part1 = timeSeries(sumPart1);
-        const part2 = timeSeries(sumPart2);
-
-        const result = TimeSeries.timeSeriesListReduce({
-            name: "sum",
-            seriesList: [part1, part2],
-            reducer: sum(),
-            fieldSpec: ["in", "out"]
-        });
-
-        // 10, 9, 8, 7
-        expect(result.at(0).get("in")).toBe(10);
-        expect(result.at(1).get("in")).toBe(9);
-        expect(result.at(2).get("in")).toBe(8);
-        expect(result.at(3).get("in")).toBe(7);
-
-        // 7, 9, 11, 13
-        expect(result.at(0).get("out")).toBe(7);
-        expect(result.at(1).get("out")).toBe(9);
-        expect(result.at(2).get("out")).toBe(11);
-        expect(result.at(3).get("out")).toBe(13);
-    });
-});
-
-describe("Averaging two timeseries together", () => {
-    it("can merge two timeseries into a new timeseries that is the sum", () => {
-        const part1 = timeSeries({
-            name: "part1",
-            columns: ["time", "in", "out"],
-            points: [
-                [1400425951000, 1, 6],
-                [1400425952000, 2, 7],
-                [1400425953000, 3, 8],
-                [1400425954000, 4, 9]
-            ]
-        });
-        const part2 = timeSeries({
-            name: "part2",
-            columns: ["time", "in", "out"],
-            points: [
-                [1400425951000, 9, 1],
-                [1400425952000, 7, 2],
-                [1400425953000, 5, 3],
-                [1400425954000, 3, 4]
-            ]
-        });
-
-        const avgSeries = TimeSeries.timeSeriesListReduce({
-            name: "avg",
-            seriesList: [part1, part2],
-            fieldSpec: ["in", "out"],
-            reducer: avg()
-        });
-
-        expect(avgSeries.at(0).get("in")).toBe(5);
-        expect(avgSeries.at(1).get("in")).toBe(4.5);
-        expect(avgSeries.at(2).get("in")).toBe(4);
-        expect(avgSeries.at(3).get("in")).toBe(3.5);
-
-        expect(avgSeries.at(0).get("out")).toBe(3.5);
-        expect(avgSeries.at(1).get("out")).toBe(4.5);
-        expect(avgSeries.at(2).get("out")).toBe(5.5);
-        expect(avgSeries.at(3).get("out")).toBe(6.5);
-
-        const avgSeries2 = TimeSeries.timeSeriesListReduce({
-            name: "avg",
-            seriesList: [part1, part2],
-            reducer: avg(),
-            fieldSpec: ["in", "out"]
-        });
-
-        expect(avgSeries2.at(0).get("in")).toBe(5);
-        expect(avgSeries2.at(1).get("in")).toBe(4.5);
-        expect(avgSeries2.at(2).get("in")).toBe(4);
-        expect(avgSeries2.at(3).get("in")).toBe(3.5);
-    });
+    expect(avgSeries2.at(0).get("in")).toBe(5);
+    expect(avgSeries2.at(1).get("in")).toBe(4.5);
+    expect(avgSeries2.at(2).get("in")).toBe(4);
+    expect(avgSeries2.at(3).get("in")).toBe(3.5);
+  });
 });
 
 describe("Collapsing down columns in a timeseries", () => {
-    it("can collapse a timeseries into a new timeseries that is the sum of two columns", () => {
-        const ts = timeSeries(sumPart1);
-        const sums = ts.collapse({
-            fieldName: "sum",
-            fieldSpecList: ["in", "out"],
-            reducer: sum(),
-            append: false
-        });
-
-        expect(sums.at(0).get("sum")).toBe(7);
-        expect(sums.at(1).get("sum")).toBe(9);
-        expect(sums.at(2).get("sum")).toBe(11);
-        expect(sums.at(3).get("sum")).toBe(13);
+  it("can collapse a timeseries into a new timeseries that is the sum of two columns", () => {
+    const ts = timeSeries(sumPart1);
+    const sums = ts.collapse({
+      fieldName: "sum",
+      fieldSpecList: ["in", "out"],
+      reducer: sum(),
+      append: false
     });
 
-    it("can collapse a timeseries into a new timeseries that is the max of two columns", () => {
-        const timeseries = timeSeries(sumPart2);
-        const c = timeseries.collapse({
-            fieldName: "max_in_out",
-            fieldSpecList: ["in", "out"],
-            reducer: max(),
-            append: true
-        });
+    expect(sums.at(0).get("sum")).toBe(7);
+    expect(sums.at(1).get("sum")).toBe(9);
+    expect(sums.at(2).get("sum")).toBe(11);
+    expect(sums.at(3).get("sum")).toBe(13);
+  });
 
-        expect(c.at(0).get("max_in_out")).toBe(9);
-        expect(c.at(1).get("max_in_out")).toBe(7);
-        expect(c.at(2).get("max_in_out")).toBe(5);
-        expect(c.at(3).get("max_in_out")).toBe(4);
+  it("can collapse a timeseries into a new timeseries that is the max of two columns", () => {
+    const timeseries = timeSeries(sumPart2);
+    const c = timeseries.collapse({
+      fieldName: "max_in_out",
+      fieldSpecList: ["in", "out"],
+      reducer: max(),
+      append: true
     });
 
-    it("can collapse a timeseries into a new timeseries that is the sum of two columns, then find the max", () => {
-        const ts = timeSeries(sumPart1);
-        const sums = ts.collapse({
-            fieldName: "value",
-            fieldSpecList: ["in", "out"],
-            reducer: sum(),
-            append: false
-        });
-        expect(sums.max("value")).toBe(13);
+    expect(c.at(0).get("max_in_out")).toBe(9);
+    expect(c.at(1).get("max_in_out")).toBe(7);
+    expect(c.at(2).get("max_in_out")).toBe(5);
+    expect(c.at(3).get("max_in_out")).toBe(4);
+  });
+
+  it("can collapse a timeseries into a new timeseries that is the sum of two columns, then find the max", () => {
+    const ts = timeSeries(sumPart1);
+    const sums = ts.collapse({
+      fieldName: "value",
+      fieldSpecList: ["in", "out"],
+      reducer: sum(),
+      append: false
     });
+    expect(sums.max("value")).toBe(13);
+  });
 });
 
 describe("Select specific columns in a TimeSeries", () => {
-    it("can select a single column from a TimeSeries", () => {
-        const timeseries = timeSeries(INTERFACE_TEST_DATA);
-        expect(timeseries.columns()).toEqual(["in", "out"]);
+  it("can select a single column from a TimeSeries", () => {
+    const timeseries = timeSeries(INTERFACE_TEST_DATA);
+    expect(timeseries.columns()).toEqual(["in", "out"]);
 
-        const ts = timeseries.select({ fields: ["in"] });
-        expect(ts.columns()).toEqual(["in"]);
-        expect(ts.name()).toBe("star-cr5:to_anl_ip-a_v4");
+    const ts = timeseries.select({ fields: ["in"] });
+    expect(ts.columns()).toEqual(["in"]);
+    expect(ts.name()).toBe("star-cr5:to_anl_ip-a_v4");
+  });
+
+  it("can select multiple columns from a TimeSeries", () => {
+    const timeseries = indexedSeries(AVAILABILITY_DATA_2);
+    expect(timeseries.columns()).toEqual(["uptime", "notes", "outages"]);
+
+    const ts = timeseries.select({ fields: ["uptime", "notes"] });
+    expect(ts.columns()).toEqual(["uptime", "notes"]);
+    expect(ts.name()).toBe("availability");
+  });
+
+  it("can rename columns", () => {
+    const ts = timeSeries(sumPart1);
+    const newTs = ts.renameColumns({
+      renameMap: { in: "new_in", out: "new_out" }
     });
+    expect(newTs.columns()).toEqual(["new_in", "new_out"]);
 
-    it("can select multiple columns from a TimeSeries", () => {
-        const timeseries = indexedSeries(AVAILABILITY_DATA_2);
-        expect(timeseries.columns()).toEqual(["uptime", "notes", "outages"]);
-
-        const ts = timeseries.select({ fields: ["uptime", "notes"] });
-        expect(ts.columns()).toEqual(["uptime", "notes"]);
-        expect(ts.name()).toBe("availability");
+    const series = indexedSeries(AVAILABILITY_DATA);
+    const newSeries = series.renameColumns({
+      renameMap: { uptime: "new_uptime" }
     });
-
-    it("can rename columns", () => {
-        const ts = timeSeries(sumPart1);
-        const newTs = ts.renameColumns({
-            renameMap: { in: "new_in", out: "new_out" }
-        });
-        expect(newTs.columns()).toEqual(["new_in", "new_out"]);
-
-        const series = indexedSeries(AVAILABILITY_DATA);
-        const newSeries = series.renameColumns({
-            renameMap: { uptime: "new_uptime" }
-        });
-        expect(newSeries.columns()).toEqual(["new_uptime"]);
-    });
+    expect(newSeries.columns()).toEqual(["new_uptime"]);
+  });
 });
 
 describe("Remapping Events in a TimeSeries", () => {
-    it("can use re-mapping to reverse the values in a TimeSeries", () => {
-        const timeseries = timeSeries(INTERFACE_TEST_DATA);
+  it("can use re-mapping to reverse the values in a TimeSeries", () => {
+    const timeseries = timeSeries(INTERFACE_TEST_DATA);
 
-        expect(timeseries.columns()).toEqual(["in", "out"]);
+    expect(timeseries.columns()).toEqual(["in", "out"]);
 
-        const ts = timeseries.map(e =>
-            e.setData(Immutable.Map({ in: e.get("out"), out: e.get("in") }))
-        );
+    const ts = timeseries.map(e =>
+      e.setData(Immutable.Map({ in: e.get("out"), out: e.get("in") }))
+    );
 
-        expect(ts.at(0).get("in")).toBe(34);
-        expect(ts.at(0).get("out")).toBe(52);
-        expect(ts.size()).toBe(timeseries.size());
+    expect(ts.at(0).get("in")).toBe(34);
+    expect(ts.at(0).get("out")).toBe(52);
+    expect(ts.size()).toBe(timeseries.size());
+  });
+
+  it("can run a flat map over the TimeSeries", () => {
+    const series = timeSeries({
+      name: "Map Traffic",
+      columns: ["time", "NASA_north", "NASA_south"],
+      points: [
+        [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
+        [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
+        [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
+        [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 1 }]
+      ]
+    });
+    const split = series.flatMap(e =>
+      Immutable.List([
+        e.setData(e.get("NASA_north")),
+        e.setData(e.get("NASA_south"))
+      ])
+    );
+
+    expect(split.size()).toBe(8);
+    expect(split.at(0).get("in")).toBe(100);
+    expect(split.at(0).get("out")).toBe(200);
+    expect(split.at(0).get("other")).toBeUndefined();
+    expect(split.at(1).get("in")).toBe(145);
+    expect(split.at(1).get("out")).toBe(135);
+    expect(split.at(1).get("other")).toBeUndefined();
+    expect(split.at(7).get("in")).toBe(155);
+    expect(split.at(7).get("out")).toBe(175);
+    expect(split.at(7).get("other")).toBe(1);
+  });
+
+  it("can remap keys of a TimeSeries using mapKeys() from times to timeranges", () => {
+    const series = timeSeries({
+      name: "series",
+      columns: ["time", "a", "b"],
+      points: [
+        [1400425951000, 100, 200],
+        [1400425952000, 300, 400],
+        [1400425953000, 800, 900]
+      ]
+    });
+    const remapped = series.mapKeys(t =>
+      t.toTimeRange(duration("5m"), TimeAlignment.Middle)
+    );
+
+    expect(remapped.size()).toBe(3);
+    expect(
+      remapped
+        .at(0)
+        .getKey()
+        .duration()
+    ).toBe(1000 * 60 * 5);
+    expect(
+      remapped
+        .at(0)
+        .getKey()
+        .mid()
+        .getTime()
+    ).toBe(1400425951000);
+    expect(remapped.at(0).get("a")).toBe(100);
+    expect(remapped.at(0).get("b")).toBe(200);
+  });
+
+  it("can remap keys of a TimeSeries using mapKeys() from indexes to times", () => {
+    const series = indexedSeries({
+      name: "series",
+      columns: ["index", "c", "d"],
+      points: [
+        ["1d-1234", 100, 200],
+        ["1d-1235", 300, 400],
+        ["1d-1236", 800, 900]
+      ]
     });
 
-    it("can run a flat map over the TimeSeries", () => {
-        const series = timeSeries({
-            name: "Map Traffic",
-            columns: ["time", "NASA_north", "NASA_south"],
-            points: [
-                [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
-                [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
-                [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
-                [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 1 }]
-            ]
-        });
-        const split = series.flatMap(e =>
-            Immutable.List([e.setData(e.get("NASA_north")), e.setData(e.get("NASA_south"))])
-        );
+    const remapped = series.mapKeys<Time>((idx: Index) =>
+      idx.toTime(TimeAlignment.End)
+    );
 
-        expect(split.size()).toBe(8);
-        expect(split.at(0).get("in")).toBe(100);
-        expect(split.at(0).get("out")).toBe(200);
-        expect(split.at(0).get("other")).toBeUndefined();
-        expect(split.at(1).get("in")).toBe(145);
-        expect(split.at(1).get("out")).toBe(135);
-        expect(split.at(1).get("other")).toBeUndefined();
-        expect(split.at(7).get("in")).toBe(155);
-        expect(split.at(7).get("out")).toBe(175);
-        expect(split.at(7).get("other")).toBe(1);
-    });
-
-    it("can remap keys of a TimeSeries using mapKeys() from times to timeranges", () => {
-        const series = timeSeries({
-            name: "series",
-            columns: ["time", "a", "b"],
-            points: [
-                [1400425951000, 100, 200],
-                [1400425952000, 300, 400],
-                [1400425953000, 800, 900]
-            ]
-        });
-        const remapped = series.mapKeys(t => t.toTimeRange(duration("5m"), TimeAlignment.Middle));
-
-        expect(remapped.size()).toBe(3);
-        expect(
-            remapped
-                .at(0)
-                .getKey()
-                .duration()
-        ).toBe(1000 * 60 * 5);
-        expect(
-            remapped
-                .at(0)
-                .getKey()
-                .mid()
-                .getTime()
-        ).toBe(1400425951000);
-        expect(remapped.at(0).get("a")).toBe(100);
-        expect(remapped.at(0).get("b")).toBe(200);
-    });
-
-    it("can remap keys of a TimeSeries using mapKeys() from indexes to times", () => {
-        const series = indexedSeries({
-            name: "series",
-            columns: ["index", "c", "d"],
-            points: [["1d-1234", 100, 200], ["1d-1235", 300, 400], ["1d-1236", 800, 900]]
-        });
-
-        const remapped = series.mapKeys<Time>((idx: Index) => idx.toTime(TimeAlignment.End));
-
-        expect(
-            remapped
-                .at(0)
-                .getKey()
-                .timestamp()
-                .getTime()
-        ).toBe(106704000000);
-        expect(remapped.at(0).get("c")).toBe(100);
-        expect(remapped.at(0).get("d")).toBe(200);
-    });
+    expect(
+      remapped
+        .at(0)
+        .getKey()
+        .timestamp()
+        .getTime()
+    ).toBe(106704000000);
+    expect(remapped.at(0).get("c")).toBe(100);
+    expect(remapped.at(0).get("d")).toBe(200);
+  });
 });
 
 describe("Rollups", () => {
-    it("can generate 1 day fixed window averages over a TimeSeries", () => {
-        const timeseries = timeSeries(sept2014Data);
-        const everyDay = window(duration("1d"));
-        const dailyAvg = timeseries.fixedWindowRollup({
-            window: everyDay,
-            aggregation: { value: ["value", avg()] }
-        });
-
-        expect(dailyAvg.size()).toBe(5);
-        expect(dailyAvg.at(0).get()).toBe(46.875);
-        expect(dailyAvg.at(2).get()).toBe(54.083333333333336);
-        expect(dailyAvg.at(4).get()).toBe(51.85);
+  it("can generate 1 day fixed window averages over a TimeSeries", () => {
+    const timeseries = timeSeries(sept2014Data);
+    const everyDay = window(duration("1d"));
+    const dailyAvg = timeseries.fixedWindowRollup({
+      window: everyDay,
+      aggregation: { value: ["value", avg()] }
     });
 
-    it("can make Collections for each day in the TimeSeries", () => {
-        const timeseries = timeSeries(sept2014Data);
-        const eachDay = window(duration("1d"));
-        const collections = timeseries.collectByWindow({ window: eachDay });
+    expect(dailyAvg.size()).toBe(5);
+    expect(dailyAvg.at(0).get()).toBe(46.875);
+    expect(dailyAvg.at(2).get()).toBe(54.083333333333336);
+    expect(dailyAvg.at(4).get()).toBe(51.85);
+  });
 
-        expect(collections["1d-16314"].size()).toBe(24);
-        expect(collections["1d-16318"].size()).toBe(20);
-    });
+  it("can make Collections for each day in the TimeSeries", () => {
+    const timeseries = timeSeries(sept2014Data);
+    const eachDay = window(duration("1d"));
+    const collections = timeseries.collectByWindow({ window: eachDay });
 
-    it("can correctly use atTime()", () => {
-        const t = new Date(1476803711641);
+    expect(collections["1d-16314"].size()).toBe(24);
+    expect(collections["1d-16318"].size()).toBe(20);
+  });
 
-        let c = new Collection();
-        c = c.addEvent(event(time(t), Immutable.Map({ value: 2 })));
+  it("can correctly use atTime()", () => {
+    const t = new Date(1476803711641);
 
-        // Test bisect to get element 0
-        const ts = new TimeSeries({ name: "coll", collection: c });
-        const bisect = ts.bisect(t);
-        expect(bisect).toEqual(0);
-        expect(ts.at(bisect).get()).toEqual(2);
+    let c = new Collection();
+    c = c.addEvent(event(time(t), Immutable.Map({ value: 2 })));
 
-        // Test atTime to get element 0
-        expect(ts.atTime(t).get()).toEqual(2);
-    });
+    // Test bisect to get element 0
+    const ts = new TimeSeries({ name: "coll", collection: c });
+    const bisect = ts.bisect(t);
+    expect(bisect).toEqual(0);
+    expect(ts.at(bisect).get()).toEqual(2);
+
+    // Test atTime to get element 0
+    expect(ts.atTime(t).get()).toEqual(2);
+  });
 });

--- a/packages/pond/tests/timeseries.test.ts
+++ b/packages/pond/tests/timeseries.test.ts
@@ -24,1202 +24,1152 @@ import { index, Index } from "../src/index";
 import { time, Time } from "../src/time";
 import { timerange } from "../src/timerange";
 import {
-  indexedSeries,
-  timeRangeSeries,
-  TimeSeries,
-  timeSeries,
-  TimeSeriesWireFormat
+    indexedSeries,
+    timeRangeSeries,
+    TimeSeries,
+    timeSeries,
+    TimeSeriesWireFormat
 } from "../src/timeseries";
 import { TimeAlignment } from "../src/types";
 import { window } from "../src/window";
 
 const EVENT_DATA = {
-  name: "avg temps",
-  events: Immutable.List([
-    event(time("2015-04-22T03:30:00Z"), Immutable.Map({ in: 1, out: 2 })),
-    event(time("2015-04-22T03:31:00Z"), Immutable.Map({ in: 3, out: 4 }))
-  ])
+    name: "avg temps",
+    events: Immutable.List([
+        event(time("2015-04-22T03:30:00Z"), Immutable.Map({ in: 1, out: 2 })),
+        event(time("2015-04-22T03:31:00Z"), Immutable.Map({ in: 3, out: 4 }))
+    ])
 };
 
 const COLLECTION_DATA = {
-  name: "avg coll",
-  collection: collection(
-    Immutable.List([
-      event(time("2015-04-22T02:30:00Z"), Immutable.Map({ a: 5, b: 6 })),
-      event(time("2015-04-22T03:30:00Z"), Immutable.Map({ a: 4, b: 2 }))
-    ])
-  )
+    name: "avg coll",
+    collection: collection(
+        Immutable.List([
+            event(time("2015-04-22T02:30:00Z"), Immutable.Map({ a: 5, b: 6 })),
+            event(time("2015-04-22T03:30:00Z"), Immutable.Map({ a: 4, b: 2 }))
+        ])
+    )
 };
 
 const TIMESERIES_TEST_DATA = {
-  name: "traffic",
-  columns: ["time", "value", "status"],
-  points: [
-    [1400425947000, 52, "ok"],
-    [1400425948000, 18, "ok"],
-    [1400425949000, 26, "fail"],
-    [1400425950000, 93, "offline"]
-  ]
+    name: "traffic",
+    columns: ["time", "value", "status"],
+    points: [
+        [1400425947000, 52, "ok"],
+        [1400425948000, 18, "ok"],
+        [1400425949000, 26, "fail"],
+        [1400425950000, 93, "offline"]
+    ]
 };
 
 const AVAILABILITY_DATA = {
-  name: "availability",
-  columns: ["index", "uptime"],
-  points: [
-    ["2014-07", "100%"],
-    ["2014-08", "88%"],
-    ["2014-09", "95%"],
-    ["2014-10", "99%"],
-    ["2014-11", "91%"],
-    ["2014-12", "99%"],
-    ["2015-01", "100%"],
-    ["2015-02", "92%"],
-    ["2015-03", "99%"],
-    ["2015-04", "87%"],
-    ["2015-05", "92%"],
-    ["2015-06", "100%"]
-  ]
+    name: "availability",
+    columns: ["index", "uptime"],
+    points: [
+        ["2014-07", "100%"],
+        ["2014-08", "88%"],
+        ["2014-09", "95%"],
+        ["2014-10", "99%"],
+        ["2014-11", "91%"],
+        ["2014-12", "99%"],
+        ["2015-01", "100%"],
+        ["2015-02", "92%"],
+        ["2015-03", "99%"],
+        ["2015-04", "87%"],
+        ["2015-05", "92%"],
+        ["2015-06", "100%"]
+    ]
 };
 
 const AVAILABILITY_DATA_2 = {
-  name: "availability",
-  columns: ["index", "uptime", "notes", "outages"],
-  points: [
-    ["2014-07", 100, "", 2],
-    ["2014-08", 88, "", 17],
-    ["2014-09", 95, "", 6],
-    ["2014-10", 99, "", 3],
-    ["2014-11", 91, "", 14],
-    ["2014-12", 99, "", 3],
-    ["2015-01", 100, "", 0],
-    ["2015-02", 92, "", 12],
-    ["2015-03", 99, "Minor outage March 2", 4],
-    ["2015-04", 87, "Planned downtime in April", 82],
-    ["2015-05", 92, "Router failure June 12", 26],
-    ["2015-06", 100, "", 0]
-  ]
+    name: "availability",
+    columns: ["index", "uptime", "notes", "outages"],
+    points: [
+        ["2014-07", 100, "", 2],
+        ["2014-08", 88, "", 17],
+        ["2014-09", 95, "", 6],
+        ["2014-10", 99, "", 3],
+        ["2014-11", 91, "", 14],
+        ["2014-12", 99, "", 3],
+        ["2015-01", 100, "", 0],
+        ["2015-02", 92, "", 12],
+        ["2015-03", 99, "Minor outage March 2", 4],
+        ["2015-04", 87, "Planned downtime in April", 82],
+        ["2015-05", 92, "Router failure June 12", 26],
+        ["2015-06", 100, "", 0]
+    ]
 };
 
 const INDEXED_DATA = {
-  index: "1d-625",
-  name: "traffic",
-  columns: ["time", "value", "status"],
-  points: [
-    [1400425947000, 52, "ok"],
-    [1400425948000, 18, "ok"],
-    [1400425949000, 26, "fail"],
-    [1400425950000, 93, "offline"]
-  ]
+    index: "1d-625",
+    name: "traffic",
+    columns: ["time", "value", "status"],
+    points: [
+        [1400425947000, 52, "ok"],
+        [1400425948000, 18, "ok"],
+        [1400425949000, 26, "fail"],
+        [1400425950000, 93, "offline"]
+    ]
 };
 
 const INTERFACE_TEST_DATA = {
-  name: "star-cr5:to_anl_ip-a_v4",
-  description: "star-cr5->anl(as683):100ge:site-ex:show:intercloud",
-  device: "star-cr5",
-  id: 169,
-  interface: "to_anl_ip-a_v4",
-  is_ipv6: false,
-  is_oscars: false,
-  oscars_id: null,
-  resource_uri: "",
-  site: "anl",
-  site_device: "noni",
-  site_interface: "et-1/0/0",
-  stats_type: "Standard",
-  title: null,
-  columns: ["time", "in", "out"],
-  points: [
-    [1400425947000, 52, 34],
-    [1400425948000, 18, 13],
-    [1400425949000, 26, 67],
-    [1400425950000, 93, 91]
-  ]
+    name: "star-cr5:to_anl_ip-a_v4",
+    description: "star-cr5->anl(as683):100ge:site-ex:show:intercloud",
+    device: "star-cr5",
+    id: 169,
+    interface: "to_anl_ip-a_v4",
+    is_ipv6: false,
+    is_oscars: false,
+    oscars_id: null,
+    resource_uri: "",
+    site: "anl",
+    site_device: "noni",
+    site_interface: "et-1/0/0",
+    stats_type: "Standard",
+    title: null,
+    columns: ["time", "in", "out"],
+    points: [
+        [1400425947000, 52, 34],
+        [1400425948000, 18, 13],
+        [1400425949000, 26, 67],
+        [1400425950000, 93, 91]
+    ]
 };
 
 const fmt = "YYYY-MM-DD HH:mm";
 
 const BISECT_TEST_DATA = {
-  name: "test",
-  columns: ["time", "value"],
-  points: [
-    [moment("2012-01-11 01:00", fmt).valueOf(), 22],
-    [moment("2012-01-11 02:00", fmt).valueOf(), 33],
-    [moment("2012-01-11 03:00", fmt).valueOf(), 44],
-    [moment("2012-01-11 04:00", fmt).valueOf(), 55],
-    [moment("2012-01-11 05:00", fmt).valueOf(), 66],
-    [moment("2012-01-11 06:00", fmt).valueOf(), 77],
-    [moment("2012-01-11 07:00", fmt).valueOf(), 88]
-  ]
+    name: "test",
+    columns: ["time", "value"],
+    points: [
+        [moment("2012-01-11 01:00", fmt).valueOf(), 22],
+        [moment("2012-01-11 02:00", fmt).valueOf(), 33],
+        [moment("2012-01-11 03:00", fmt).valueOf(), 44],
+        [moment("2012-01-11 04:00", fmt).valueOf(), 55],
+        [moment("2012-01-11 05:00", fmt).valueOf(), 66],
+        [moment("2012-01-11 06:00", fmt).valueOf(), 77],
+        [moment("2012-01-11 07:00", fmt).valueOf(), 88]
+    ]
 };
 
 const TRAFFIC_DATA_IN = {
-  name: "star-cr5:to_anl_ip-a_v4",
-  columns: ["time", "in"],
-  points: [
-    [1400425947000, 52],
-    [1400425948000, 18],
-    [1400425949000, 26],
-    [1400425950000, 93]
-  ]
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "in"],
+    points: [[1400425947000, 52], [1400425948000, 18], [1400425949000, 26], [1400425950000, 93]]
 };
 
 const TRAFFIC_DATA_OUT = {
-  name: "star-cr5:to_anl_ip-a_v4",
-  columns: ["time", "out"],
-  points: [
-    [1400425947000, 34],
-    [1400425948000, 13],
-    [1400425949000, 67],
-    [1400425950000, 91]
-  ]
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "out"],
+    points: [[1400425947000, 34], [1400425948000, 13], [1400425949000, 67], [1400425950000, 91]]
 };
 
 const PARTIAL_TRAFFIC_PART_A = {
-  name: "star-cr5:to_anl_ip-a_v4",
-  columns: ["time", "value"],
-  points: [
-    [1400425947000, 34],
-    [1400425948000, 13],
-    [1400425949000, 67],
-    [1400425950000, 91]
-  ]
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "value"],
+    points: [[1400425947000, 34], [1400425948000, 13], [1400425949000, 67], [1400425950000, 91]]
 };
 
 const PARTIAL_TRAFFIC_PART_B = {
-  name: "star-cr5:to_anl_ip-a_v4",
-  columns: ["time", "value"],
-  points: [
-    [1400425951000, 65],
-    [1400425952000, 86],
-    [1400425953000, 27],
-    [1400425954000, 72]
-  ]
+    name: "star-cr5:to_anl_ip-a_v4",
+    columns: ["time", "value"],
+    points: [[1400425951000, 65], [1400425952000, 86], [1400425953000, 27], [1400425954000, 72]]
 };
 
 const TRAFFIC_BNL_TO_NEWY = {
-  name: "BNL to NEWY",
-  columns: ["time", "in"],
-  points: [
-    [1441051950000, 2998846524.2666664],
-    [1441051980000, 2682032885.3333335],
-    [1441052010000, 2753537586.9333334]
-  ]
+    name: "BNL to NEWY",
+    columns: ["time", "in"],
+    points: [
+        [1441051950000, 2998846524.2666664],
+        [1441051980000, 2682032885.3333335],
+        [1441052010000, 2753537586.9333334]
+    ]
 };
 
 const TRAFFIC_NEWY_TO_BNL = {
-  name: "NEWY to BNL",
-  columns: ["time", "out"],
-  points: [
-    [1441051950000, 22034579982.4],
-    [1441051980000, 24783871443.2],
-    [1441052010000, 26907368572.800003]
-  ]
+    name: "NEWY to BNL",
+    columns: ["time", "out"],
+    points: [
+        [1441051950000, 22034579982.4],
+        [1441051980000, 24783871443.2],
+        [1441052010000, 26907368572.800003]
+    ]
 };
 
 const sumPart1 = {
-  name: "part1",
-  columns: ["time", "in", "out"],
-  points: [
-    [1400425951000, 1, 6],
-    [1400425952000, 2, 7],
-    [1400425953000, 3, 8],
-    [1400425954000, 4, 9]
-  ]
-};
-const sumPart2 = {
-  name: "part2",
-  columns: ["time", "in", "out"],
-  points: [
-    [1400425951000, 9, 1],
-    [1400425952000, 7, 2],
-    [1400425953000, 5, 3],
-    [1400425954000, 3, 4]
-  ]
-};
-
-const sept2014Data = {
-  utc: false,
-  name: "traffic",
-  columns: ["time", "value"],
-  points: [
-    [1409529600000, 80],
-    [1409533200000, 88],
-    [1409536800000, 52],
-    [1409540400000, 80],
-    [1409544000000, 26],
-    [1409547600000, 37],
-    [1409551200000, 6],
-    [1409554800000, 32],
-    [1409558400000, 69],
-    [1409562000000, 21],
-    [1409565600000, 6],
-    [1409569200000, 54],
-    [1409572800000, 88],
-    [1409576400000, 41],
-    [1409580000000, 35],
-    [1409583600000, 43],
-    [1409587200000, 84],
-    [1409590800000, 32],
-    [1409594400000, 41],
-    [1409598000000, 57],
-    [1409601600000, 27],
-    [1409605200000, 50],
-    [1409608800000, 13],
-    [1409612400000, 63],
-    [1409616000000, 58],
-    [1409619600000, 80],
-    [1409623200000, 59],
-    [1409626800000, 96],
-    [1409630400000, 2],
-    [1409634000000, 20],
-    [1409637600000, 64],
-    [1409641200000, 7],
-    [1409644800000, 50],
-    [1409648400000, 88],
-    [1409652000000, 34],
-    [1409655600000, 31],
-    [1409659200000, 16],
-    [1409662800000, 38],
-    [1409666400000, 94],
-    [1409670000000, 78],
-    [1409673600000, 86],
-    [1409677200000, 13],
-    [1409680800000, 34],
-    [1409684400000, 29],
-    [1409688000000, 48],
-    [1409691600000, 80],
-    [1409695200000, 30],
-    [1409698800000, 15],
-    [1409702400000, 62],
-    [1409706000000, 66],
-    [1409709600000, 44],
-    [1409713200000, 94],
-    [1409716800000, 78],
-    [1409720400000, 29],
-    [1409724000000, 21],
-    [1409727600000, 4],
-    [1409731200000, 83],
-    [1409734800000, 15],
-    [1409738400000, 89],
-    [1409742000000, 53],
-    [1409745600000, 70],
-    [1409749200000, 41],
-    [1409752800000, 47],
-    [1409756400000, 30],
-    [1409760000000, 68],
-    [1409763600000, 89],
-    [1409767200000, 29],
-    [1409770800000, 17],
-    [1409774400000, 38],
-    [1409778000000, 67],
-    [1409781600000, 75],
-    [1409785200000, 89],
-    [1409788800000, 47],
-    [1409792400000, 82],
-    [1409796000000, 33],
-    [1409799600000, 67],
-    [1409803200000, 93],
-    [1409806800000, 86],
-    [1409810400000, 97],
-    [1409814000000, 19],
-    [1409817600000, 19],
-    [1409821200000, 31],
-    [1409824800000, 56],
-    [1409828400000, 19],
-    [1409832000000, 43],
-    [1409835600000, 29],
-    [1409839200000, 72],
-    [1409842800000, 27],
-    [1409846400000, 21],
-    [1409850000000, 88],
-    [1409853600000, 18],
-    [1409857200000, 30],
-    [1409860800000, 46],
-    [1409864400000, 34],
-    [1409868000000, 31],
-    [1409871600000, 20],
-    [1409875200000, 45],
-    [1409878800000, 17],
-    [1409882400000, 24],
-    [1409886000000, 84],
-    [1409889600000, 6],
-    [1409893200000, 91],
-    [1409896800000, 82],
-    [1409900400000, 71],
-    [1409904000000, 97],
-    [1409907600000, 43],
-    [1409911200000, 38],
-    [1409914800000, 1],
-    [1409918400000, 71],
-    [1409922000000, 50],
-    [1409925600000, 19],
-    [1409929200000, 19],
-    [1409932800000, 86],
-    [1409936400000, 65],
-    [1409940000000, 93],
-    [1409943600000, 35]
-  ]
-};
-
-const OUTAGE_EVENT_LIST = Immutable.List([
-  {
-    startTime: "2015-03-04T09:00:00Z",
-    endTime: "2015-03-04T14:00:00Z",
-    title: "ANL Scheduled Maintenance",
-    description: "ANL will be switching border routers...",
-    completed: true,
-    external_ticket: "",
-    esnet_ticket: "ESNET-20150302-002",
-    organization: "ANL",
-    type: "Planned"
-  },
-  {
-    startTime: "2015-04-22T03:30:00Z",
-    endTime: "2015-04-22T13:00:00Z",
-    description: "At 13:33 pacific circuit 06519 went down.",
-    title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-    completed: true,
-    external_ticket: "",
-    esnet_ticket: "ESNET-20150421-013",
-    organization: "Internet2 / Level 3",
-    type: "Unplanned"
-  },
-  {
-    startTime: "2015-04-22T03:35:00Z",
-    endTime: "2015-04-22T16:50:00Z",
-    title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
-    description: "The listed circuit was unavailable due to bent pins.",
-    completed: true,
-    external_ticket: "3576:144",
-    esnet_ticket: "ESNET-20150421-013",
-    organization: "Internet2 / Level 3",
-    type: "Unplanned"
-  }
-]);
-
-const TIMERANGE_EVENT_LIST = OUTAGE_EVENT_LIST.map(evt => {
-  const { startTime, endTime, ...other } = evt;
-  const b = new Date(startTime);
-  const e = new Date(endTime);
-  return timeRangeEvent(timerange(b, e), Immutable.Map(other as {}));
-});
-
-const weather = Immutable.List([
-  {
-    date: "2014-7-1",
-    actual_mean_temp: 81,
-    actual_min_temp: 72,
-    actual_max_temp: 89,
-    average_min_temp: 68,
-    average_max_temp: 83,
-    record_min_temp: 52,
-    record_max_temp: 100,
-    record_min_temp_year: 1943,
-    record_max_temp_year: 1901,
-    actual_precipitation: 0,
-    average_precipitation: 0.12,
-    record_precipitation: 2.17
-  },
-  {
-    date: "2014-7-2",
-    actual_mean_temp: 82,
-    actual_min_temp: 72,
-    actual_max_temp: 91,
-    average_min_temp: 68,
-    average_max_temp: 83,
-    record_min_temp: 56,
-    record_max_temp: 100,
-    record_min_temp_year: 2001,
-    record_max_temp_year: 1966,
-    actual_precipitation: 0.96,
-    average_precipitation: 0.13,
-    record_precipitation: 1.79
-  },
-  {
-    date: "2014-7-3",
-    actual_mean_temp: 78,
-    actual_min_temp: 69,
-    actual_max_temp: 87,
-    average_min_temp: 68,
-    average_max_temp: 83,
-    record_min_temp: 54,
-    record_max_temp: 103,
-    record_min_temp_year: 1933,
-    record_max_temp_year: 1966,
-    actual_precipitation: 1.78,
-    average_precipitation: 0.12,
-    record_precipitation: 2.8
-  }
-]);
-
-describe("Creation", () => {
-  it("can create a series with a list of events", () => {
-    const series = new TimeSeries(EVENT_DATA);
-    expect(series).toBeDefined();
-  });
-
-  it("can create a series with a collection", () => {
-    const series = new TimeSeries(COLLECTION_DATA);
-    expect(series).toBeDefined();
-  });
-
-  it("can create a timeseries with our wire format", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    expect(series).toBeDefined();
-  });
-
-  it("can create an indexed series with our wire format", () => {
-    const series = indexedSeries(AVAILABILITY_DATA);
-    expect(series).toBeDefined();
-  });
-
-  it("can create an series with a list of Events", () => {
-    const events = [];
-    events.push(
-      timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 }))
-    );
-    events.push(
-      timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 }))
-    );
-    const series = new TimeSeries({
-      name: "events",
-      events: Immutable.List(events)
-    });
-    expect(series.size()).toBe(2);
-  });
-
-  it("can create an series with a list of Indexed Events", () => {
-    const events = weather.map(item => {
-      const {
-        date,
-        actual_min_temp,
-        actual_max_temp,
-        record_min_temp,
-        record_max_temp
-      } = item;
-      return indexedEvent(
-        index(date),
-        Immutable.Map({
-          temp: [
-            +record_min_temp, // tslint-disable-line
-            +actual_min_temp, // tslint-disable-line
-            +actual_max_temp, // tslint-disable-line
-            +record_max_temp // tslint-disable-line
-          ]
-        })
-      );
-    });
-
-    const c = new Collection(events);
-    const series = new TimeSeries({ name, collection: c });
-    expect(series.size()).toBe(3);
-  });
-
-  it("can create an series with no events", () => {
-    const events = [];
-    const series = new TimeSeries({
-      name: "events",
-      events: Immutable.List(events)
-    });
-    expect(series.size()).toBe(0);
-  });
-
-  it("can create a timerange series with the right timerange", () => {
-    const series = new TimeSeries({
-      name: "outages",
-      events: TIMERANGE_EVENT_LIST
-    });
-    expect(series.range().toString()).toBe(
-      '{"timerange":[1425459600000,1429721400000]}'
-    );
-  });
-});
-
-describe("Basic Query API", () => {
-  // tslint:disable:max-line-length
-  it("can return the size of the series", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    expect(series.size()).toBe(4);
-  });
-
-  it("can return an item in the series as an event", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const e = series.at(1);
-    expect(e.keyType()).toBe("time");
-  });
-
-  it("can return an item in the series with the correct data", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const e = series.at(1);
-    expect(JSON.stringify(e.getData())).toBe(`{"value":18,"status":"ok"}`);
-    expect(e.timestamp().getTime()).toBe(1400425948000);
-  });
-
-  it("can serialize to a string", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const expectedString = `{"name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
-    expect(series.toString()).toBe(expectedString);
-  });
-
-  it("can return the time range of the series", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const expectedString =
-      "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
-    expect(series.timerange().toUTCString()).toBe(expectedString);
-  });
-});
-
-describe("Meta Data", () => {
-  it("can create a series with meta data and get that data back", () => {
-    const series = timeSeries(INTERFACE_TEST_DATA);
-    const expected = `{"site_interface":"et-1/0/0","tz":"Etc/UTC","site":"anl","name":"star-cr5:to_anl_ip-a_v4","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]]}`;
-    expect(series.toString()).toBe(expected);
-    expect(series.meta("interface")).toBe("to_anl_ip-a_v4");
-  });
-
-  it("can create a series and set a new name", () => {
-    const series = timeSeries(INTERFACE_TEST_DATA);
-    expect(series.name()).toBe("star-cr5:to_anl_ip-a_v4");
-    const newSeries = series.setName("bob");
-    expect(newSeries.name()).toBe("bob");
-  });
-
-  it("can create a series with meta data and get that data back", () => {
-    const series = timeSeries(INTERFACE_TEST_DATA);
-    expect(series.meta("site_interface")).toBe("et-1/0/0");
-    const newSeries = series.setMeta("site_interface", "bob");
-    expect(newSeries.meta("site_interface")).toBe("bob");
-    expect(newSeries.at(0).get("in")).toBe(52);
-    expect(newSeries.meta("site")).toBe("anl");
-  });
-});
-
-describe("Deep Event Data", () => {
-  it("can create a series with a nested object", () => {
-    const series = timeSeries({
-      name: "Map Traffic",
-      columns: ["time", "NASA_north", "NASA_south"],
-      points: [
-        [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
-        [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
-        [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
-        [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175 }]
-      ]
-    });
-    expect(
-      series
-        .at(0)
-        .get("NASA_north")
-        .get("in")
-    ).toBe(100);
-    expect(
-      series
-        .at(0)
-        .get("NASA_north")
-        .get("out")
-    ).toBe(200);
-
-    expect(series.at(0).get("NASA_north.in")).toBe(100);
-    expect(series.at(0).get(["NASA_north", "in"])).toBe(100);
-  });
-
-  it("can create a series with nested events", () => {
-    const events = [];
-    events.push(
-      timeEvent(
-        time(new Date(2015, 6, 1)),
-        Immutable.Map({
-          NASA_north: { in: 100, out: 200 },
-          NASA_south: { in: 145, out: 135 }
-        })
-      )
-    );
-    events.push(
-      timeEvent(
-        time(new Date(2015, 7, 1)),
-        Immutable.Map({
-          NASA_north: { in: 200, out: 400 },
-          NASA_south: { in: 146, out: 142 }
-        })
-      )
-    );
-    events.push(
-      timeEvent(
-        time(new Date(2015, 8, 1)),
-        Immutable.Map({
-          NASA_north: { in: 300, out: 600 },
-          NASA_south: { in: 147, out: 158 }
-        })
-      )
-    );
-    events.push(
-      timeEvent(
-        time(new Date(2015, 9, 1)),
-        Immutable.Map({
-          NASA_north: { in: 400, out: 800 },
-          NASA_south: { in: 155, out: 175 }
-        })
-      )
-    );
-    const series = new TimeSeries({
-      name: "Map traffic",
-      events: Immutable.List(events)
-    });
-    expect(series.at(0).get("NASA_north").in).toBe(100);
-    expect(series.at(3).get("NASA_south").out).toBe(175);
-    expect(series.size()).toBe(4);
-  });
-});
-
-describe("Comparing TimeSeries", () => {
-  it("can compare a series and a reference to a series as being equal", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const refSeries = series;
-    expect(series).toBe(refSeries);
-  });
-
-  it("can use the equals() comparator to compare a series and a copy of the series as true", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const copyOfSeries = new TimeSeries(series);
-    expect(TimeSeries.equal(series, copyOfSeries)).toBeTruthy();
-  });
-
-  it("can use the equals() comparator to compare a series and a value equivalent series as false", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
-    expect(TimeSeries.equal(series, otherSeries)).toBeFalsy();
-  });
-
-  it("can use the is() comparator to compare a series and a value equivalent series as true", () => {
-    const series = timeSeries(TIMESERIES_TEST_DATA);
-    const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
-    expect(TimeSeries.is(series, otherSeries)).toBeTruthy();
-  });
-
-  it("can use the is() comparator to compare a series and a value different series as false", () => {
-    const series = timeSeries(sumPart1);
-    const otherSeries = timeSeries(sumPart2);
-    expect(TimeSeries.is(series, otherSeries)).toBeFalsy();
-  });
-});
-
-describe("Bisect", () => {
-  it("can find the bisect starting from 0", () => {
-    const series = timeSeries(BISECT_TEST_DATA);
-    expect(series.bisect(moment("2012-01-11 00:30", fmt).toDate())).toBe(0);
-    expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate())).toBe(2);
-    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate())).toBe(2);
-    expect(series.bisect(moment("2012-01-11 08:00", fmt).toDate())).toBe(6);
-  });
-
-  it("can find the bisect starting from an begin index", () => {
-    const series = timeSeries(BISECT_TEST_DATA);
-    expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate(), 2)).toBe(2);
-    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 3)).toBe(2);
-    expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 4)).toBe(3);
-
-    const first = series.bisect(moment("2012-01-11 03:30", fmt).toDate());
-    const second = series.bisect(
-      moment("2012-01-11 04:30", fmt).toDate(),
-      first
-    );
-    expect(series.at(first).get()).toBe(44);
-    expect(series.at(second).get()).toBe(55);
-  });
-});
-
-describe("Time Range Events", () => {
-  it("can make a timeseries with the right timerange", () => {
-    const series = new TimeSeries({
-      name: "outages",
-      events: TIMERANGE_EVENT_LIST
-    });
-    expect(series.range().toString()).toBe(
-      '{"timerange":[1425459600000,1429721400000]}'
-    );
-  });
-
-  it("can make a timeseries that can be serialized to a string", () => {
-    const series = new TimeSeries({
-      name: "outages",
-      events: TIMERANGE_EVENT_LIST
-    });
-    const expected = `{"name":"outages","tz":"Etc/UTC","columns":["timerange","title","description","completed","external_ticket","esnet_ticket","organization","type"],"points":[[[1425459600000,1425477600000],"ANL Scheduled Maintenance","ANL will be switching border routers...",true,"","ESNET-20150302-002","ANL","Planned"],[[1429673400000,1429707600000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","At 13:33 pacific circuit 06519 went down.",true,"","ESNET-20150421-013","Internet2 / Level 3","Unplanned"],[[1429673700000,1429721400000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","The listed circuit was unavailable due to bent pins.",true,"3576:144","ESNET-20150421-013","Internet2 / Level 3","Unplanned"]]}`;
-    expect(series.toString()).toBe(expected);
-  });
-
-  it("can make a timeseries that can be serialized to JSON and then used to construct a TimeSeries again", () => {
-    const series = new TimeSeries({
-      name: "outages",
-      events: TIMERANGE_EVENT_LIST
-    });
-    const newSeries = timeRangeSeries(series.toJSON() as TimeSeriesWireFormat);
-    expect(series.toString()).toBe(newSeries.toString());
-  });
-});
-
-describe("Indexed Events", () => {
-  it("can serialize to a string", () => {
-    const series = timeSeries(INDEXED_DATA);
-    const expectedString = `{"index":"1d-625","name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
-    expect(series.toString()).toBe(expectedString);
-  });
-
-  it("can return the time range of the series", () => {
-    const series = timeSeries(INDEXED_DATA);
-    const expectedString =
-      "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
-    expect(series.indexAsRange().toUTCString()).toBe(expectedString);
-  });
-
-  it("can create an series with indexed data (in UTC time)", () => {
-    const series = indexedSeries(AVAILABILITY_DATA);
-    const e = series.at(2);
-    expect(e.timerangeAsUTCString()).toBe(
-      "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]"
-    );
-    expect(
-      series
-        .range()
-        .begin()
-        .getTime()
-    ).toBe(1404172800000);
-    expect(
-      series
-        .range()
-        .end()
-        .getTime()
-    ).toBe(1435708799999);
-  });
-});
-
-describe("Slicing a timeseries", () => {
-  it("can create a slice of a series", () => {
-    const series = indexedSeries(AVAILABILITY_DATA);
-    const expectedLastTwo = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2015-05","92%"],["2015-06","100%"]]}`;
-    const lastTwo = series.slice(-2);
-    expect(lastTwo.toString()).toBe(expectedLastTwo);
-    const expectedFirstThree = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"]]}`;
-    const firstThree = series.slice(0, 3);
-    expect(firstThree.toString()).toBe(expectedFirstThree);
-    const expectedAll = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"],["2014-10","99%"],["2014-11","91%"],["2014-12","99%"],["2015-01","100%"],["2015-02","92%"],["2015-03","99%"],["2015-04","87%"],["2015-05","92%"],["2015-06","100%"]]}`;
-    const sliceAll = series.slice();
-    expect(sliceAll.toString()).toBe(expectedAll);
-  });
-});
-
-describe("Cropping a timeseries", () => {
-  it("can create crop a series", () => {
-    const series = timeSeries({
-      name: "exact timestamps",
-      columns: ["time", "value"],
-      points: [
-        [1504014065240, 1],
-        [1504014065243, 2],
-        [1504014065244, 3],
-        [1504014065245, 4],
-        [1504014065249, 5]
-      ]
-    });
-    const ts1 = series.crop(timerange(1504014065243, 1504014065245));
-    expect(ts1.size()).toBe(3);
-    const ts2 = series.crop(timerange(1504014065242, 1504014065245));
-    expect(ts2.size()).toBe(3);
-    const ts3 = series.crop(timerange(1504014065243, 1504014065247));
-    expect(ts3.size()).toBe(3);
-    const ts4 = series.crop(timerange(1504014065242, 1504014065247));
-    expect(ts4.size()).toBe(3);
-  });
-});
-
-describe("Merging two timeseries together", () => {
-  it("can merge two timeseries columns together using merge", () => {
-    const inTraffic = timeSeries(TRAFFIC_DATA_IN);
-    const outTraffic = timeSeries(TRAFFIC_DATA_OUT);
-    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-      name: "traffic",
-      seriesList: [inTraffic, outTraffic],
-      fieldSpec: ["in", "out"]
-    });
-
-    expect(trafficSeries.at(2).get("in")).toBe(26);
-    expect(trafficSeries.at(2).get("out")).toBe(67);
-  });
-
-  it("can append two timeseries together using merge", () => {
-    const tile1 = timeSeries(PARTIAL_TRAFFIC_PART_A);
-    const tile2 = timeSeries(PARTIAL_TRAFFIC_PART_B);
-    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-      name: "traffic",
-      source: "router",
-      seriesList: [tile1, tile2],
-      fieldSpec: "value"
-    });
-    expect(trafficSeries.size()).toBe(8);
-    expect(trafficSeries.at(0).get()).toBe(34);
-    expect(trafficSeries.at(1).get()).toBe(13);
-    expect(trafficSeries.at(2).get()).toBe(67);
-    expect(trafficSeries.at(3).get()).toBe(91);
-    expect(trafficSeries.at(4).get()).toBe(65);
-    expect(trafficSeries.at(5).get()).toBe(86);
-    expect(trafficSeries.at(6).get()).toBe(27);
-    expect(trafficSeries.at(7).get()).toBe(72);
-    expect(trafficSeries.name()).toBe("traffic");
-    expect(trafficSeries.meta("source")).toBe("router");
-  });
-
-  it("can merge two series and preserve the correct time format", () => {
-    const inTraffic = timeSeries(TRAFFIC_BNL_TO_NEWY);
-    const outTraffic = timeSeries(TRAFFIC_NEWY_TO_BNL);
-    const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
-      name: "traffic",
-      seriesList: [inTraffic, outTraffic]
-    });
-    expect(trafficSeries.at(0).timestampAsUTCString()).toBe(
-      "Mon, 31 Aug 2015 20:12:30 GMT"
-    );
-    expect(trafficSeries.at(1).timestampAsUTCString()).toBe(
-      "Mon, 31 Aug 2015 20:13:00 GMT"
-    );
-    expect(trafficSeries.at(2).timestampAsUTCString()).toBe(
-      "Mon, 31 Aug 2015 20:13:30 GMT"
-    );
-  });
-
-  it("can merge two irregular time series together", () => {
-    const A = {
-      name: "a",
-      columns: ["time", "valueA"],
-      points: [
-        [1400425947000, 34],
-        [1400425948000, 13],
-        [1400425949000, 67],
-        [1400425950000, 91]
-      ]
-    };
-
-    const B = {
-      name: "b",
-      columns: ["time", "valueB"],
-      points: [
-        [1400425951000, 65],
-        [1400425952000, 86],
-        [1400425953000, 27],
-        [1400425954000, 72]
-      ]
-    };
-
-    const tile1 = timeSeries(A);
-    const tile2 = timeSeries(B);
-
-    const series = TimeSeries.timeSeriesListMerge({
-      name: "traffic",
-      seriesList: [tile1, tile2]
-    });
-    // console.log("series is ", series);
-    const expected = `{"name":"traffic","tz":"Etc/UTC","columns":["time","valueA","valueB"],"points":[[1400425947000,34,null],[1400425948000,13,null],[1400425949000,67,null],[1400425950000,91,null],[1400425951000,null,65],[1400425952000,null,86],[1400425953000,null,27],[1400425954000,null,72]]}`;
-    expect(series.toString()).toBe(expected);
-  });
-});
-
-describe("Summing two timeseries together", () => {
-  it("can merge two timeseries into a new timeseries that is the sum", () => {
-    const part1 = timeSeries(sumPart1);
-    const part2 = timeSeries(sumPart2);
-
-    const result = TimeSeries.timeSeriesListReduce({
-      name: "sum",
-      seriesList: [part1, part2],
-      reducer: sum(),
-      fieldSpec: ["in", "out"]
-    });
-
-    // 10, 9, 8, 7
-    expect(result.at(0).get("in")).toBe(10);
-    expect(result.at(1).get("in")).toBe(9);
-    expect(result.at(2).get("in")).toBe(8);
-    expect(result.at(3).get("in")).toBe(7);
-
-    // 7, 9, 11, 13
-    expect(result.at(0).get("out")).toBe(7);
-    expect(result.at(1).get("out")).toBe(9);
-    expect(result.at(2).get("out")).toBe(11);
-    expect(result.at(3).get("out")).toBe(13);
-  });
-});
-
-describe("Averaging two timeseries together", () => {
-  it("can merge two timeseries into a new timeseries that is the sum", () => {
-    const part1 = timeSeries({
-      name: "part1",
-      columns: ["time", "in", "out"],
-      points: [
+    name: "part1",
+    columns: ["time", "in", "out"],
+    points: [
         [1400425951000, 1, 6],
         [1400425952000, 2, 7],
         [1400425953000, 3, 8],
         [1400425954000, 4, 9]
-      ]
-    });
-    const part2 = timeSeries({
-      name: "part2",
-      columns: ["time", "in", "out"],
-      points: [
+    ]
+};
+const sumPart2 = {
+    name: "part2",
+    columns: ["time", "in", "out"],
+    points: [
         [1400425951000, 9, 1],
         [1400425952000, 7, 2],
         [1400425953000, 5, 3],
         [1400425954000, 3, 4]
-      ]
+    ]
+};
+
+const sept2014Data = {
+    utc: false,
+    name: "traffic",
+    columns: ["time", "value"],
+    points: [
+        [1409529600000, 80],
+        [1409533200000, 88],
+        [1409536800000, 52],
+        [1409540400000, 80],
+        [1409544000000, 26],
+        [1409547600000, 37],
+        [1409551200000, 6],
+        [1409554800000, 32],
+        [1409558400000, 69],
+        [1409562000000, 21],
+        [1409565600000, 6],
+        [1409569200000, 54],
+        [1409572800000, 88],
+        [1409576400000, 41],
+        [1409580000000, 35],
+        [1409583600000, 43],
+        [1409587200000, 84],
+        [1409590800000, 32],
+        [1409594400000, 41],
+        [1409598000000, 57],
+        [1409601600000, 27],
+        [1409605200000, 50],
+        [1409608800000, 13],
+        [1409612400000, 63],
+        [1409616000000, 58],
+        [1409619600000, 80],
+        [1409623200000, 59],
+        [1409626800000, 96],
+        [1409630400000, 2],
+        [1409634000000, 20],
+        [1409637600000, 64],
+        [1409641200000, 7],
+        [1409644800000, 50],
+        [1409648400000, 88],
+        [1409652000000, 34],
+        [1409655600000, 31],
+        [1409659200000, 16],
+        [1409662800000, 38],
+        [1409666400000, 94],
+        [1409670000000, 78],
+        [1409673600000, 86],
+        [1409677200000, 13],
+        [1409680800000, 34],
+        [1409684400000, 29],
+        [1409688000000, 48],
+        [1409691600000, 80],
+        [1409695200000, 30],
+        [1409698800000, 15],
+        [1409702400000, 62],
+        [1409706000000, 66],
+        [1409709600000, 44],
+        [1409713200000, 94],
+        [1409716800000, 78],
+        [1409720400000, 29],
+        [1409724000000, 21],
+        [1409727600000, 4],
+        [1409731200000, 83],
+        [1409734800000, 15],
+        [1409738400000, 89],
+        [1409742000000, 53],
+        [1409745600000, 70],
+        [1409749200000, 41],
+        [1409752800000, 47],
+        [1409756400000, 30],
+        [1409760000000, 68],
+        [1409763600000, 89],
+        [1409767200000, 29],
+        [1409770800000, 17],
+        [1409774400000, 38],
+        [1409778000000, 67],
+        [1409781600000, 75],
+        [1409785200000, 89],
+        [1409788800000, 47],
+        [1409792400000, 82],
+        [1409796000000, 33],
+        [1409799600000, 67],
+        [1409803200000, 93],
+        [1409806800000, 86],
+        [1409810400000, 97],
+        [1409814000000, 19],
+        [1409817600000, 19],
+        [1409821200000, 31],
+        [1409824800000, 56],
+        [1409828400000, 19],
+        [1409832000000, 43],
+        [1409835600000, 29],
+        [1409839200000, 72],
+        [1409842800000, 27],
+        [1409846400000, 21],
+        [1409850000000, 88],
+        [1409853600000, 18],
+        [1409857200000, 30],
+        [1409860800000, 46],
+        [1409864400000, 34],
+        [1409868000000, 31],
+        [1409871600000, 20],
+        [1409875200000, 45],
+        [1409878800000, 17],
+        [1409882400000, 24],
+        [1409886000000, 84],
+        [1409889600000, 6],
+        [1409893200000, 91],
+        [1409896800000, 82],
+        [1409900400000, 71],
+        [1409904000000, 97],
+        [1409907600000, 43],
+        [1409911200000, 38],
+        [1409914800000, 1],
+        [1409918400000, 71],
+        [1409922000000, 50],
+        [1409925600000, 19],
+        [1409929200000, 19],
+        [1409932800000, 86],
+        [1409936400000, 65],
+        [1409940000000, 93],
+        [1409943600000, 35]
+    ]
+};
+
+const OUTAGE_EVENT_LIST = Immutable.List([
+    {
+        startTime: "2015-03-04T09:00:00Z",
+        endTime: "2015-03-04T14:00:00Z",
+        title: "ANL Scheduled Maintenance",
+        description: "ANL will be switching border routers...",
+        completed: true,
+        external_ticket: "",
+        esnet_ticket: "ESNET-20150302-002",
+        organization: "ANL",
+        type: "Planned"
+    },
+    {
+        startTime: "2015-04-22T03:30:00Z",
+        endTime: "2015-04-22T13:00:00Z",
+        description: "At 13:33 pacific circuit 06519 went down.",
+        title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+        completed: true,
+        external_ticket: "",
+        esnet_ticket: "ESNET-20150421-013",
+        organization: "Internet2 / Level 3",
+        type: "Unplanned"
+    },
+    {
+        startTime: "2015-04-22T03:35:00Z",
+        endTime: "2015-04-22T16:50:00Z",
+        title: "STAR-CR5 < 100 ge 06519 > ANL  - Outage",
+        description: "The listed circuit was unavailable due to bent pins.",
+        completed: true,
+        external_ticket: "3576:144",
+        esnet_ticket: "ESNET-20150421-013",
+        organization: "Internet2 / Level 3",
+        type: "Unplanned"
+    }
+]);
+
+const TIMERANGE_EVENT_LIST = OUTAGE_EVENT_LIST.map(evt => {
+    const { startTime, endTime, ...other } = evt;
+    const b = new Date(startTime);
+    const e = new Date(endTime);
+    return timeRangeEvent(timerange(b, e), Immutable.Map(other as {}));
+});
+
+const weather = Immutable.List([
+    {
+        date: "2014-7-1",
+        actual_mean_temp: 81,
+        actual_min_temp: 72,
+        actual_max_temp: 89,
+        average_min_temp: 68,
+        average_max_temp: 83,
+        record_min_temp: 52,
+        record_max_temp: 100,
+        record_min_temp_year: 1943,
+        record_max_temp_year: 1901,
+        actual_precipitation: 0,
+        average_precipitation: 0.12,
+        record_precipitation: 2.17
+    },
+    {
+        date: "2014-7-2",
+        actual_mean_temp: 82,
+        actual_min_temp: 72,
+        actual_max_temp: 91,
+        average_min_temp: 68,
+        average_max_temp: 83,
+        record_min_temp: 56,
+        record_max_temp: 100,
+        record_min_temp_year: 2001,
+        record_max_temp_year: 1966,
+        actual_precipitation: 0.96,
+        average_precipitation: 0.13,
+        record_precipitation: 1.79
+    },
+    {
+        date: "2014-7-3",
+        actual_mean_temp: 78,
+        actual_min_temp: 69,
+        actual_max_temp: 87,
+        average_min_temp: 68,
+        average_max_temp: 83,
+        record_min_temp: 54,
+        record_max_temp: 103,
+        record_min_temp_year: 1933,
+        record_max_temp_year: 1966,
+        actual_precipitation: 1.78,
+        average_precipitation: 0.12,
+        record_precipitation: 2.8
+    }
+]);
+
+describe("Creation", () => {
+    it("can create a series with a list of events", () => {
+        const series = new TimeSeries(EVENT_DATA);
+        expect(series).toBeDefined();
     });
 
-    const avgSeries = TimeSeries.timeSeriesListReduce({
-      name: "avg",
-      seriesList: [part1, part2],
-      fieldSpec: ["in", "out"],
-      reducer: avg()
+    it("can create a series with a collection", () => {
+        const series = new TimeSeries(COLLECTION_DATA);
+        expect(series).toBeDefined();
     });
 
-    expect(avgSeries.at(0).get("in")).toBe(5);
-    expect(avgSeries.at(1).get("in")).toBe(4.5);
-    expect(avgSeries.at(2).get("in")).toBe(4);
-    expect(avgSeries.at(3).get("in")).toBe(3.5);
-
-    expect(avgSeries.at(0).get("out")).toBe(3.5);
-    expect(avgSeries.at(1).get("out")).toBe(4.5);
-    expect(avgSeries.at(2).get("out")).toBe(5.5);
-    expect(avgSeries.at(3).get("out")).toBe(6.5);
-
-    const avgSeries2 = TimeSeries.timeSeriesListReduce({
-      name: "avg",
-      seriesList: [part1, part2],
-      reducer: avg(),
-      fieldSpec: ["in", "out"]
+    it("can create a timeseries with our wire format", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        expect(series).toBeDefined();
     });
 
-    expect(avgSeries2.at(0).get("in")).toBe(5);
-    expect(avgSeries2.at(1).get("in")).toBe(4.5);
-    expect(avgSeries2.at(2).get("in")).toBe(4);
-    expect(avgSeries2.at(3).get("in")).toBe(3.5);
-  });
+    it("can create an indexed series with our wire format", () => {
+        const series = indexedSeries(AVAILABILITY_DATA);
+        expect(series).toBeDefined();
+    });
+
+    it("can create an series with a list of Events", () => {
+        const events = [];
+        events.push(timeEvent(time(new Date(2015, 7, 1)), Immutable.Map({ value: 27 })));
+        events.push(timeEvent(time(new Date(2015, 8, 1)), Immutable.Map({ value: 14 })));
+        const series = new TimeSeries({
+            name: "events",
+            events: Immutable.List(events)
+        });
+        expect(series.size()).toBe(2);
+    });
+
+    it("can create an series with a list of Indexed Events", () => {
+        const events = weather.map(item => {
+            const {
+                date,
+                actual_min_temp,
+                actual_max_temp,
+                record_min_temp,
+                record_max_temp
+            } = item;
+            return indexedEvent(
+                index(date),
+                Immutable.Map({
+                    temp: [
+                        +record_min_temp, // tslint-disable-line
+                        +actual_min_temp, // tslint-disable-line
+                        +actual_max_temp, // tslint-disable-line
+                        +record_max_temp // tslint-disable-line
+                    ]
+                })
+            );
+        });
+
+        const c = new Collection(events);
+        const series = new TimeSeries({ name, collection: c });
+        expect(series.size()).toBe(3);
+    });
+
+    it("can create an series with no events", () => {
+        const events = [];
+        const series = new TimeSeries({
+            name: "events",
+            events: Immutable.List(events)
+        });
+        expect(series.size()).toBe(0);
+    });
+
+    it("can create a timerange series with the right timerange", () => {
+        const series = new TimeSeries({
+            name: "outages",
+            events: TIMERANGE_EVENT_LIST
+        });
+        expect(series.range().toString()).toBe('{"timerange":[1425459600000,1429721400000]}');
+    });
+});
+
+describe("Basic Query API", () => {
+    // tslint:disable:max-line-length
+    it("can return the size of the series", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        expect(series.size()).toBe(4);
+    });
+
+    it("can return an item in the series as an event", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const e = series.at(1);
+        expect(e.keyType()).toBe("time");
+    });
+
+    it("can return an item in the series with the correct data", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const e = series.at(1);
+        expect(JSON.stringify(e.getData())).toBe(`{"value":18,"status":"ok"}`);
+        expect(e.timestamp().getTime()).toBe(1400425948000);
+    });
+
+    it("can serialize to a string", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const expectedString = `{"name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+        expect(series.toString()).toBe(expectedString);
+    });
+
+    it("can return the time range of the series", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const expectedString = "[Sun, 18 May 2014 15:12:27 GMT, Sun, 18 May 2014 15:12:30 GMT]";
+        expect(series.timerange().toUTCString()).toBe(expectedString);
+    });
+});
+
+describe("Meta Data", () => {
+    it("can create a series with meta data and get that data back", () => {
+        const series = timeSeries(INTERFACE_TEST_DATA);
+        const expected = `{"site_interface":"et-1/0/0","tz":"Etc/UTC","site":"anl","name":"star-cr5:to_anl_ip-a_v4","site_device":"noni","device":"star-cr5","oscars_id":null,"title":null,"is_oscars":false,"interface":"to_anl_ip-a_v4","stats_type":"Standard","id":169,"resource_uri":"","is_ipv6":false,"description":"star-cr5->anl(as683):100ge:site-ex:show:intercloud","columns":["time","in","out"],"points":[[1400425947000,52,34],[1400425948000,18,13],[1400425949000,26,67],[1400425950000,93,91]]}`;
+        expect(series.toString()).toBe(expected);
+        expect(series.meta("interface")).toBe("to_anl_ip-a_v4");
+    });
+
+    it("can create a series and set a new name", () => {
+        const series = timeSeries(INTERFACE_TEST_DATA);
+        expect(series.name()).toBe("star-cr5:to_anl_ip-a_v4");
+        const newSeries = series.setName("bob");
+        expect(newSeries.name()).toBe("bob");
+    });
+
+    it("can create a series with meta data and get that data back", () => {
+        const series = timeSeries(INTERFACE_TEST_DATA);
+        expect(series.meta("site_interface")).toBe("et-1/0/0");
+        const newSeries = series.setMeta("site_interface", "bob");
+        expect(newSeries.meta("site_interface")).toBe("bob");
+        expect(newSeries.at(0).get("in")).toBe(52);
+        expect(newSeries.meta("site")).toBe("anl");
+    });
+});
+
+describe("Deep Event Data", () => {
+    it("can create a series with a nested object", () => {
+        const series = timeSeries({
+            name: "Map Traffic",
+            columns: ["time", "NASA_north", "NASA_south"],
+            points: [
+                [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
+                [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
+                [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
+                [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175 }]
+            ]
+        });
+        expect(
+            series
+                .at(0)
+                .get("NASA_north")
+                .get("in")
+        ).toBe(100);
+        expect(
+            series
+                .at(0)
+                .get("NASA_north")
+                .get("out")
+        ).toBe(200);
+
+        expect(series.at(0).get("NASA_north.in")).toBe(100);
+        expect(series.at(0).get(["NASA_north", "in"])).toBe(100);
+    });
+
+    it("can create a series with nested events", () => {
+        const events = [];
+        events.push(
+            timeEvent(
+                time(new Date(2015, 6, 1)),
+                Immutable.Map({
+                    NASA_north: { in: 100, out: 200 },
+                    NASA_south: { in: 145, out: 135 }
+                })
+            )
+        );
+        events.push(
+            timeEvent(
+                time(new Date(2015, 7, 1)),
+                Immutable.Map({
+                    NASA_north: { in: 200, out: 400 },
+                    NASA_south: { in: 146, out: 142 }
+                })
+            )
+        );
+        events.push(
+            timeEvent(
+                time(new Date(2015, 8, 1)),
+                Immutable.Map({
+                    NASA_north: { in: 300, out: 600 },
+                    NASA_south: { in: 147, out: 158 }
+                })
+            )
+        );
+        events.push(
+            timeEvent(
+                time(new Date(2015, 9, 1)),
+                Immutable.Map({
+                    NASA_north: { in: 400, out: 800 },
+                    NASA_south: { in: 155, out: 175 }
+                })
+            )
+        );
+        const series = new TimeSeries({
+            name: "Map traffic",
+            events: Immutable.List(events)
+        });
+        expect(series.at(0).get("NASA_north").in).toBe(100);
+        expect(series.at(3).get("NASA_south").out).toBe(175);
+        expect(series.size()).toBe(4);
+    });
+});
+
+describe("Comparing TimeSeries", () => {
+    it("can compare a series and a reference to a series as being equal", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const refSeries = series;
+        expect(series).toBe(refSeries);
+    });
+
+    it("can use the equals() comparator to compare a series and a copy of the series as true", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const copyOfSeries = new TimeSeries(series);
+        expect(TimeSeries.equal(series, copyOfSeries)).toBeTruthy();
+    });
+
+    it("can use the equals() comparator to compare a series and a value equivalent series as false", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
+        expect(TimeSeries.equal(series, otherSeries)).toBeFalsy();
+    });
+
+    it("can use the is() comparator to compare a series and a value equivalent series as true", () => {
+        const series = timeSeries(TIMESERIES_TEST_DATA);
+        const otherSeries = timeSeries(TIMESERIES_TEST_DATA);
+        expect(TimeSeries.is(series, otherSeries)).toBeTruthy();
+    });
+
+    it("can use the is() comparator to compare a series and a value different series as false", () => {
+        const series = timeSeries(sumPart1);
+        const otherSeries = timeSeries(sumPart2);
+        expect(TimeSeries.is(series, otherSeries)).toBeFalsy();
+    });
+});
+
+describe("Bisect", () => {
+    it("can find the bisect starting from 0", () => {
+        const series = timeSeries(BISECT_TEST_DATA);
+        expect(series.bisect(moment("2012-01-11 00:30", fmt).toDate())).toBe(0);
+        expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate())).toBe(2);
+        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate())).toBe(2);
+        expect(series.bisect(moment("2012-01-11 08:00", fmt).toDate())).toBe(6);
+    });
+
+    it("can find the bisect starting from an begin index", () => {
+        const series = timeSeries(BISECT_TEST_DATA);
+        expect(series.bisect(moment("2012-01-11 03:00", fmt).toDate(), 2)).toBe(2);
+        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 3)).toBe(2);
+        expect(series.bisect(moment("2012-01-11 03:30", fmt).toDate(), 4)).toBe(3);
+
+        const first = series.bisect(moment("2012-01-11 03:30", fmt).toDate());
+        const second = series.bisect(moment("2012-01-11 04:30", fmt).toDate(), first);
+        expect(series.at(first).get()).toBe(44);
+        expect(series.at(second).get()).toBe(55);
+    });
+});
+
+describe("Time Range Events", () => {
+    it("can make a timeseries with the right timerange", () => {
+        const series = new TimeSeries({
+            name: "outages",
+            events: TIMERANGE_EVENT_LIST
+        });
+        expect(series.range().toString()).toBe('{"timerange":[1425459600000,1429721400000]}');
+    });
+
+    it("can make a timeseries that can be serialized to a string", () => {
+        const series = new TimeSeries({
+            name: "outages",
+            events: TIMERANGE_EVENT_LIST
+        });
+        const expected = `{"name":"outages","tz":"Etc/UTC","columns":["timerange","title","description","completed","external_ticket","esnet_ticket","organization","type"],"points":[[[1425459600000,1425477600000],"ANL Scheduled Maintenance","ANL will be switching border routers...",true,"","ESNET-20150302-002","ANL","Planned"],[[1429673400000,1429707600000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","At 13:33 pacific circuit 06519 went down.",true,"","ESNET-20150421-013","Internet2 / Level 3","Unplanned"],[[1429673700000,1429721400000],"STAR-CR5 < 100 ge 06519 > ANL  - Outage","The listed circuit was unavailable due to bent pins.",true,"3576:144","ESNET-20150421-013","Internet2 / Level 3","Unplanned"]]}`;
+        expect(series.toString()).toBe(expected);
+    });
+
+    it("can make a timeseries that can be serialized to JSON and then used to construct a TimeSeries again", () => {
+        const series = new TimeSeries({
+            name: "outages",
+            events: TIMERANGE_EVENT_LIST
+        });
+        const newSeries = timeRangeSeries(series.toJSON() as TimeSeriesWireFormat);
+        expect(series.toString()).toBe(newSeries.toString());
+    });
+});
+
+describe("Indexed Events", () => {
+    it("can serialize to a string", () => {
+        const series = timeSeries(INDEXED_DATA);
+        const expectedString = `{"index":"1d-625","name":"traffic","tz":"Etc/UTC","columns":["time","value","status"],"points":[[1400425947000,52,"ok"],[1400425948000,18,"ok"],[1400425949000,26,"fail"],[1400425950000,93,"offline"]]}`;
+        expect(series.toString()).toBe(expectedString);
+    });
+
+    it("can return the time range of the series", () => {
+        const series = timeSeries(INDEXED_DATA);
+        const expectedString = "[Sat, 18 Sep 1971 00:00:00 GMT, Sun, 19 Sep 1971 00:00:00 GMT]";
+        expect(series.indexAsRange().toUTCString()).toBe(expectedString);
+    });
+
+    it("can create an series with indexed data (in UTC time)", () => {
+        const series = indexedSeries(AVAILABILITY_DATA);
+        const e = series.at(2);
+        expect(e.timerangeAsUTCString()).toBe(
+            "[Mon, 01 Sep 2014 00:00:00 GMT, Tue, 30 Sep 2014 23:59:59 GMT]"
+        );
+        expect(
+            series
+                .range()
+                .begin()
+                .getTime()
+        ).toBe(1404172800000);
+        expect(
+            series
+                .range()
+                .end()
+                .getTime()
+        ).toBe(1435708799999);
+    });
+});
+
+describe("Slicing a timeseries", () => {
+    it("can create a slice of a series", () => {
+        const series = indexedSeries(AVAILABILITY_DATA);
+        const expectedLastTwo = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2015-05","92%"],["2015-06","100%"]]}`;
+        const lastTwo = series.slice(-2);
+        expect(lastTwo.toString()).toBe(expectedLastTwo);
+        const expectedFirstThree = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"]]}`;
+        const firstThree = series.slice(0, 3);
+        expect(firstThree.toString()).toBe(expectedFirstThree);
+        const expectedAll = `{"name":"availability","tz":"Etc/UTC","columns":["index","uptime"],"points":[["2014-07","100%"],["2014-08","88%"],["2014-09","95%"],["2014-10","99%"],["2014-11","91%"],["2014-12","99%"],["2015-01","100%"],["2015-02","92%"],["2015-03","99%"],["2015-04","87%"],["2015-05","92%"],["2015-06","100%"]]}`;
+        const sliceAll = series.slice();
+        expect(sliceAll.toString()).toBe(expectedAll);
+    });
+});
+
+describe("Cropping a timeseries", () => {
+    it("can create crop a series", () => {
+        const series = timeSeries({
+            name: "exact timestamps",
+            columns: ["time", "value"],
+            points: [
+                [1504014065240, 1],
+                [1504014065243, 2],
+                [1504014065244, 3],
+                [1504014065245, 4],
+                [1504014065249, 5]
+            ]
+        });
+        const ts1 = series.crop(timerange(1504014065243, 1504014065245));
+        expect(ts1.size()).toBe(3);
+        const ts2 = series.crop(timerange(1504014065242, 1504014065245));
+        expect(ts2.size()).toBe(3);
+        const ts3 = series.crop(timerange(1504014065243, 1504014065247));
+        expect(ts3.size()).toBe(3);
+        const ts4 = series.crop(timerange(1504014065242, 1504014065247));
+        expect(ts4.size()).toBe(3);
+    });
+});
+
+describe("Merging two timeseries together", () => {
+    it("can merge two timeseries columns together using merge", () => {
+        const inTraffic = timeSeries(TRAFFIC_DATA_IN);
+        const outTraffic = timeSeries(TRAFFIC_DATA_OUT);
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+            name: "traffic",
+            seriesList: [inTraffic, outTraffic],
+            fieldSpec: ["in", "out"]
+        });
+
+        expect(trafficSeries.at(2).get("in")).toBe(26);
+        expect(trafficSeries.at(2).get("out")).toBe(67);
+    });
+
+    it("can append two timeseries together using merge", () => {
+        const tile1 = timeSeries(PARTIAL_TRAFFIC_PART_A);
+        const tile2 = timeSeries(PARTIAL_TRAFFIC_PART_B);
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+            name: "traffic",
+            source: "router",
+            seriesList: [tile1, tile2],
+            fieldSpec: "value"
+        });
+        expect(trafficSeries.size()).toBe(8);
+        expect(trafficSeries.at(0).get()).toBe(34);
+        expect(trafficSeries.at(1).get()).toBe(13);
+        expect(trafficSeries.at(2).get()).toBe(67);
+        expect(trafficSeries.at(3).get()).toBe(91);
+        expect(trafficSeries.at(4).get()).toBe(65);
+        expect(trafficSeries.at(5).get()).toBe(86);
+        expect(trafficSeries.at(6).get()).toBe(27);
+        expect(trafficSeries.at(7).get()).toBe(72);
+        expect(trafficSeries.name()).toBe("traffic");
+        expect(trafficSeries.meta("source")).toBe("router");
+    });
+
+    it("can merge two series and preserve the correct time format", () => {
+        const inTraffic = timeSeries(TRAFFIC_BNL_TO_NEWY);
+        const outTraffic = timeSeries(TRAFFIC_NEWY_TO_BNL);
+        const trafficSeries = TimeSeries.timeSeriesListMerge<Time>({
+            name: "traffic",
+            seriesList: [inTraffic, outTraffic]
+        });
+        expect(trafficSeries.at(0).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:12:30 GMT");
+        expect(trafficSeries.at(1).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:13:00 GMT");
+        expect(trafficSeries.at(2).timestampAsUTCString()).toBe("Mon, 31 Aug 2015 20:13:30 GMT");
+    });
+
+    it("can merge two irregular time series together", () => {
+        const A = {
+            name: "a",
+            columns: ["time", "valueA"],
+            points: [
+                [1400425947000, 34],
+                [1400425948000, 13],
+                [1400425949000, 67],
+                [1400425950000, 91]
+            ]
+        };
+
+        const B = {
+            name: "b",
+            columns: ["time", "valueB"],
+            points: [
+                [1400425951000, 65],
+                [1400425952000, 86],
+                [1400425953000, 27],
+                [1400425954000, 72]
+            ]
+        };
+
+        const tile1 = timeSeries(A);
+        const tile2 = timeSeries(B);
+
+        const series = TimeSeries.timeSeriesListMerge({
+            name: "traffic",
+            seriesList: [tile1, tile2]
+        });
+        // console.log("series is ", series);
+        const expected = `{"name":"traffic","tz":"Etc/UTC","columns":["time","valueA","valueB"],"points":[[1400425947000,34,null],[1400425948000,13,null],[1400425949000,67,null],[1400425950000,91,null],[1400425951000,null,65],[1400425952000,null,86],[1400425953000,null,27],[1400425954000,null,72]]}`;
+        expect(series.toString()).toBe(expected);
+    });
+});
+
+describe("Summing two timeseries together", () => {
+    it("can merge two timeseries into a new timeseries that is the sum", () => {
+        const part1 = timeSeries(sumPart1);
+        const part2 = timeSeries(sumPart2);
+
+        const result = TimeSeries.timeSeriesListReduce({
+            name: "sum",
+            seriesList: [part1, part2],
+            reducer: sum(),
+            fieldSpec: ["in", "out"]
+        });
+
+        // 10, 9, 8, 7
+        expect(result.at(0).get("in")).toBe(10);
+        expect(result.at(1).get("in")).toBe(9);
+        expect(result.at(2).get("in")).toBe(8);
+        expect(result.at(3).get("in")).toBe(7);
+
+        // 7, 9, 11, 13
+        expect(result.at(0).get("out")).toBe(7);
+        expect(result.at(1).get("out")).toBe(9);
+        expect(result.at(2).get("out")).toBe(11);
+        expect(result.at(3).get("out")).toBe(13);
+    });
+});
+
+describe("Averaging two timeseries together", () => {
+    it("can merge two timeseries into a new timeseries that is the sum", () => {
+        const part1 = timeSeries({
+            name: "part1",
+            columns: ["time", "in", "out"],
+            points: [
+                [1400425951000, 1, 6],
+                [1400425952000, 2, 7],
+                [1400425953000, 3, 8],
+                [1400425954000, 4, 9]
+            ]
+        });
+        const part2 = timeSeries({
+            name: "part2",
+            columns: ["time", "in", "out"],
+            points: [
+                [1400425951000, 9, 1],
+                [1400425952000, 7, 2],
+                [1400425953000, 5, 3],
+                [1400425954000, 3, 4]
+            ]
+        });
+
+        const avgSeries = TimeSeries.timeSeriesListReduce({
+            name: "avg",
+            seriesList: [part1, part2],
+            fieldSpec: ["in", "out"],
+            reducer: avg()
+        });
+
+        expect(avgSeries.at(0).get("in")).toBe(5);
+        expect(avgSeries.at(1).get("in")).toBe(4.5);
+        expect(avgSeries.at(2).get("in")).toBe(4);
+        expect(avgSeries.at(3).get("in")).toBe(3.5);
+
+        expect(avgSeries.at(0).get("out")).toBe(3.5);
+        expect(avgSeries.at(1).get("out")).toBe(4.5);
+        expect(avgSeries.at(2).get("out")).toBe(5.5);
+        expect(avgSeries.at(3).get("out")).toBe(6.5);
+
+        const avgSeries2 = TimeSeries.timeSeriesListReduce({
+            name: "avg",
+            seriesList: [part1, part2],
+            reducer: avg(),
+            fieldSpec: ["in", "out"]
+        });
+
+        expect(avgSeries2.at(0).get("in")).toBe(5);
+        expect(avgSeries2.at(1).get("in")).toBe(4.5);
+        expect(avgSeries2.at(2).get("in")).toBe(4);
+        expect(avgSeries2.at(3).get("in")).toBe(3.5);
+    });
 });
 
 describe("Collapsing down columns in a timeseries", () => {
-  it("can collapse a timeseries into a new timeseries that is the sum of two columns", () => {
-    const ts = timeSeries(sumPart1);
-    const sums = ts.collapse({
-      fieldName: "sum",
-      fieldSpecList: ["in", "out"],
-      reducer: sum(),
-      append: false
+    it("can collapse a timeseries into a new timeseries that is the sum of two columns", () => {
+        const ts = timeSeries(sumPart1);
+        const sums = ts.collapse({
+            fieldName: "sum",
+            fieldSpecList: ["in", "out"],
+            reducer: sum(),
+            append: false
+        });
+
+        expect(sums.at(0).get("sum")).toBe(7);
+        expect(sums.at(1).get("sum")).toBe(9);
+        expect(sums.at(2).get("sum")).toBe(11);
+        expect(sums.at(3).get("sum")).toBe(13);
     });
 
-    expect(sums.at(0).get("sum")).toBe(7);
-    expect(sums.at(1).get("sum")).toBe(9);
-    expect(sums.at(2).get("sum")).toBe(11);
-    expect(sums.at(3).get("sum")).toBe(13);
-  });
+    it("can collapse a timeseries into a new timeseries that is the max of two columns", () => {
+        const timeseries = timeSeries(sumPart2);
+        const c = timeseries.collapse({
+            fieldName: "max_in_out",
+            fieldSpecList: ["in", "out"],
+            reducer: max(),
+            append: true
+        });
 
-  it("can collapse a timeseries into a new timeseries that is the max of two columns", () => {
-    const timeseries = timeSeries(sumPart2);
-    const c = timeseries.collapse({
-      fieldName: "max_in_out",
-      fieldSpecList: ["in", "out"],
-      reducer: max(),
-      append: true
+        expect(c.at(0).get("max_in_out")).toBe(9);
+        expect(c.at(1).get("max_in_out")).toBe(7);
+        expect(c.at(2).get("max_in_out")).toBe(5);
+        expect(c.at(3).get("max_in_out")).toBe(4);
     });
 
-    expect(c.at(0).get("max_in_out")).toBe(9);
-    expect(c.at(1).get("max_in_out")).toBe(7);
-    expect(c.at(2).get("max_in_out")).toBe(5);
-    expect(c.at(3).get("max_in_out")).toBe(4);
-  });
-
-  it("can collapse a timeseries into a new timeseries that is the sum of two columns, then find the max", () => {
-    const ts = timeSeries(sumPart1);
-    const sums = ts.collapse({
-      fieldName: "value",
-      fieldSpecList: ["in", "out"],
-      reducer: sum(),
-      append: false
+    it("can collapse a timeseries into a new timeseries that is the sum of two columns, then find the max", () => {
+        const ts = timeSeries(sumPart1);
+        const sums = ts.collapse({
+            fieldName: "value",
+            fieldSpecList: ["in", "out"],
+            reducer: sum(),
+            append: false
+        });
+        expect(sums.max("value")).toBe(13);
     });
-    expect(sums.max("value")).toBe(13);
-  });
 });
 
 describe("Select specific columns in a TimeSeries", () => {
-  it("can select a single column from a TimeSeries", () => {
-    const timeseries = timeSeries(INTERFACE_TEST_DATA);
-    expect(timeseries.columns()).toEqual(["in", "out"]);
+    it("can select a single column from a TimeSeries", () => {
+        const timeseries = timeSeries(INTERFACE_TEST_DATA);
+        expect(timeseries.columns()).toEqual(["in", "out"]);
 
-    const ts = timeseries.select({ fields: ["in"] });
-    expect(ts.columns()).toEqual(["in"]);
-    expect(ts.name()).toBe("star-cr5:to_anl_ip-a_v4");
-  });
-
-  it("can select multiple columns from a TimeSeries", () => {
-    const timeseries = indexedSeries(AVAILABILITY_DATA_2);
-    expect(timeseries.columns()).toEqual(["uptime", "notes", "outages"]);
-
-    const ts = timeseries.select({ fields: ["uptime", "notes"] });
-    expect(ts.columns()).toEqual(["uptime", "notes"]);
-    expect(ts.name()).toBe("availability");
-  });
-
-  it("can rename columns", () => {
-    const ts = timeSeries(sumPart1);
-    const newTs = ts.renameColumns({
-      renameMap: { in: "new_in", out: "new_out" }
+        const ts = timeseries.select({ fields: ["in"] });
+        expect(ts.columns()).toEqual(["in"]);
+        expect(ts.name()).toBe("star-cr5:to_anl_ip-a_v4");
     });
-    expect(newTs.columns()).toEqual(["new_in", "new_out"]);
 
-    const series = indexedSeries(AVAILABILITY_DATA);
-    const newSeries = series.renameColumns({
-      renameMap: { uptime: "new_uptime" }
+    it("can select multiple columns from a TimeSeries", () => {
+        const timeseries = indexedSeries(AVAILABILITY_DATA_2);
+        expect(timeseries.columns()).toEqual(["uptime", "notes", "outages"]);
+
+        const ts = timeseries.select({ fields: ["uptime", "notes"] });
+        expect(ts.columns()).toEqual(["uptime", "notes"]);
+        expect(ts.name()).toBe("availability");
     });
-    expect(newSeries.columns()).toEqual(["new_uptime"]);
-  });
+
+    it("can rename columns", () => {
+        const ts = timeSeries(sumPart1);
+        const newTs = ts.renameColumns({
+            renameMap: { in: "new_in", out: "new_out" }
+        });
+        expect(newTs.columns()).toEqual(["new_in", "new_out"]);
+
+        const series = indexedSeries(AVAILABILITY_DATA);
+        const newSeries = series.renameColumns({
+            renameMap: { uptime: "new_uptime" }
+        });
+        expect(newSeries.columns()).toEqual(["new_uptime"]);
+    });
 });
 
 describe("Remapping Events in a TimeSeries", () => {
-  it("can use re-mapping to reverse the values in a TimeSeries", () => {
-    const timeseries = timeSeries(INTERFACE_TEST_DATA);
+    it("can use re-mapping to reverse the values in a TimeSeries", () => {
+        const timeseries = timeSeries(INTERFACE_TEST_DATA);
 
-    expect(timeseries.columns()).toEqual(["in", "out"]);
+        expect(timeseries.columns()).toEqual(["in", "out"]);
 
-    const ts = timeseries.map(e =>
-      e.setData(Immutable.Map({ in: e.get("out"), out: e.get("in") }))
-    );
+        const ts = timeseries.map(e =>
+            e.setData(Immutable.Map({ in: e.get("out"), out: e.get("in") }))
+        );
 
-    expect(ts.at(0).get("in")).toBe(34);
-    expect(ts.at(0).get("out")).toBe(52);
-    expect(ts.size()).toBe(timeseries.size());
-  });
-
-  it("can run a flat map over the TimeSeries", () => {
-    const series = timeSeries({
-      name: "Map Traffic",
-      columns: ["time", "NASA_north", "NASA_south"],
-      points: [
-        [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
-        [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
-        [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
-        [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 1 }]
-      ]
-    });
-    const split = series.flatMap(e =>
-      Immutable.List([
-        e.setData(e.get("NASA_north")),
-        e.setData(e.get("NASA_south"))
-      ])
-    );
-
-    expect(split.size()).toBe(8);
-    expect(split.at(0).get("in")).toBe(100);
-    expect(split.at(0).get("out")).toBe(200);
-    expect(split.at(0).get("other")).toBeUndefined();
-    expect(split.at(1).get("in")).toBe(145);
-    expect(split.at(1).get("out")).toBe(135);
-    expect(split.at(1).get("other")).toBeUndefined();
-    expect(split.at(7).get("in")).toBe(155);
-    expect(split.at(7).get("out")).toBe(175);
-    expect(split.at(7).get("other")).toBe(1);
-  });
-
-  it("can remap keys of a TimeSeries using mapKeys() from times to timeranges", () => {
-    const series = timeSeries({
-      name: "series",
-      columns: ["time", "a", "b"],
-      points: [
-        [1400425951000, 100, 200],
-        [1400425952000, 300, 400],
-        [1400425953000, 800, 900]
-      ]
-    });
-    const remapped = series.mapKeys(t =>
-      t.toTimeRange(duration("5m"), TimeAlignment.Middle)
-    );
-
-    expect(remapped.size()).toBe(3);
-    expect(
-      remapped
-        .at(0)
-        .getKey()
-        .duration()
-    ).toBe(1000 * 60 * 5);
-    expect(
-      remapped
-        .at(0)
-        .getKey()
-        .mid()
-        .getTime()
-    ).toBe(1400425951000);
-    expect(remapped.at(0).get("a")).toBe(100);
-    expect(remapped.at(0).get("b")).toBe(200);
-  });
-
-  it("can remap keys of a TimeSeries using mapKeys() from indexes to times", () => {
-    const series = indexedSeries({
-      name: "series",
-      columns: ["index", "c", "d"],
-      points: [
-        ["1d-1234", 100, 200],
-        ["1d-1235", 300, 400],
-        ["1d-1236", 800, 900]
-      ]
+        expect(ts.at(0).get("in")).toBe(34);
+        expect(ts.at(0).get("out")).toBe(52);
+        expect(ts.size()).toBe(timeseries.size());
     });
 
-    const remapped = series.mapKeys<Time>((idx: Index) =>
-      idx.toTime(TimeAlignment.End)
-    );
+    it("can run a flat map over the TimeSeries", () => {
+        const series = timeSeries({
+            name: "Map Traffic",
+            columns: ["time", "NASA_north", "NASA_south"],
+            points: [
+                [1400425951000, { in: 100, out: 200 }, { in: 145, out: 135 }],
+                [1400425952000, { in: 200, out: 400 }, { in: 146, out: 142 }],
+                [1400425953000, { in: 300, out: 600 }, { in: 147, out: 158 }],
+                [1400425954000, { in: 400, out: 800 }, { in: 155, out: 175, other: 1 }]
+            ]
+        });
+        const split = series.flatMap(e =>
+            Immutable.List([e.setData(e.get("NASA_north")), e.setData(e.get("NASA_south"))])
+        );
 
-    expect(
-      remapped
-        .at(0)
-        .getKey()
-        .timestamp()
-        .getTime()
-    ).toBe(106704000000);
-    expect(remapped.at(0).get("c")).toBe(100);
-    expect(remapped.at(0).get("d")).toBe(200);
-  });
+        expect(split.size()).toBe(8);
+        expect(split.at(0).get("in")).toBe(100);
+        expect(split.at(0).get("out")).toBe(200);
+        expect(split.at(0).get("other")).toBeUndefined();
+        expect(split.at(1).get("in")).toBe(145);
+        expect(split.at(1).get("out")).toBe(135);
+        expect(split.at(1).get("other")).toBeUndefined();
+        expect(split.at(7).get("in")).toBe(155);
+        expect(split.at(7).get("out")).toBe(175);
+        expect(split.at(7).get("other")).toBe(1);
+    });
+
+    it("can remap keys of a TimeSeries using mapKeys() from times to timeranges", () => {
+        const series = timeSeries({
+            name: "series",
+            columns: ["time", "a", "b"],
+            points: [
+                [1400425951000, 100, 200],
+                [1400425952000, 300, 400],
+                [1400425953000, 800, 900]
+            ]
+        });
+        const remapped = series.mapKeys(t => t.toTimeRange(duration("5m"), TimeAlignment.Middle));
+
+        expect(remapped.size()).toBe(3);
+        expect(
+            remapped
+                .at(0)
+                .getKey()
+                .duration()
+        ).toBe(1000 * 60 * 5);
+        expect(
+            remapped
+                .at(0)
+                .getKey()
+                .mid()
+                .getTime()
+        ).toBe(1400425951000);
+        expect(remapped.at(0).get("a")).toBe(100);
+        expect(remapped.at(0).get("b")).toBe(200);
+    });
+
+    it("can remap keys of a TimeSeries using mapKeys() from indexes to times", () => {
+        const series = indexedSeries({
+            name: "series",
+            columns: ["index", "c", "d"],
+            points: [["1d-1234", 100, 200], ["1d-1235", 300, 400], ["1d-1236", 800, 900]]
+        });
+
+        const remapped = series.mapKeys<Time>((idx: Index) => idx.toTime(TimeAlignment.End));
+
+        expect(
+            remapped
+                .at(0)
+                .getKey()
+                .timestamp()
+                .getTime()
+        ).toBe(106704000000);
+        expect(remapped.at(0).get("c")).toBe(100);
+        expect(remapped.at(0).get("d")).toBe(200);
+    });
 });
 
 describe("Rollups", () => {
-  it("can generate 1 day fixed window averages over a TimeSeries", () => {
-    const timeseries = timeSeries(sept2014Data);
-    const everyDay = window(duration("1d"));
-    const dailyAvg = timeseries.fixedWindowRollup({
-      window: everyDay,
-      aggregation: { value: ["value", avg()] }
+    it("can generate 1 day fixed window averages over a TimeSeries", () => {
+        const timeseries = timeSeries(sept2014Data);
+        const everyDay = window(duration("1d"));
+        const dailyAvg = timeseries.fixedWindowRollup({
+            window: everyDay,
+            aggregation: { value: ["value", avg()] }
+        });
+
+        expect(dailyAvg.size()).toBe(5);
+        expect(dailyAvg.at(0).get()).toBe(46.875);
+        expect(dailyAvg.at(2).get()).toBe(54.083333333333336);
+        expect(dailyAvg.at(4).get()).toBe(51.85);
     });
 
-    expect(dailyAvg.size()).toBe(5);
-    expect(dailyAvg.at(0).get()).toBe(46.875);
-    expect(dailyAvg.at(2).get()).toBe(54.083333333333336);
-    expect(dailyAvg.at(4).get()).toBe(51.85);
-  });
+    it("can make Collections for each day in the TimeSeries", () => {
+        const timeseries = timeSeries(sept2014Data);
+        const eachDay = window(duration("1d"));
+        const collections = timeseries.collectByWindow({ window: eachDay });
 
-  it("can make Collections for each day in the TimeSeries", () => {
-    const timeseries = timeSeries(sept2014Data);
-    const eachDay = window(duration("1d"));
-    const collections = timeseries.collectByWindow({ window: eachDay });
+        expect(collections["1d-16314"].size()).toBe(24);
+        expect(collections["1d-16318"].size()).toBe(20);
+    });
 
-    expect(collections["1d-16314"].size()).toBe(24);
-    expect(collections["1d-16318"].size()).toBe(20);
-  });
+    it("can correctly use atTime()", () => {
+        const t = new Date(1476803711641);
 
-  it("can correctly use atTime()", () => {
-    const t = new Date(1476803711641);
+        let c = new Collection();
+        c = c.addEvent(event(time(t), Immutable.Map({ value: 2 })));
 
-    let c = new Collection();
-    c = c.addEvent(event(time(t), Immutable.Map({ value: 2 })));
+        // Test bisect to get element 0
+        const ts = new TimeSeries({ name: "coll", collection: c });
+        const bisect = ts.bisect(t);
+        expect(bisect).toEqual(0);
+        expect(ts.at(bisect).get()).toEqual(2);
 
-    // Test bisect to get element 0
-    const ts = new TimeSeries({ name: "coll", collection: c });
-    const bisect = ts.bisect(t);
-    expect(bisect).toEqual(0);
-    expect(ts.at(bisect).get()).toEqual(2);
-
-    // Test atTime to get element 0
-    expect(ts.atTime(t).get()).toEqual(2);
-  });
+        // Test atTime to get element 0
+        expect(ts.atTime(t).get()).toEqual(2);
+    });
 });

--- a/packages/pond/tslint.json
+++ b/packages/pond/tslint.json
@@ -1,36 +1,13 @@
 {
-    "extends": "tslint:recommended",
-    "rules": {
-        "max-line-length": [
-            true,
-            100
-        ],
-        "member-access": false,
-        "variable-name": [
-            true,
-            "ban-keywords",
-            "check-format",
-            "allow-leading-underscore"
-        ],
-        "object-literal-sort-keys": false,
-        "no-require-imports": false,
-        "interface-name": [
-            true,
-            "never-prefix"
-        ],
-        "arrow-parens": [
-            true,
-            "ban-single-arg-parens"
-        ],
-        "trailing-comma": [
-            false,
-            {
-                "multiline": "never",
-                "singleline": "never"
-            }
-        ],
-        "semicolon": [
-            false
-        ]
-    }
+  "defaultSeverity": "error",
+  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "jsRules": {},
+  "rules": {
+    "no-console": false,
+    "interface-name": false,
+    "no-submodule-imports": false,
+    "no-object-literal-type-assertion": false,
+    "object-literal-sort-keys": false
+  },
+  "rulesDirectory": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,690 @@
 # yarn lockfile v1
 
 
+"@lerna/add@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.3.tgz#f4c1674839780e458f0426d4f7b6d0a77b9a2ae9"
+  integrity sha512-T3/Lsbo9ZFq+vL3ssaHxA8oKikZAPTJTGFe4CRuQgWCDd/M61+51jeWsngdaHpwzSSRDRjxg8fJTG10y10pnfA==
+  dependencies:
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/npm-conf" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    dedent "^0.7.0"
+    npm-package-arg "^6.1.0"
+    p-map "^1.2.0"
+    pacote "^9.5.0"
+    semver "^5.5.0"
+
+"@lerna/batch-packages@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/batch-packages/-/batch-packages-3.13.0.tgz#697fde5be28822af9d9dca2f750250b90a89a000"
+  integrity sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==
+  dependencies:
+    "@lerna/package-graph" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    npmlog "^4.1.2"
+
+"@lerna/bootstrap@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/bootstrap/-/bootstrap-3.13.3.tgz#a0e5e466de5c100b49d558d39139204fc4db5c95"
+  integrity sha512-2XzijnLHRZOVQh8pwS7+5GR3cG4uh+EiLrWOishCq2TVzkqgjaS3GGBoef7KMCXfWHoLqAZRr/jEdLqfETLVqg==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/has-npm-version" "3.13.3"
+    "@lerna/npm-install" "3.13.3"
+    "@lerna/package-graph" "3.13.0"
+    "@lerna/pulse-till-done" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
+    "@lerna/run-lifecycle" "3.13.0"
+    "@lerna/run-parallel-batches" "3.13.0"
+    "@lerna/symlink-binary" "3.13.0"
+    "@lerna/symlink-dependencies" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    dedent "^0.7.0"
+    get-port "^3.2.0"
+    multimatch "^2.1.0"
+    npm-package-arg "^6.1.0"
+    npmlog "^4.1.2"
+    p-finally "^1.0.0"
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+    p-waterfall "^1.0.0"
+    read-package-tree "^5.1.6"
+    semver "^5.5.0"
+
+"@lerna/changed@3.13.4":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@lerna/changed/-/changed-3.13.4.tgz#c69d8a079999e49611dd58987f08437baee81ad4"
+  integrity sha512-9lfOyRVObasw6L/z7yCSfsEl1QKy0Eamb8t2Krg1deIoAt+cE3JXOdGGC1MhOSli+7f/U9LyLXjJzIOs/pc9fw==
+  dependencies:
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/listable" "3.13.0"
+    "@lerna/output" "3.13.0"
+    "@lerna/version" "3.13.4"
+
+"@lerna/check-working-tree@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/check-working-tree/-/check-working-tree-3.13.3.tgz#836a3ffd4413a29aca92ccca4a115e4f97109992"
+  integrity sha512-LoGZvTkne+V1WpVdCTU0XNzFKsQa2AiAFKksGRT0v8NQj6VAPp0jfVYDayTqwaWt2Ne0OGKOFE79Y5LStOuhaQ==
+  dependencies:
+    "@lerna/describe-ref" "3.13.3"
+    "@lerna/validation-error" "3.13.0"
+
+"@lerna/child-process@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/child-process/-/child-process-3.13.3.tgz#6c084ee5cca9fc9e04d6bf4fc3f743ed26ff190c"
+  integrity sha512-3/e2uCLnbU+bydDnDwyadpOmuzazS01EcnOleAnuj9235CU2U97DH6OyoG1EW/fU59x11J+HjIqovh5vBaMQjQ==
+  dependencies:
+    chalk "^2.3.1"
+    execa "^1.0.0"
+    strong-log-transformer "^2.0.0"
+
+"@lerna/clean@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/clean/-/clean-3.13.3.tgz#5673a1238e0712d31711e7e4e8cb9641891daaea"
+  integrity sha512-xmNauF1PpmDaKdtA2yuRc23Tru4q7UMO6yB1a/TTwxYPYYsAWG/CBK65bV26J7x4RlZtEv06ztYGMa9zh34UXA==
+  dependencies:
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/prompt" "3.13.0"
+    "@lerna/pulse-till-done" "3.13.0"
+    "@lerna/rimraf-dir" "3.13.3"
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+    p-waterfall "^1.0.0"
+
+"@lerna/cli@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/cli/-/cli-3.13.0.tgz#3d7b357fdd7818423e9681a7b7f2abd106c8a266"
+  integrity sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==
+  dependencies:
+    "@lerna/global-options" "3.13.0"
+    dedent "^0.7.0"
+    npmlog "^4.1.2"
+    yargs "^12.0.1"
+
+"@lerna/collect-updates@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/collect-updates/-/collect-updates-3.13.3.tgz#616648da59f0aff4a8e60257795cc46ca6921edd"
+  integrity sha512-sTpALOAxli/ZS+Mjq6fbmjU9YXqFJ2E4FrE1Ijl4wPC5stXEosg2u0Z1uPY+zVKdM+mOIhLxPVdx83rUgRS+Cg==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
+    minimatch "^3.0.4"
+    npmlog "^4.1.2"
+    slash "^1.0.0"
+
+"@lerna/command@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/command/-/command-3.13.3.tgz#5b20b3f507224573551039e0460bc36c39f7e9d1"
+  integrity sha512-WHFIQCubJV0T8gSLRNr6exZUxTswrh+iAtJCb86SE0Sa+auMPklE8af7w2Yck5GJfewmxSjke3yrjNxQrstx7w==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/package-graph" "3.13.0"
+    "@lerna/project" "3.13.1"
+    "@lerna/validation-error" "3.13.0"
+    "@lerna/write-log-file" "3.13.0"
+    dedent "^0.7.0"
+    execa "^1.0.0"
+    is-ci "^1.0.10"
+    lodash "^4.17.5"
+    npmlog "^4.1.2"
+
+"@lerna/conventional-commits@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz#877aa225ca34cca61c31ea02a5a6296af74e1144"
+  integrity sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==
+  dependencies:
+    "@lerna/validation-error" "3.13.0"
+    conventional-changelog-angular "^5.0.3"
+    conventional-changelog-core "^3.1.6"
+    conventional-recommended-bump "^4.0.4"
+    fs-extra "^7.0.0"
+    get-stream "^4.0.0"
+    npm-package-arg "^6.1.0"
+    npmlog "^4.1.2"
+    pify "^3.0.0"
+    semver "^5.5.0"
+
+"@lerna/create-symlink@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/create-symlink/-/create-symlink-3.13.0.tgz#e01133082fe040779712c960683cb3a272b67809"
+  integrity sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==
+  dependencies:
+    cmd-shim "^2.0.2"
+    fs-extra "^7.0.0"
+    npmlog "^4.1.2"
+
+"@lerna/create@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-3.13.3.tgz#6ded142c54b7f3cea86413c3637b067027b7f55d"
+  integrity sha512-4M5xT1AyUMwt1gCDph4BfW3e6fZmt0KjTa3FoXkUotf/w/eqTsc2IQ+ULz2+gOFQmtuNbqIZEOK3J4P9ArJJ/A==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/npm-conf" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    camelcase "^5.0.0"
+    dedent "^0.7.0"
+    fs-extra "^7.0.0"
+    globby "^8.0.1"
+    init-package-json "^1.10.3"
+    npm-package-arg "^6.1.0"
+    p-reduce "^1.0.0"
+    pacote "^9.5.0"
+    pify "^3.0.0"
+    semver "^5.5.0"
+    slash "^1.0.0"
+    validate-npm-package-license "^3.0.3"
+    validate-npm-package-name "^3.0.0"
+    whatwg-url "^7.0.0"
+
+"@lerna/describe-ref@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/describe-ref/-/describe-ref-3.13.3.tgz#13318513613f6a407d37fc5dc025ec2cfb705606"
+  integrity sha512-5KcLTvjdS4gU5evW8ESbZ0BF44NM5HrP3dQNtWnOUSKJRgsES8Gj0lq9AlB2+YglZfjEftFT03uOYOxnKto4Uw==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    npmlog "^4.1.2"
+
+"@lerna/diff@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/diff/-/diff-3.13.3.tgz#883cb3a83a956dbfc2c17bc9a156468a5d3fae17"
+  integrity sha512-/DRS2keYbnKaAC+5AkDyZRGkP/kT7v1GlUS0JGZeiRDPQ1H6PzhX09EgE5X6nj0Ytrm0sUasDeN++CDVvgaI+A==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/validation-error" "3.13.0"
+    npmlog "^4.1.2"
+
+"@lerna/exec@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/exec/-/exec-3.13.3.tgz#5d2eda3f6e584f2f15b115e8a4b5bc960ba5de85"
+  integrity sha512-c0bD4XqM96CTPV8+lvkxzE7mkxiFyv/WNM4H01YvvbFAJzk+S4Y7cBtRkIYFTfkFZW3FLo8pEgtG1ONtIdM+tg==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/run-parallel-batches" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+
+"@lerna/filter-options@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-options/-/filter-options-3.13.3.tgz#aa42a4ab78837b8a6c4278ba871d27e92d77c54f"
+  integrity sha512-DbtQX4eRgrBz1wCFWRP99JBD7ODykYme9ykEK79+RrKph40znhJQRlLg4idogj6IsUEzwo1OHjihCzSfnVo6Cg==
+  dependencies:
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/filter-packages" "3.13.0"
+    dedent "^0.7.0"
+
+"@lerna/filter-packages@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/filter-packages/-/filter-packages-3.13.0.tgz#f5371249e7e1a15928e5e88c544a242e0162c21c"
+  integrity sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==
+  dependencies:
+    "@lerna/validation-error" "3.13.0"
+    multimatch "^2.1.0"
+    npmlog "^4.1.2"
+
+"@lerna/get-npm-exec-opts@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz#d1b552cb0088199fc3e7e126f914e39a08df9ea5"
+  integrity sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==
+  dependencies:
+    npmlog "^4.1.2"
+
+"@lerna/get-packed@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/get-packed/-/get-packed-3.13.0.tgz#335e40d77f3c1855aa248587d3e0b2d8f4b06e16"
+  integrity sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==
+  dependencies:
+    fs-extra "^7.0.0"
+    ssri "^6.0.1"
+    tar "^4.4.8"
+
+"@lerna/github-client@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/github-client/-/github-client-3.13.3.tgz#bcf9b4ff40bdd104cb40cd257322f052b41bb9ce"
+  integrity sha512-fcJkjab4kX0zcLLSa/DCUNvU3v8wmy2c1lhdIbL7s7gABmDcV0QZq93LhnEee3VkC9UpnJ6GKG4EkD7eIifBnA==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@octokit/plugin-enterprise-rest" "^2.1.1"
+    "@octokit/rest" "^16.16.0"
+    git-url-parse "^11.1.2"
+    npmlog "^4.1.2"
+
+"@lerna/global-options@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/global-options/-/global-options-3.13.0.tgz#217662290db06ad9cf2c49d8e3100ee28eaebae1"
+  integrity sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==
+
+"@lerna/has-npm-version@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/has-npm-version/-/has-npm-version-3.13.3.tgz#167e3f602a2fb58f84f93cf5df39705ca6432a2d"
+  integrity sha512-mQzoghRw4dBg0R9FFfHrj0TH0glvXyzdEZmYZ8Isvx5BSuEEwpsryoywuZSdppcvLu8o7NAdU5Tac8cJ/mT52w==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    semver "^5.5.0"
+
+"@lerna/import@3.13.4":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@lerna/import/-/import-3.13.4.tgz#e9a1831b8fed33f3cbeab3b84c722c9371a2eaf7"
+  integrity sha512-dn6eNuPEljWsifBEzJ9B6NoaLwl/Zvof7PBUPA4hRyRlqG5sXRn6F9DnusMTovvSarbicmTURbOokYuotVWQQA==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/prompt" "3.13.0"
+    "@lerna/pulse-till-done" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    dedent "^0.7.0"
+    fs-extra "^7.0.0"
+    p-map-series "^1.0.0"
+
+"@lerna/init@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/init/-/init-3.13.3.tgz#ebd522fee9b9d7d3b2dacb0261eaddb4826851ff"
+  integrity sha512-bK/mp0sF6jT0N+c+xrbMCqN4xRoiZCXQzlYsyACxPK99KH/mpHv7hViZlTYUGlYcymtew6ZC770miv5A9wF9hA==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/command" "3.13.3"
+    fs-extra "^7.0.0"
+    p-map "^1.2.0"
+    write-json-file "^2.3.0"
+
+"@lerna/link@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/link/-/link-3.13.3.tgz#11124d4a0c8d0b79752fbda3babedfd62dd57847"
+  integrity sha512-IHhtdhA0KlIdevCsq6WHkI2rF3lHWHziJs2mlrEWAKniVrFczbELON1KJAgdJS1k3kAP/WeWVqmIYZ2hJDxMvg==
+  dependencies:
+    "@lerna/command" "3.13.3"
+    "@lerna/package-graph" "3.13.0"
+    "@lerna/symlink-dependencies" "3.13.0"
+    p-map "^1.2.0"
+    slash "^1.0.0"
+
+"@lerna/list@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/list/-/list-3.13.3.tgz#fa93864d43cadeb4cd540a4e78a52886c57dbe74"
+  integrity sha512-rLRDsBCkydMq2FL6WY1J/elvnXIjxxRtb72lfKHdvDEqVdquT5Qgt9ci42hwjmcocFwWcFJgF6BZozj5pbc13A==
+  dependencies:
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/listable" "3.13.0"
+    "@lerna/output" "3.13.0"
+
+"@lerna/listable@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/listable/-/listable-3.13.0.tgz#babc18442c590b549cf0966d20d75fea066598d4"
+  integrity sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    chalk "^2.3.1"
+    columnify "^1.5.4"
+
+"@lerna/log-packed@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/log-packed/-/log-packed-3.13.0.tgz#497b5f692a8d0e3f669125da97b0dadfd9e480f3"
+  integrity sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==
+  dependencies:
+    byte-size "^4.0.3"
+    columnify "^1.5.4"
+    has-unicode "^2.0.1"
+    npmlog "^4.1.2"
+
+"@lerna/npm-conf@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-conf/-/npm-conf-3.13.0.tgz#6b434ed75ff757e8c14381b9bbfe5d5ddec134a7"
+  integrity sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==
+  dependencies:
+    config-chain "^1.1.11"
+    pify "^3.0.0"
+
+"@lerna/npm-dist-tag@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz#49ecbe0e82cbe4ad4a8ea6de112982bf6c4e6cd4"
+  integrity sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.9.0"
+    npmlog "^4.1.2"
+
+"@lerna/npm-install@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-install/-/npm-install-3.13.3.tgz#9b09852732e51c16d2e060ff2fd8bfbbb49cf7ba"
+  integrity sha512-7Jig9MLpwAfcsdQ5UeanAjndChUjiTjTp50zJ+UZz4CbIBIDhoBehvNMTCL2G6pOEC7sGEg6sAqJINAqred6Tg==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/get-npm-exec-opts" "3.13.0"
+    fs-extra "^7.0.0"
+    npm-package-arg "^6.1.0"
+    npmlog "^4.1.2"
+    signal-exit "^3.0.2"
+    write-pkg "^3.1.0"
+
+"@lerna/npm-publish@3.13.2":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-publish/-/npm-publish-3.13.2.tgz#ad713ca6f91a852687d7d0e1bda7f9c66df21768"
+  integrity sha512-HMucPyEYZfom5tRJL4GsKBRi47yvSS2ynMXYxL3kO0ie+j9J7cb0Ir8NmaAMEd3uJWJVFCPuQarehyfTDZsSxg==
+  dependencies:
+    "@lerna/run-lifecycle" "3.13.0"
+    figgy-pudding "^3.5.1"
+    fs-extra "^7.0.0"
+    libnpmpublish "^1.1.1"
+    npm-package-arg "^6.1.0"
+    npmlog "^4.1.2"
+    pify "^3.0.0"
+    read-package-json "^2.0.13"
+
+"@lerna/npm-run-script@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/npm-run-script/-/npm-run-script-3.13.3.tgz#9bb6389ed70cd506905d6b05b6eab336b4266caf"
+  integrity sha512-qR4o9BFt5hI8Od5/DqLalOJydnKpiQFEeN0h9xZi7MwzuX1Ukwh3X22vqsX4YRbipIelSFtrDzleNVUm5jj0ow==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    "@lerna/get-npm-exec-opts" "3.13.0"
+    npmlog "^4.1.2"
+
+"@lerna/output@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/output/-/output-3.13.0.tgz#3ded7cc908b27a9872228a630d950aedae7a4989"
+  integrity sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==
+  dependencies:
+    npmlog "^4.1.2"
+
+"@lerna/pack-directory@3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@lerna/pack-directory/-/pack-directory-3.13.1.tgz#5ad4d0945f86a648f565e24d53c1e01bb3a912d1"
+  integrity sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==
+  dependencies:
+    "@lerna/get-packed" "3.13.0"
+    "@lerna/package" "3.13.0"
+    "@lerna/run-lifecycle" "3.13.0"
+    figgy-pudding "^3.5.1"
+    npm-packlist "^1.4.1"
+    npmlog "^4.1.2"
+    tar "^4.4.8"
+    temp-write "^3.4.0"
+
+"@lerna/package-graph@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/package-graph/-/package-graph-3.13.0.tgz#607062f8d2ce22b15f8d4a0623f384736e67f760"
+  integrity sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==
+  dependencies:
+    "@lerna/validation-error" "3.13.0"
+    npm-package-arg "^6.1.0"
+    semver "^5.5.0"
+
+"@lerna/package@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/package/-/package-3.13.0.tgz#4baeebc49a57fc9b31062cc59f5ee38384429fc8"
+  integrity sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==
+  dependencies:
+    load-json-file "^4.0.0"
+    npm-package-arg "^6.1.0"
+    write-pkg "^3.1.0"
+
+"@lerna/project@3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@lerna/project/-/project-3.13.1.tgz#bce890f60187bd950bcf36c04b5260642e295e79"
+  integrity sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==
+  dependencies:
+    "@lerna/package" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    cosmiconfig "^5.1.0"
+    dedent "^0.7.0"
+    dot-prop "^4.2.0"
+    glob-parent "^3.1.0"
+    globby "^8.0.1"
+    load-json-file "^4.0.0"
+    npmlog "^4.1.2"
+    p-map "^1.2.0"
+    resolve-from "^4.0.0"
+    write-json-file "^2.3.0"
+
+"@lerna/prompt@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/prompt/-/prompt-3.13.0.tgz#53571462bb3f5399cc1ca6d335a411fe093426a5"
+  integrity sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==
+  dependencies:
+    inquirer "^6.2.0"
+    npmlog "^4.1.2"
+
+"@lerna/publish@3.13.4":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@lerna/publish/-/publish-3.13.4.tgz#25b678c285110897a7fc5198a35bdfa9db7f9cc1"
+  integrity sha512-v03pabiPlqCDwX6cVNis1PDdT6/jBgkVb5Nl4e8wcJXevIhZw3ClvtI94gSZu/wdoVFX0RMfc8QBVmaimSO0qg==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/describe-ref" "3.13.3"
+    "@lerna/log-packed" "3.13.0"
+    "@lerna/npm-conf" "3.13.0"
+    "@lerna/npm-dist-tag" "3.13.0"
+    "@lerna/npm-publish" "3.13.2"
+    "@lerna/output" "3.13.0"
+    "@lerna/pack-directory" "3.13.1"
+    "@lerna/prompt" "3.13.0"
+    "@lerna/pulse-till-done" "3.13.0"
+    "@lerna/run-lifecycle" "3.13.0"
+    "@lerna/run-parallel-batches" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    "@lerna/version" "3.13.4"
+    figgy-pudding "^3.5.1"
+    fs-extra "^7.0.0"
+    libnpmaccess "^3.0.1"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.9.0"
+    npmlog "^4.1.2"
+    p-finally "^1.0.0"
+    p-map "^1.2.0"
+    p-pipe "^1.2.0"
+    p-reduce "^1.0.0"
+    pacote "^9.5.0"
+    semver "^5.5.0"
+
+"@lerna/pulse-till-done@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz#c8e9ce5bafaf10d930a67d7ed0ccb5d958fe0110"
+  integrity sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==
+  dependencies:
+    npmlog "^4.1.2"
+
+"@lerna/resolve-symlink@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz#3e6809ef53b63fe914814bfa071cd68012e22fbb"
+  integrity sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==
+  dependencies:
+    fs-extra "^7.0.0"
+    npmlog "^4.1.2"
+    read-cmd-shim "^1.0.1"
+
+"@lerna/rimraf-dir@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/rimraf-dir/-/rimraf-dir-3.13.3.tgz#3a8e71317fde853893ef0262bc9bba6a180b7227"
+  integrity sha512-d0T1Hxwu3gpYVv73ytSL+/Oy8JitsmvOYUR5ouRSABsmqS7ZZCh5t6FgVDDGVXeuhbw82+vuny1Og6Q0k4ilqw==
+  dependencies:
+    "@lerna/child-process" "3.13.3"
+    npmlog "^4.1.2"
+    path-exists "^3.0.0"
+    rimraf "^2.6.2"
+
+"@lerna/run-lifecycle@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz#d8835ee83425edee40f687a55f81b502354d3261"
+  integrity sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==
+  dependencies:
+    "@lerna/npm-conf" "3.13.0"
+    figgy-pudding "^3.5.1"
+    npm-lifecycle "^2.1.0"
+    npmlog "^4.1.2"
+
+"@lerna/run-parallel-batches@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz#0276bb4e7cd0995297db82d134ca2bd08d63e311"
+  integrity sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==
+  dependencies:
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+
+"@lerna/run@3.13.3":
+  version "3.13.3"
+  resolved "https://registry.yarnpkg.com/@lerna/run/-/run-3.13.3.tgz#0781c82d225ef6e85e28d3e763f7fc090a376a21"
+  integrity sha512-ygnLIfIYS6YY1JHWOM4CsdZiY8kTYPsDFOLAwASlRnlAXF9HiMT08GFXLmMHIblZJ8yJhsM2+QgraCB0WdxzOQ==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    "@lerna/command" "3.13.3"
+    "@lerna/filter-options" "3.13.3"
+    "@lerna/npm-run-script" "3.13.3"
+    "@lerna/output" "3.13.0"
+    "@lerna/run-parallel-batches" "3.13.0"
+    "@lerna/timer" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    p-map "^1.2.0"
+
+"@lerna/symlink-binary@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz#36a9415d468afcb8105750296902f6f000a9680d"
+  integrity sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==
+  dependencies:
+    "@lerna/create-symlink" "3.13.0"
+    "@lerna/package" "3.13.0"
+    fs-extra "^7.0.0"
+    p-map "^1.2.0"
+
+"@lerna/symlink-dependencies@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz#76c23ecabda7824db98a0561364f122b457509cf"
+  integrity sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==
+  dependencies:
+    "@lerna/create-symlink" "3.13.0"
+    "@lerna/resolve-symlink" "3.13.0"
+    "@lerna/symlink-binary" "3.13.0"
+    fs-extra "^7.0.0"
+    p-finally "^1.0.0"
+    p-map "^1.2.0"
+    p-map-series "^1.0.0"
+
+"@lerna/timer@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/timer/-/timer-3.13.0.tgz#bcd0904551db16e08364d6c18e5e2160fc870781"
+  integrity sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==
+
+"@lerna/validation-error@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/validation-error/-/validation-error-3.13.0.tgz#c86b8f07c5ab9539f775bd8a54976e926f3759c3"
+  integrity sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==
+  dependencies:
+    npmlog "^4.1.2"
+
+"@lerna/version@3.13.4":
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/@lerna/version/-/version-3.13.4.tgz#ea23b264bebda425ccbfcdcd1de13ef45a390e59"
+  integrity sha512-pptWUEgN/lUTQZu34+gfH1g4Uhs7TDKRcdZY9A4T9k6RTOwpKC2ceLGiXdeR+ZgQJAey2C4qiE8fo5Z6Rbc6QA==
+  dependencies:
+    "@lerna/batch-packages" "3.13.0"
+    "@lerna/check-working-tree" "3.13.3"
+    "@lerna/child-process" "3.13.3"
+    "@lerna/collect-updates" "3.13.3"
+    "@lerna/command" "3.13.3"
+    "@lerna/conventional-commits" "3.13.0"
+    "@lerna/github-client" "3.13.3"
+    "@lerna/output" "3.13.0"
+    "@lerna/prompt" "3.13.0"
+    "@lerna/run-lifecycle" "3.13.0"
+    "@lerna/validation-error" "3.13.0"
+    chalk "^2.3.1"
+    dedent "^0.7.0"
+    minimatch "^3.0.4"
+    npmlog "^4.1.2"
+    p-map "^1.2.0"
+    p-pipe "^1.2.0"
+    p-reduce "^1.0.0"
+    p-waterfall "^1.0.0"
+    semver "^5.5.0"
+    slash "^1.0.0"
+    temp-write "^3.4.0"
+
+"@lerna/write-log-file@3.13.0":
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/@lerna/write-log-file/-/write-log-file-3.13.0.tgz#b78d9e4cfc1349a8be64d91324c4c8199e822a26"
+  integrity sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==
+  dependencies:
+    npmlog "^4.1.2"
+    write-file-atomic "^2.3.0"
+
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  integrity sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
+"@nodelib/fs.stat@^1.1.2":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
+  integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@octokit/endpoint@^4.0.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-4.2.2.tgz#4ff11382bad89c7e01030a1e62d5e9d13c2402b0"
+  integrity sha512-5IZjkUNhx5q0IRN7Juwf5A+Lu2qAso7ULST7C1P2mbGHePuCOk936Stcl/5GdJpB3ovD8M6/Lv3xra6Mn0IKNQ==
+  dependencies:
+    deepmerge "3.2.0"
+    is-plain-object "^3.0.0"
+    universal-user-agent "^2.0.1"
+    url-template "^2.0.8"
+
+"@octokit/plugin-enterprise-rest@^2.1.1":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz#c0e22067a043e19f96ff9c7832e2a3019f9be75c"
+  integrity sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw==
+
+"@octokit/request@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-3.0.1.tgz#21e888c6dce80566ec69477360bab79f2f14861f"
+  integrity sha512-aH61OVkMKMofGW/go2x4mJ44X4U/JF8xsiFFictwkZYtz0psE8OPKpsP2TZBZaJoCg2wmeTyEgqGfY+veg0hGQ==
+  dependencies:
+    "@octokit/endpoint" "^4.0.0"
+    deprecation "^1.0.1"
+    is-plain-object "^3.0.0"
+    node-fetch "^2.3.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.1"
+
+"@octokit/rest@^16.16.0":
+  version "16.25.1"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.1.tgz#60a3171018dbc4feb23d1bf9805a06aad106d53e"
+  integrity sha512-a1Byzjj07OMQNUQDP5Ng/rChaI7aq6TNMY1ZFf8+zCVEEtYzCgcmrFG9BDerFbLPPKGQ5TAeRRFyLujUUN1HIg==
+  dependencies:
+    "@octokit/request" "3.0.1"
+    atob-lite "^2.0.0"
+    before-after-hook "^1.4.0"
+    btoa-lite "^1.0.0"
+    deprecation "^1.0.1"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    lodash.uniq "^4.5.0"
+    octokit-pagination-methods "^1.1.0"
+    once "^1.4.0"
+    universal-user-agent "^2.0.0"
+    url-template "^2.0.8"
+
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -9,29 +693,47 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-add-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
-
-align-text@^0.1.1, align-text@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+JSONStream@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
   dependencies:
-    kind-of "^3.0.2"
-    longest "^1.0.1"
-    repeat-string "^1.5.2"
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
+  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
-ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+agentkeepalive@^3.4.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
+  integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
+  dependencies:
+    humanize-ms "^1.2.1"
+
+ajv@^6.5.5:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -41,23 +743,31 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-styles@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
-
-app-root-path@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 aproba@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
+
+aproba@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+aproba@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
+  integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -67,10 +777,36 @@ are-we-there-yet@~1.1.2:
     readable-stream "^2.0.6"
 
 argparse@^1.0.7:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+  integrity sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
+
+arr-flatten@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+  integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-differ@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
+  integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+
+array-differ@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
+  integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -80,7 +816,7 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
 
-array-union@^1.0.1:
+array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
   dependencies:
@@ -90,13 +826,103 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
-async@^1.4.0, async@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
+  integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+arrify@^1.0.0, arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
+asn1@~0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
+  integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+atob-lite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
+  integrity sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=
+
+atob@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
+  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  integrity sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+  dependencies:
+    tweetnacl "^0.14.3"
+
+before-after-hook@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
+  integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
+  dependencies:
+    inherits "~2.0.0"
+
+bluebird@^3.5.1, bluebird@^3.5.3:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -105,13 +931,108 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+
+byte-size@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/byte-size/-/byte-size-4.0.4.tgz#29d381709f41aae0d89c631f1c81aec88cd40b23"
+  integrity sha512-82RPeneC6nqCdSwCX2hZUz3JPOvN5at/nTEw/CMf05Smu3Hrpo9Psb7LjN+k+XndNArG1EY8L4+BM3aTM4BCvw==
+
+cacache@^11.0.1, cacache@^11.3.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-11.3.2.tgz#2d81e308e3d258ca38125b676b98b2ac9ce69bfa"
+  integrity sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
+  dependencies:
+    bluebird "^3.5.3"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.3"
+    graceful-fs "^4.1.15"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.2"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  integrity sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
+
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+  integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
+
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
 camelcase-keys@^2.0.0:
   version "2.1.0"
@@ -120,9 +1041,14 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
-camelcase@^1.0.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -132,44 +1058,53 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
-capture-stack-trace@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-center-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
-  dependencies:
-    align-text "^0.1.3"
-    lazy-cache "^1.0.3"
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
+    ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
+    supports-color "^5.3.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
 
-cli-cursor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
   dependencies:
-    restore-cursor "^1.0.1"
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -177,35 +1112,17 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
-
-cli-truncate@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
-  dependencies:
-    slice-ansi "0.0.4"
-    string-width "^1.0.1"
-
 cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
-cliui@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+cliui@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
+  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
   dependencies:
-    center-align "^0.1.1"
-    right-align "^0.1.1"
-    wordwrap "0.0.2"
-
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 clone@^1.0.2:
@@ -222,6 +1139,14 @@ cmd-shim@^2.0.2:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  integrity sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
 
 color-convert@^1.9.0:
   version "1.9.0"
@@ -240,13 +1165,17 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-command-join@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  dependencies:
+    delayed-stream "~1.0.0"
 
-commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+commander@~2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 compare-func@^1.3.1:
   version "1.3.2"
@@ -255,195 +1184,178 @@ compare-func@^1.3.1:
     array-ify "^1.0.0"
     dot-prop "^3.0.0"
 
+component-emitter@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
+  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+concat-stream@^1.5.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
   dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
+
+config-chain@^1.1.11:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
+  integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-conventional-changelog-angular@^1.5.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.5.3.tgz#ff0dd01d740e35bfdbc3f02dfea13cf0d96f0b82"
+conventional-changelog-angular@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz#299fdd43df5a1f095283ac16aeedfb0a682ecab0"
+  integrity sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==
   dependencies:
     compare-func "^1.3.1"
-    q "^1.4.1"
+    q "^1.5.1"
 
-conventional-changelog-atom@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz#12595ad5267a6937c34cf900281b1c65198a4c63"
+conventional-changelog-core@^3.1.6:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz#de41e6b4a71011a18bcee58e744f6f8f0e7c29c0"
+  integrity sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==
   dependencies:
-    q "^1.4.1"
-
-conventional-changelog-cli@^1.3.2:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.5.tgz#46c51496216b7406588883defa6fac589e9bb31e"
-  dependencies:
-    add-stream "^1.0.0"
-    conventional-changelog "^1.1.7"
-    lodash "^4.1.0"
-    meow "^3.7.0"
-    tempfile "^1.1.1"
-
-conventional-changelog-codemirror@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz#299a4f7147baf350e6c8158fc54954a291c5cc09"
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-core@^1.9.3:
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-1.9.4.tgz#a541e5354f91072f8583b19e34abb9f6e461c367"
-  dependencies:
-    conventional-changelog-writer "^2.0.3"
-    conventional-commits-parser "^2.1.0"
-    dateformat "^1.0.12"
+    conventional-changelog-writer "^4.0.5"
+    conventional-commits-parser "^3.0.2"
+    dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
-    git-raw-commits "^1.3.0"
+    git-raw-commits "2.0.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.2.3"
-    lodash "^4.0.0"
+    git-semver-tags "^2.0.2"
+    lodash "^4.2.1"
     normalize-package-data "^2.3.5"
-    q "^1.4.1"
-    read-pkg "^1.1.0"
-    read-pkg-up "^1.0.1"
-    through2 "^2.0.0"
+    q "^1.5.1"
+    read-pkg "^3.0.0"
+    read-pkg-up "^3.0.0"
+    through2 "^3.0.0"
 
-conventional-changelog-ember@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz#dcd6e4cdc2e6c2b58653cf4d2cb1656a60421929"
-  dependencies:
-    q "^1.4.1"
+conventional-changelog-preset-loader@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz#65bb600547c56d5627d23135154bcd9a907668c4"
+  integrity sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==
 
-conventional-changelog-eslint@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz#2c2a11beb216f80649ba72834180293b687c0662"
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-express@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz#838d9e1e6c9099703b150b9c19aa2d781742bd6c"
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-jquery@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jquery/-/conventional-changelog-jquery-0.1.0.tgz#0208397162e3846986e71273b6c79c5b5f80f510"
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-jscs@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jscs/-/conventional-changelog-jscs-0.1.0.tgz#0479eb443cc7d72c58bf0bcf0ef1d444a92f0e5c"
-  dependencies:
-    q "^1.4.1"
-
-conventional-changelog-jshint@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz#86139bb3ac99899f2b177e9617e09b37d99bcf3a"
+conventional-changelog-writer@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.5.tgz#fb9e384bb294e8e8a9f2568a3f4d1e11953d8641"
+  integrity sha512-g/Myp4MaJ1A+f7Ai+SnVhkcWtaHk6flw0SYN7A+vQ+MTu0+gSovQWs4Pg4NtcNUcIztYQ9YHsoxHP+GGQplI7Q==
   dependencies:
     compare-func "^1.3.1"
-    q "^1.4.1"
-
-conventional-changelog-writer@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz#073b0c39f1cc8fc0fd9b1566e93833f51489c81c"
-  dependencies:
-    compare-func "^1.3.1"
-    conventional-commits-filter "^1.1.1"
-    dateformat "^1.0.11"
-    handlebars "^4.0.2"
+    conventional-commits-filter "^2.0.2"
+    dateformat "^3.0.0"
+    handlebars "^4.1.0"
     json-stringify-safe "^5.0.1"
-    lodash "^4.0.0"
-    meow "^3.3.0"
-    semver "^5.0.1"
+    lodash "^4.2.1"
+    meow "^4.0.0"
+    semver "^5.5.0"
     split "^1.0.0"
-    through2 "^2.0.0"
+    through2 "^3.0.0"
 
-conventional-changelog@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.7.tgz#9151a62b1d8edb2d82711dabf5b7cf71041f82b1"
+conventional-commits-filter@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz#f122f89fbcd5bb81e2af2fcac0254d062d1039c1"
+  integrity sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==
   dependencies:
-    conventional-changelog-angular "^1.5.2"
-    conventional-changelog-atom "^0.1.2"
-    conventional-changelog-codemirror "^0.2.1"
-    conventional-changelog-core "^1.9.3"
-    conventional-changelog-ember "^0.2.9"
-    conventional-changelog-eslint "^0.2.1"
-    conventional-changelog-express "^0.2.1"
-    conventional-changelog-jquery "^0.1.0"
-    conventional-changelog-jscs "^0.1.0"
-    conventional-changelog-jshint "^0.2.1"
-
-conventional-commits-filter@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-1.1.1.tgz#72172319c0c88328a015b30686b55527b3a5e54a"
-  dependencies:
-    is-subset "^0.1.1"
+    lodash.ismatch "^4.4.0"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.1.0.tgz#9b4b7c91124bf2a1a9a2cc1c72760d382cbbb229"
+conventional-commits-parser@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz#1295590dd195f64f53d6f8eb7c41114bb9a60742"
+  integrity sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"
     lodash "^4.2.1"
-    meow "^3.3.0"
+    meow "^4.0.0"
     split2 "^2.0.0"
-    through2 "^2.0.0"
+    through2 "^3.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-recommended-bump@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-1.1.0.tgz#964d4fcc70fb5259d41fa9b39d3df6afdb87d253"
+conventional-recommended-bump@^4.0.4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz#37014fadeda267d0607e2fc81124da840a585127"
+  integrity sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==
   dependencies:
-    concat-stream "^1.4.10"
-    conventional-commits-filter "^1.1.1"
-    conventional-commits-parser "^2.1.0"
-    git-raw-commits "^1.3.0"
-    git-semver-tags "^1.2.3"
-    meow "^3.3.0"
-    object-assign "^4.0.1"
+    concat-stream "^2.0.0"
+    conventional-changelog-preset-loader "^2.1.1"
+    conventional-commits-filter "^2.0.2"
+    conventional-commits-parser "^3.0.2"
+    git-raw-commits "2.0.0"
+    git-semver-tags "^2.0.2"
+    meow "^4.0.0"
+    q "^1.5.1"
 
-core-util-is@~1.0.0:
+copy-concurrently@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
+  integrity sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==
+  dependencies:
+    aproba "^1.1.1"
+    fs-write-stream-atomic "^1.0.8"
+    iferr "^0.1.5"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.0"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+  integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+cosmiconfig@^5.1.0, cosmiconfig@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
   dependencies:
-    graceful-fs "^4.1.2"
-    js-yaml "^3.4.3"
-    minimist "^1.2.0"
-    object-assign "^4.0.1"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    pinkie-promise "^2.0.0"
-    require-from-string "^1.1.0"
-
-create-error-class@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  dependencies:
-    capture-stack-trace "^1.0.0"
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.0"
+    parse-json "^4.0.0"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -453,34 +1365,81 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
+cyclist@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+  integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
   dependencies:
     number-is-nan "^1.0.0"
 
-date-fns@^1.27.2:
-  version "1.28.5"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
-
-dateformat@^1.0.11, dateformat@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
-    get-stdin "^4.0.1"
-    meow "^3.3.0"
+    assert-plus "^1.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+dateformat@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
+  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
+
+debug@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.2.0, debug@^2.3.3:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debuglog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
+  integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
+
+decamelize-keys@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+deepmerge@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
+  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -488,13 +1447,61 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  integrity sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  integrity sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  integrity sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+deprecation@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
+  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
+
 detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+
+dezalgo@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
+  integrity sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
+
+dir-glob@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -502,17 +1509,53 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+dot-prop@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
+  dependencies:
+    is-obj "^1.0.0"
 
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+duplexify@^3.4.2, duplexify@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
+  integrity sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==
+  dependencies:
+    end-of-stream "^1.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+    stream-shift "^1.0.0"
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
+  dependencies:
+    iconv-lite "~0.4.13"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
+err-code@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
+  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
@@ -520,29 +1563,31 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+es6-promise@^4.0.3:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
+  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 esprima@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
-
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 execa@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -552,24 +1597,111 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
-external-editor@^2.0.4:
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  integrity sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  integrity sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  integrity sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+external-editor@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
+extglob@^2.0.4:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  integrity sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
   dependencies:
-    iconv-lite "^0.4.17"
-    jschardet "^1.4.2"
-    tmp "^0.0.31"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
-figures@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-glob@^2.0.2:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
+  integrity sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==
   dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    "@nodelib/fs.stat" "^1.1.2"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.3"
+    micromatch "^3.1.10"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
+  integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
 
 figures@^2.0.0:
   version "2.0.0"
@@ -577,9 +1709,15 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-find-parent-dir@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  integrity sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -594,17 +1732,94 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-fs-extra@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
+flush-write-stream@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
+  integrity sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.3.6"
+
+for-in@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
+  integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+  dependencies:
+    map-cache "^0.2.2"
+
+from2@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  integrity sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
+fs-extra@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
+  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
+
+fs-write-stream-atomic@^1.0.8:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
+  integrity sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=
+  dependencies:
+    graceful-fs "^4.1.2"
+    iferr "^0.1.5"
+    imurmurhash "^0.1.4"
+    readable-stream "1 || 2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fstream@^1.0.0, fstream@^1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -618,6 +1833,11 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+genfun@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/genfun/-/genfun-5.0.0.tgz#9dd9710a06900a5c4a5bf57aca5da4e52fe76537"
+  integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -641,17 +1861,43 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
-git-raw-commits@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-1.3.0.tgz#0bc8596e90d5ffe736f7f5546bd2d12f73abaac6"
+get-stream@^4.0.0, get-stream@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
+  integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+  dependencies:
+    assert-plus "^1.0.0"
+
+git-raw-commits@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"
+  integrity sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==
   dependencies:
     dargs "^4.0.1"
     lodash.template "^4.0.2"
-    meow "^3.3.0"
+    meow "^4.0.0"
     split2 "^2.0.0"
     through2 "^2.0.0"
 
@@ -662,12 +1908,28 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.2.3.tgz#188b453882bf9d7a23afd31baba537dab7388d5d"
+git-semver-tags@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.2.tgz#f506ec07caade191ac0c8d5a21bdb8131b4934e3"
+  integrity sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==
   dependencies:
-    meow "^3.3.0"
-    semver "^5.0.1"
+    meow "^4.0.0"
+    semver "^5.5.0"
+
+git-up@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
+  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^5.0.0"
+
+git-url-parse@^11.1.2:
+  version "11.1.2"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
+  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
+  dependencies:
+    git-up "^4.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -682,7 +1944,12 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+  integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob@^7.0.3, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -693,76 +1960,205 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globby@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+glob@^7.1.1, glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globby@^8.0.1:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.2.tgz#5697619ccd95c5275dbb2d6faa42087c1a941d8d"
+  integrity sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==
   dependencies:
     array-union "^1.0.1"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-
-got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
-    url-parse-lax "^1.0.0"
+    dir-glob "2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-handlebars@^4.0.2:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
+graceful-fs@^4.1.15:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+handlebars@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
-    async "^1.4.0"
+    neo-async "^2.6.0"
     optimist "^0.6.1"
-    source-map "^0.4.4"
+    source-map "^0.6.1"
   optionalDependencies:
-    uglify-js "^2.6"
+    uglify-js "^3.1.4"
 
-has-ansi@^2.0.0:
+har-schema@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+
+har-validator@~5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
   dependencies:
-    ansi-regex "^2.0.0"
+    ajv "^6.5.5"
+    har-schema "^2.0.0"
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-unicode@^2.0.0:
+has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  integrity sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+  integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
+
+hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-husky@^0.13.3:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.4.tgz#48785c5028de3452a51c48c12c4f94b2124a1407"
-  dependencies:
-    chalk "^1.1.3"
-    find-parent-dir "^0.3.0"
-    is-ci "^1.0.9"
-    normalize-path "^1.0.0"
+hosted-git-info@^2.6.0:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
-iconv-lite@^0.4.17:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+http-cache-semantics@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
+  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
+
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+https-proxy-agent@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
+
+husky@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-2.1.0.tgz#f486dd063596ad3aad4bbbcd8673ca5bface3caa"
+  integrity sha512-FHsqdIJPmQX/89Xg/761RMFCPSNNG2eiQMxChGP081NTohHexEuu/4nYh5m4TcFKq4xm+DqaGp8J/EUnkzL1Aw==
+  dependencies:
+    cosmiconfig "^5.2.0"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^7.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^4.1.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^5.0.0"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
+iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
+iferr@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
+  integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  dependencies:
+    minimatch "^3.0.4"
+
+ignore@^3.3.5, ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  integrity sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -777,6 +2173,7 @@ indent-string@^2.1.0:
 indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -785,36 +2182,75 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.2, ini@~1.3.0:
+ini@^1.3.2:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inquirer@^3.2.2:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+ini@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+  integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+init-package-json@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-1.10.3.tgz#45ffe2f610a8ca134f2bd1db5637b235070f6cbe"
+  integrity sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    glob "^7.1.1"
+    npm-package-arg "^4.0.0 || ^5.0.0 || ^6.0.0"
+    promzard "^0.3.0"
+    read "~1.0.1"
+    read-package-json "1 || 2"
+    semver "2.x || 3.x || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+    validate-npm-package-name "^3.0.0"
+
+inquirer@^6.2.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
+  integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^2.0.4"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.3.0"
+    lodash "^4.17.11"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rx-lite "^4.0.8"
-    rx-lite-aggregates "^4.0.8"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
-    strip-ansi "^4.0.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
-invert-kv@^1.0.0:
+invert-kv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
+  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
+
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  integrity sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  integrity sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
+  dependencies:
+    kind-of "^6.0.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -830,13 +2266,69 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-ci@^1.0.10, is-ci@^1.0.9:
+is-ci@^1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
 
-is-extglob@^2.1.0:
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
+
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  integrity sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
+  dependencies:
+    kind-of "^6.0.0"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  integrity sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  integrity sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
+is-extendable@^0.1.0, is-extendable@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+  integrity sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  integrity sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+  dependencies:
+    is-plain-object "^2.0.4"
+
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
@@ -862,33 +2354,56 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
+is-glob@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
+  integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
+  dependencies:
+    kind-of "^3.0.2"
+
 is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
+
+is-plain-object@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.0.tgz#47bfc5da1b5d50d64110806c199359482e75a928"
+  integrity sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==
+  dependencies:
+    isobject "^4.0.0"
 
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+is-ssh@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
+  integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
+  dependencies:
+    protocols "^1.1.0"
 
-is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-
-is-subset@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-text-path@^1.0.0:
   version "1.0.1"
@@ -896,11 +2411,21 @@ is-text-path@^1.0.0:
   dependencies:
     text-extensions "^1.0.0"
 
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-isarray@~1.0.0:
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -908,18 +2433,57 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-js-yaml@^3.4.3:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+isobject@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
+  integrity sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
+  dependencies:
+    isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isobject@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
+  integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jschardet@^1.4.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-json-stringify-safe@^5.0.1:
+json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -933,125 +2497,93 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
 
-kind-of@^3.0.2:
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
+
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
     is-buffer "^1.1.5"
 
-lazy-cache@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
-    invert-kv "^1.0.0"
+    is-buffer "^1.1.5"
 
-lerna@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.5.1.tgz#d07099bd3051ee799f98c753328bd69e96c6fab8"
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+lcid@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
+  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
-    async "^1.5.0"
-    chalk "^2.1.0"
-    cmd-shim "^2.0.2"
-    columnify "^1.5.4"
-    command-join "^2.0.0"
-    conventional-changelog-cli "^1.3.2"
-    conventional-recommended-bump "^1.0.1"
-    dedent "^0.7.0"
-    execa "^0.8.0"
-    find-up "^2.1.0"
-    fs-extra "^4.0.1"
-    get-port "^3.2.0"
-    glob "^7.1.2"
-    glob-parent "^3.1.0"
-    globby "^6.1.0"
-    graceful-fs "^4.1.11"
-    hosted-git-info "^2.5.0"
-    inquirer "^3.2.2"
-    is-ci "^1.0.10"
-    load-json-file "^3.0.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
+    invert-kv "^2.0.0"
+
+lerna@^3.13.4:
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.13.4.tgz#03026c11c5643f341fda42e4fb1882e2df35e6cb"
+  integrity sha512-qTp22nlpcgVrJGZuD7oHnFbTk72j2USFimc2Pj4kC0/rXmcU2xPtCiyuxLl8y6/6Lj5g9kwEuvKDZtSXujjX/A==
+  dependencies:
+    "@lerna/add" "3.13.3"
+    "@lerna/bootstrap" "3.13.3"
+    "@lerna/changed" "3.13.4"
+    "@lerna/clean" "3.13.3"
+    "@lerna/cli" "3.13.0"
+    "@lerna/create" "3.13.3"
+    "@lerna/diff" "3.13.3"
+    "@lerna/exec" "3.13.3"
+    "@lerna/import" "3.13.4"
+    "@lerna/init" "3.13.3"
+    "@lerna/link" "3.13.3"
+    "@lerna/list" "3.13.3"
+    "@lerna/publish" "3.13.4"
+    "@lerna/run" "3.13.3"
+    "@lerna/version" "3.13.4"
+    import-local "^1.0.0"
     npmlog "^4.1.2"
-    p-finally "^1.0.0"
-    package-json "^4.0.1"
-    path-exists "^3.0.0"
-    read-cmd-shim "^1.0.1"
-    read-pkg "^2.0.0"
-    rimraf "^2.6.1"
-    safe-buffer "^5.1.1"
-    semver "^5.4.1"
-    signal-exit "^3.0.2"
-    strong-log-transformer "^1.0.6"
-    temp-write "^3.3.0"
-    write-file-atomic "^2.3.0"
-    write-json-file "^2.2.0"
-    write-pkg "^3.1.0"
-    yargs "^8.0.2"
 
-lint-staged@^3.4.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.6.1.tgz#24423c8b7bd99d96e15acd1ac8cb392a78e58582"
+libnpmaccess@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
+  integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
   dependencies:
-    app-root-path "^2.0.0"
-    cosmiconfig "^1.1.0"
-    execa "^0.7.0"
-    listr "^0.12.0"
-    lodash.chunk "^4.2.0"
-    minimatch "^3.0.0"
-    npm-which "^3.0.1"
-    p-map "^1.1.1"
-    staged-git-files "0.0.4"
+    aproba "^2.0.0"
+    get-stream "^4.0.0"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.8.0"
 
-listr-silent-renderer@^1.1.1:
+libnpmpublish@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
-
-listr-update-renderer@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-1.1.1.tgz#ff0c6bb0b4ad2bda2ad1f5fba6760a4af37125f0"
+  integrity sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==
   dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-listr-verbose-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-listr@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    figures "^1.7.0"
-    indent-string "^2.1.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.2.0"
-    listr-verbose-renderer "^0.4.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    ora "^0.2.3"
-    p-map "^1.1.1"
-    rxjs "^5.0.0-beta.11"
-    stream-to-observable "^0.1.0"
-    strip-ansi "^3.0.1"
+    aproba "^2.0.0"
+    figgy-pudding "^3.5.1"
+    get-stream "^4.0.0"
+    lodash.clonedeep "^4.5.0"
+    normalize-package-data "^2.4.0"
+    npm-package-arg "^6.1.0"
+    npm-registry-fetch "^3.8.0"
+    semver "^5.5.1"
+    ssri "^6.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -1063,22 +2595,14 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-load-json-file@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
   dependencies:
     graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    strip-bom "^3.0.0"
-
-load-json-file@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-3.0.0.tgz#7eb3735d983a7ed2262ade4ff769af5369c5c440"
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^3.0.0"
-    pify "^2.0.0"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 locate-path@^2.0.0:
@@ -1088,13 +2612,42 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
 
-lodash.chunk@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.ismatch@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
+  integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
+
+lodash.set@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash.template@^4.0.2:
   version "4.4.0"
@@ -1109,26 +2662,19 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
+lodash@^4.17.11, lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-log-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
-  dependencies:
-    chalk "^1.0.0"
-
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
-  dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
-
-longest@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -1137,16 +2683,25 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
-
-lru-cache@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+lru-cache@^4.0.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
+macos-release@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.2.0.tgz#ab58d55dd4714f0a05ad4b0e90f4370fef5cdea8"
+  integrity sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==
 
 make-dir@^1.0.0:
   version "1.0.0"
@@ -1154,17 +2709,61 @@ make-dir@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+make-fetch-happen@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz#141497cb878f243ba93136c83d8aba12c216c083"
+  integrity sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==
+  dependencies:
+    agentkeepalive "^3.4.1"
+    cacache "^11.0.1"
+    http-cache-semantics "^3.8.1"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
+    lru-cache "^4.1.2"
+    mississippi "^3.0.0"
+    node-fetch-npm "^2.0.2"
+    promise-retry "^1.1.1"
+    socks-proxy-agent "^4.0.0"
+    ssri "^6.0.0"
+
+map-age-cleaner@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
+  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
+  dependencies:
+    p-defer "^1.0.0"
+
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+  integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  dependencies:
-    mimic-fn "^1.0.0"
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
 
-meow@^3.3.0, meow@^3.7.0:
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
+  dependencies:
+    object-visit "^1.0.0"
+
+mem@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
+  dependencies:
+    map-age-cleaner "^0.1.1"
+    mimic-fn "^2.0.0"
+    p-is-promise "^2.0.0"
+
+meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -1179,9 +2778,65 @@ meow@^3.3.0, meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+meow@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz#d48598f6f4b1472f35bf6317a95945ace347f975"
+  integrity sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist "^1.1.3"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+
+merge2@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
+  integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+
+micromatch@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
+mime-db@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  dependencies:
+    mime-db "1.40.0"
+
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+mimic-fn@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
@@ -1189,21 +2844,65 @@ minimatch@^3.0.0, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-minimist@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
 minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@~0.5.0:
+minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
+  dependencies:
+    minipass "^2.2.1"
+
+mississippi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mississippi/-/mississippi-3.0.0.tgz#ea0a3291f97e0b5e8776b363d5f0a12d94c67022"
+  integrity sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
+  dependencies:
+    concat-stream "^1.5.0"
+    duplexify "^3.4.2"
+    end-of-stream "^1.1.0"
+    flush-write-stream "^1.0.0"
+    from2 "^2.1.0"
+    parallel-transform "^1.1.0"
+    pump "^3.0.0"
+    pumpify "^1.3.3"
+    stream-each "^1.1.0"
+    through2 "^2.0.0"
+
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
@@ -1211,13 +2910,137 @@ modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"
 
-moment@^2.6.0:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+move-concurrently@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
+  integrity sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=
+  dependencies:
+    aproba "^1.1.1"
+    copy-concurrently "^1.0.0"
+    fs-write-stream-atomic "^1.0.8"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.4"
+    run-queue "^1.0.3"
+
+mri@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@^2.0.0, ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+multimatch@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  integrity sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=
+  dependencies:
+    array-differ "^1.0.0"
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    minimatch "^3.0.0"
+
+multimatch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-3.0.0.tgz#0e2534cc6bc238d9ab67e1b9cd5fcd85a6dbf70b"
+  integrity sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==
+  dependencies:
+    array-differ "^2.0.3"
+    array-union "^1.0.2"
+    arrify "^1.0.1"
+    minimatch "^3.0.4"
 
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mute-stream@~0.0.4:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  integrity sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+neo-async@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
+  integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch-npm@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz#7258c9046182dca345b4208eda918daf33697ff7"
+  integrity sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==
+  dependencies:
+    encoding "^0.1.11"
+    json-parse-better-errors "^1.0.0"
+    safe-buffer "^5.1.1"
+
+node-fetch@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
+  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
+
+node-gyp@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
+  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
+  dependencies:
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3 || 4"
+    osenv "0"
+    request "^2.87.0"
+    rimraf "2"
+    semver "~5.3.0"
+    tar "^2.0.0"
+    which "1"
+
+"nopt@2 || 3":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
+  dependencies:
+    abbrev "1"
+
+normalize-package-data@^2.0.0, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
@@ -1228,15 +3051,68 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+normalize-url@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
+  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-path@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+npm-bundled@^1.0.1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
+  integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+
+npm-lifecycle@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/npm-lifecycle/-/npm-lifecycle-2.1.0.tgz#1eda2eedb82db929e3a0c50341ab0aad140ed569"
+  integrity sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==
   dependencies:
-    which "^1.2.10"
+    byline "^5.0.0"
+    graceful-fs "^4.1.11"
+    node-gyp "^3.8.0"
+    resolve-from "^4.0.0"
+    slide "^1.1.6"
+    uid-number "0.0.6"
+    umask "^1.1.0"
+    which "^1.3.1"
+
+"npm-package-arg@^4.0.0 || ^5.0.0 || ^6.0.0", npm-package-arg@^6.0.0, npm-package-arg@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-6.1.0.tgz#15ae1e2758a5027efb4c250554b85a737db7fcc1"
+  integrity sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==
+  dependencies:
+    hosted-git-info "^2.6.0"
+    osenv "^0.1.5"
+    semver "^5.5.0"
+    validate-npm-package-name "^3.0.0"
+
+npm-packlist@^1.1.12, npm-packlist@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.1.tgz#19064cdf988da80ea3cee45533879d90192bbfbc"
+  integrity sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+
+npm-pick-manifest@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-2.2.3.tgz#32111d2a9562638bb2c8f2bf27f7f3092c8fae40"
+  integrity sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+    npm-package-arg "^6.0.0"
+    semver "^5.4.1"
+
+npm-registry-fetch@^3.8.0, npm-registry-fetch@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz#44d841780e2833f06accb34488f8c7450d1a6856"
+  integrity sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==
+  dependencies:
+    JSONStream "^1.3.4"
+    bluebird "^3.5.1"
+    figgy-pudding "^3.4.1"
+    lru-cache "^4.1.3"
+    make-fetch-happen "^4.0.1"
+    npm-package-arg "^6.1.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -1244,15 +3120,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-which@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
-  dependencies:
-    commander "^2.9.0"
-    npm-path "^2.0.2"
-    which "^1.2.10"
-
-npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
@@ -1265,19 +3133,48 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-once@^1.3.0:
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  integrity sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+  dependencies:
+    isobject "^3.0.0"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+  dependencies:
+    isobject "^3.0.1"
+
+octokit-pagination-methods@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz#cf472edc9d551055f9ef73f6e42b4dbb4c80bea4"
+  integrity sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==
+
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -1292,38 +3189,64 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-ora@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
-  dependencies:
-    chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
-
-os-homedir@^1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+os-locale@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
+  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
   dependencies:
-    execa "^0.7.0"
-    lcid "^1.0.0"
-    mem "^1.1.0"
+    execa "^1.0.0"
+    lcid "^2.0.0"
+    mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
+os-name@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
+  integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
+  dependencies:
+    macos-release "^2.2.0"
+    windows-release "^3.1.0"
+
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+osenv@0, osenv@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
+
+p-defer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
+  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
+p-is-promise@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
+  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
+
 p-limit@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-limit@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -1331,18 +3254,88 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
-p-map@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
-
-package-json@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
-    got "^6.7.1"
-    registry-auth-token "^3.0.1"
-    registry-url "^3.0.3"
-    semver "^5.1.0"
+    p-limit "^2.0.0"
+
+p-map-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-map-series/-/p-map-series-1.0.0.tgz#bf98fe575705658a9e1351befb85ae4c1f07bdca"
+  integrity sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=
+  dependencies:
+    p-reduce "^1.0.0"
+
+p-map@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
+p-pipe@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-pipe/-/p-pipe-1.2.0.tgz#4b1a11399a11520a67790ee5a0c1d5881d6befe9"
+  integrity sha1-SxoROZoRUgpneQ7loMHViB1r7+k=
+
+p-reduce@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
+  integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+p-waterfall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-waterfall/-/p-waterfall-1.0.0.tgz#7ed94b3ceb3332782353af6aae11aa9fc235bb00"
+  integrity sha1-ftlLPOszMngjU69qrhGqn8I1uwA=
+  dependencies:
+    p-reduce "^1.0.0"
+
+pacote@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-9.5.0.tgz#85f3013a3f6dd51c108b0ccabd3de8102ddfaeda"
+  integrity sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==
+  dependencies:
+    bluebird "^3.5.3"
+    cacache "^11.3.2"
+    figgy-pudding "^3.5.1"
+    get-stream "^4.1.0"
+    glob "^7.1.3"
+    lru-cache "^5.1.1"
+    make-fetch-happen "^4.0.1"
+    minimatch "^3.0.4"
+    minipass "^2.3.5"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    normalize-package-data "^2.4.0"
+    npm-package-arg "^6.1.0"
+    npm-packlist "^1.1.12"
+    npm-pick-manifest "^2.2.3"
+    npm-registry-fetch "^3.8.0"
+    osenv "^0.1.5"
+    promise-inflight "^1.0.1"
+    promise-retry "^1.1.1"
+    protoduck "^5.0.1"
+    rimraf "^2.6.2"
+    safe-buffer "^5.1.2"
+    semver "^5.6.0"
+    ssri "^6.0.1"
+    tar "^4.4.8"
+    unique-filename "^1.1.1"
+    which "^1.3.1"
+
+parallel-transform@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
+  integrity sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=
+  dependencies:
+    cyclist "~0.2.2"
+    inherits "^2.0.3"
+    readable-stream "^2.1.5"
 
 parse-github-repo-url@^1.3.0:
   version "1.4.0"
@@ -1354,11 +3347,36 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-json@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
   dependencies:
     error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
+parse-path@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
+  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-url@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
+  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^3.3.0"
+    parse-path "^4.0.0"
+    protocols "^1.4.0"
+
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -1378,9 +3396,14 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -1390,15 +3413,26 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-path-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
   dependencies:
-    pify "^2.0.0"
+    pify "^3.0.0"
 
-pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -1410,40 +3444,182 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-prepend-http@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
-prettier@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+pkg-dir@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.1.0.tgz#aaeb91c0d3b9c4f74a44ad849f4de34781ae01de"
+  integrity sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==
+  dependencies:
+    find-up "^3.0.0"
+
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
+  integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+prettier@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+
+pretty-quick@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.10.0.tgz#d86cc46fe92ed8cfcfba6a082ec5949c53858198"
+  integrity sha512-uNvm2N3UWmnZRZrClyQI45hIbV20f5BpSyZY51Spbvn4APp9+XLyX4bCjWRGT3fGyVyQ/2/iw7dbQq1UUaq7SQ==
+  dependencies:
+    chalk "^2.3.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    ignore "^3.3.7"
+    mri "^1.1.0"
+    multimatch "^3.0.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+  integrity sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==
+
+promise-inflight@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
+  integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-retry@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
+  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
+  dependencies:
+    err-code "^1.0.0"
+    retry "^0.10.0"
+
+promzard@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/promzard/-/promzard-0.3.0.tgz#26a5d6ee8c7dee4cb12208305acfb93ba382a9ee"
+  integrity sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=
+  dependencies:
+    read "1"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
+
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
+  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
+
+protoduck@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/protoduck/-/protoduck-5.0.1.tgz#03c3659ca18007b69a50fd82a7ebcc516261151f"
+  integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
+  dependencies:
+    genfun "^5.0.0"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-q@^1.4.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
+psl@^1.1.24:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
 
-rc@^1.0.1, rc@^1.1.6:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
+pump@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  integrity sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
   dependencies:
-    deep-extend "~0.4.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pumpify@^1.3.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  integrity sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+q@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz#2d5d157786a37c055d22077c32c53f8329e91c7b"
   dependencies:
     graceful-fs "^4.1.2"
+
+"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
+  integrity sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==
+  dependencies:
+    glob "^7.1.1"
+    json-parse-better-errors "^1.0.1"
+    normalize-package-data "^2.0.0"
+    slash "^1.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+read-package-tree@^5.1.6:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.2.2.tgz#4b6a0ef2d943c1ea36a578214c9a7f6b7424f7a8"
+  integrity sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    once "^1.3.0"
+    read-package-json "^2.0.0"
+    readdir-scoped-modules "^1.0.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -1452,14 +3628,15 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
-read-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
   dependencies:
     find-up "^2.0.0"
-    read-pkg "^2.0.0"
+    read-pkg "^3.0.0"
 
-read-pkg@^1.0.0, read-pkg@^1.1.0:
+read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
   dependencies:
@@ -1467,13 +3644,53 @@ read-pkg@^1.0.0, read-pkg@^1.1.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-read-pkg@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
   dependencies:
-    load-json-file "^2.0.0"
+    load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
-    path-type "^2.0.0"
+    path-type "^3.0.0"
+
+read-pkg@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.1.1.tgz#5cf234dde7a405c90c88a519ab73c467e9cb83f5"
+  integrity sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^4.0.0"
+    type-fest "^0.4.1"
+
+read@1, read@~1.0.1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
+  integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+  dependencies:
+    mute-stream "~0.0.4"
+
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+"readable-stream@2 || 3", readable-stream@^3.0.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
@@ -1487,6 +3704,16 @@ readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
+readdir-scoped-modules@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
+  integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    graceful-fs "^4.1.2"
+    once "^1.3.0"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -1494,22 +3721,31 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
-registry-auth-token@^3.0.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
   dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  integrity sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
   dependencies:
-    rc "^1.0.1"
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
 
-repeat-string@^1.5.2:
+repeat-element@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+
+repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
 repeating@^2.0.0:
   version "2.0.1"
@@ -1517,24 +3753,68 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-
-require-from-string@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
 
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  integrity sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    resolve-from "^3.0.0"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+  integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+  integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -1543,17 +3823,22 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-right-align@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
-  dependencies:
-    align-text "^0.1.1"
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.2:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
-    glob "^7.0.5"
+    glob "^7.1.3"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1561,33 +3846,88 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rx-lite-aggregates@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
-  dependencies:
-    rx-lite "*"
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
 
-rx-lite@*, rx-lite@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
-
-rxjs@^5.0.0-beta.11:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
+run-queue@^1.0.0, run-queue@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
+  integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
-    symbol-observable "^1.0.1"
+    aproba "^1.1.1"
+
+rxjs@^6.4.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
+  integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.4.1:
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  integrity sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+  dependencies:
+    ret "~0.1.10"
+
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
+"semver@2 || 3 || 4 || 5", semver@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+"semver@2.x || 3.x || 4 || 5", semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  integrity sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -1603,13 +3943,70 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+  integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
 
-slide@^1.1.5:
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slide@^1.1.5, slide@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+
+smart-buffer@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.0.2.tgz#5207858c3815cc69110703c6b94e46c15634395d"
+  integrity sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==
+
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  integrity sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  integrity sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  integrity sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
+socks-proxy-agent@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz#3c8991f3145b2799e70e11bd5fbc8b1963116386"
+  integrity sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==
+  dependencies:
+    agent-base "~4.2.1"
+    socks "~2.3.2"
+
+socks@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.3.2.tgz#ade388e9e6d87fdb11649c15746c578922a5883e"
+  integrity sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "4.0.2"
 
 sort-keys@^1.1.1:
   version "1.1.2"
@@ -1623,21 +4020,58 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
-    amdefine ">=0.0.4"
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
 
-source-map@~0.5.1:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
+source-map@^0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spdx-correct@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
   dependencies:
     spdx-license-ids "^1.0.2"
+
+spdx-exceptions@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
 
 spdx-expression-parse@~1.0.0:
   version "1.0.4"
@@ -1646,6 +4080,18 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
+  integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
+
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+  dependencies:
+    extend-shallow "^3.0.0"
 
 split2@^2.0.0:
   version "2.1.1"
@@ -1662,14 +4108,50 @@ split@^1.0.0:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-staged-git-files@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+sshpk@^1.7.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
 
-stream-to-observable@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+ssri@^6.0.0, ssri@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
+  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+  dependencies:
+    figgy-pudding "^3.5.1"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  integrity sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
+
+stream-each@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
+  integrity sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==
+  dependencies:
+    end-of-stream "^1.1.0"
+    stream-shift "^1.0.0"
+
+stream-shift@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
+  integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
@@ -1679,16 +4161,30 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
 
@@ -1703,6 +4199,13 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -1724,55 +4227,64 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
+  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strong-log-transformer@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-1.0.6.tgz#f7fb93758a69a571140181277eea0c2eb1301fa3"
+strong-log-transformer@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
+  integrity sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==
   dependencies:
-    byline "^5.0.0"
     duplexer "^0.1.1"
-    minimist "^0.1.0"
-    moment "^2.6.0"
+    minimist "^1.2.0"
     through "^2.3.4"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
-supports-color@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
-    has-flag "^2.0.0"
+    has-flag "^3.0.0"
 
-symbol-observable@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+tar@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
+
+tar@^4.4.8:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
 
 temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
 
-temp-write@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.3.0.tgz#c1a96de2b36061342eae81f44ff001aec8f615a9"
+temp-write@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
+  integrity sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
   dependencies:
     graceful-fs "^4.1.2"
     is-stream "^1.1.0"
     make-dir "^1.0.0"
-    pify "^2.2.0"
+    pify "^3.0.0"
     temp-dir "^1.0.0"
     uuid "^3.0.1"
-
-tempfile@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-1.1.1.tgz#5bcc4eaecc4ab2c707d8bc11d99ccc9a2cb287f2"
-  dependencies:
-    os-tmpdir "^1.0.0"
-    uuid "^2.0.1"
 
 text-extensions@^1.0.0:
   version "1.5.0"
@@ -1785,70 +4297,198 @@ through2@^2.0.0, through2@^2.0.2:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
+through2@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
+  integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
+  dependencies:
+    readable-stream "2 || 3"
+
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-timed-out@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
-
-tmp@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
-    os-tmpdir "~1.0.1"
+    os-tmpdir "~1.0.2"
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  integrity sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  integrity sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
+
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
+
 trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-fest@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.4.1.tgz#8bdf77743385d8a4f13ba95f610f5ccd68c728f8"
+  integrity sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==
 
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uglify-js@^2.6:
-  version "2.8.29"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+uglify-js@^3.1.4:
+  version "3.5.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.9.tgz#372fbf95939555b1f460b1777d33a67d4a994ac9"
+  integrity sha512-WpT0RqsDtAWPNJK955DEnb6xjymR8Fn0OlK4TT4pS0ASYsVPqr5ELhgwOwLCP5J5vHeJ4xmMmz3DEgdqC10JeQ==
   dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
+    commander "~2.20.0"
+    source-map "~0.6.1"
 
-uglify-to-browserify@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+uid-number@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
+
+umask@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
+  integrity sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=
+
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  integrity sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
+unique-filename@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
+  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+  dependencies:
+    unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"
+  integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
+  dependencies:
+    imurmurhash "^0.1.4"
+
+universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
+  integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
+  dependencies:
+    os-name "^3.0.0"
 
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
-unzip-response@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
-
-url-parse-lax@^1.0.0:
+unset-value@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  integrity sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
   dependencies:
-    prepend-http "^1.0.1"
+    has-value "^0.3.1"
+    isobject "^3.0.0"
 
-util-deprecate@~1.0.1:
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+  integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-template@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
+  integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-uuid@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -1857,17 +4497,62 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+validate-npm-package-license@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
 wcwidth@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.10, which@^1.2.9:
+which@1, which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -1879,13 +4564,12 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
-window-size@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-
-wordwrap@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+windows-release@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.2.0.tgz#8122dad5afc303d833422380680a79cdfa91785f"
+  integrity sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==
+  dependencies:
+    execa "^1.0.0"
 
 wordwrap@~0.0.2:
   version "0.0.3"
@@ -1929,6 +4613,18 @@ write-json-file@^2.2.0:
     sort-keys "^1.1.1"
     write-file-atomic "^2.0.0"
 
+write-json-file@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-2.3.0.tgz#2b64c8a33004d54b8698c76d585a77ceb61da32f"
+  integrity sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=
+  dependencies:
+    detect-indent "^5.0.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    pify "^3.0.0"
+    sort-keys "^2.0.0"
+    write-file-atomic "^2.0.0"
+
 write-pkg@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-3.1.0.tgz#030a9994cc9993d25b4e75a9f1a1923607291ce9"
@@ -1940,43 +4636,42 @@ xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
   dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^12.0.1:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
     get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
+    os-locale "^3.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^7.0.0"
-
-yargs@~3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
-  dependencies:
-    camelcase "^1.0.2"
-    cliui "^2.1.0"
-    decamelize "^1.0.0"
-    window-size "0.1.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"


### PR DESCRIPTION
Previously when calculating rates if either the previous or current values were null pond would emit a console.log message saying the `field value is invalid or missing`. In the case of nulls though it is better to just output a null rate and not pollute logs. Nulls are often seen in timeseries when incomplete data is present.