### PR TITLE
remove duplicate *events def in v0.9.0

### DIFF
--- a/lib/lib/timeseries.js
+++ b/lib/lib/timeseries.js
@@ -509,23 +509,8 @@ class TimeSeries {
 
     return this.setCollection(cleaned, true);
   }
-  /**
-   * Generator to return all the events in the collection.
-   *
-   * @example
-   * ```
-   * for (let event of timeseries.events()) {
-   *     console.log(event.toString());
-   * }
-   * ```
-   */
 
-
-  *events() {
-    for (var i = 0; i < this.size(); i++) {
-      yield this.at(i);
-    }
-  } //
+  //
   // Access meta data about the series
   //
 


### PR DESCRIPTION
As per #203 report, could  you please consider fix to remove the duplicate definition from v0.9.0.

I understand v0.9.x is the "only version currently aligned with react-time-series". 

Thanks

