### PR TITLE
WindowedCollection .ungroup() Map construction fix

### DIFF
--- a/packages/pond/src/windowedcollection.ts
+++ b/packages/pond/src/windowedcollection.ts
@@ -187,12 +187,12 @@ export class WindowedCollection<T extends Key> extends Base {
      * mapping just the window to the `SortedCollection`.
      */
     public ungroup(): Immutable.Map<string, SortedCollection<T>> {
-        const result = Immutable.Map<string, SortedCollection<T>>();
+        const mutableResult: { [key: string]: SortedCollection<T> } = {};
         this.collections.forEach((collection, key) => {
             const newKey = key.split("::")[1];
-            result[newKey] = collection;
+            mutableResult[newKey] = collection;
         });
-        return result;
+        return Immutable.Map<SortedCollection<T>>(mutableResult);
     }
 
     addEvent(event: Event<T>): Immutable.List<KeyedCollection<T>> {
@@ -262,8 +262,8 @@ export class WindowedCollection<T extends Key> extends Base {
             }
         }
         const groupKey = fn ? fn(event) : null;
-        return windowKeyList.map(
-            windowKey => (groupKey ? `${groupKey}::${windowKey}` : `${windowKey}`)
+        return windowKeyList.map(windowKey =>
+            groupKey ? `${groupKey}::${windowKey}` : `${windowKey}`
         );
     }
 }

--- a/packages/pond/tests/windowed.test.ts
+++ b/packages/pond/tests/windowed.test.ts
@@ -154,4 +154,27 @@ describe("Windowed", () => {
         expect(rolledUp.at(2).get("total")).toBe(5);
         expect(rolledUp.at(3).get("total")).toBe(10);
     });
+
+    it("can ungroup WindowedCollection", () => {
+        const eventCollection = sortedCollection(
+            Immutable.List([
+                event(time("2015-04-22T02:28:00Z"), map({ value: 3 })),
+                event(time("2015-04-22T02:29:00Z"), map({ value: 4 })),
+                event(time("2015-04-22T02:30:00Z"), map({ value: 5 })),
+                event(time("2015-04-22T02:29:00Z"), map({ value: 3 })),
+                event(time("2015-04-22T02:30:00Z"), map({ value: 4 })),
+                event(time("2015-04-22T02:31:00Z"), map({ value: 6 }))
+            ])
+        );
+
+        const everyThirtyMinutes = window(duration("30m"));
+        const groups = eventCollection.window({ window: everyThirtyMinutes }).ungroup();
+
+        expect(groups.size).toBe(2);
+
+        const groupsList = groups.toList();
+
+        expect(groupsList.get(0).size()).toBe(3);
+        expect(groupsList.get(1).size()).toBe(3);
+    });
 });


### PR DESCRIPTION
There was a problem with Immutable Map construction. This PR fixes it and adds test.

We are not supposed to call `map[key] = ...` on immutable object.

As a result, the Immutable Map with size 0 and all collections as a fields of the Map object were created.